### PR TITLE
Use QuerierWrapper not Querier in helpers

### DIFF
--- a/contracts/cw20-escrow/src/integration_test.rs
+++ b/contracts/cw20-escrow/src/integration_test.rs
@@ -80,9 +80,9 @@ fn escrow_happy_path_cw20_tokens() {
     let cash = Cw20Contract(cash_addr.clone());
 
     // ensure our balances
-    let owner_balance = cash.balance(&router, owner.clone()).unwrap();
+    let owner_balance = cash.balance(&router.wrap(), owner.clone()).unwrap();
     assert_eq!(owner_balance, Uint128::new(5000));
-    let escrow_balance = cash.balance(&router, escrow_addr.clone()).unwrap();
+    let escrow_balance = cash.balance(&router.wrap(), escrow_addr.clone()).unwrap();
     assert_eq!(escrow_balance, Uint128::zero());
 
     // send some tokens to create an escrow
@@ -119,9 +119,9 @@ fn escrow_happy_path_cw20_tokens() {
     assert_eq!(2, escrow_attr.len());
 
     // ensure balances updated
-    let owner_balance = cash.balance(&router, owner.clone()).unwrap();
+    let owner_balance = cash.balance(&router.wrap(), owner.clone()).unwrap();
     assert_eq!(owner_balance, Uint128::new(3800));
-    let escrow_balance = cash.balance(&router, escrow_addr.clone()).unwrap();
+    let escrow_balance = cash.balance(&router.wrap(), escrow_addr.clone()).unwrap();
     assert_eq!(escrow_balance, Uint128::new(1200));
 
     // ensure escrow properly created
@@ -147,10 +147,10 @@ fn escrow_happy_path_cw20_tokens() {
         .unwrap();
 
     // ensure balances updated - release to ben
-    let owner_balance = cash.balance(&router, owner).unwrap();
+    let owner_balance = cash.balance(&router.wrap(), owner).unwrap();
     assert_eq!(owner_balance, Uint128::new(3800));
-    let escrow_balance = cash.balance(&router, escrow_addr).unwrap();
+    let escrow_balance = cash.balance(&router.wrap(), escrow_addr).unwrap();
     assert_eq!(escrow_balance, Uint128::zero());
-    let ben_balance = cash.balance(&router, ben).unwrap();
+    let ben_balance = cash.balance(&router.wrap(), ben).unwrap();
     assert_eq!(ben_balance, Uint128::new(1200));
 }

--- a/packages/cw721/src/helpers.rs
+++ b/packages/cw721/src/helpers.rs
@@ -1,9 +1,7 @@
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use cosmwasm_std::{
-    to_binary, Addr, CosmosMsg, Querier, QuerierWrapper, StdResult, WasmMsg, WasmQuery,
-};
+use cosmwasm_std::{to_binary, Addr, CosmosMsg, QuerierWrapper, StdResult, WasmMsg, WasmQuery};
 
 use crate::{
     AllNftInfoResponse, Approval, ApprovedForAllResponse, ContractInfoResponse, Cw721ExecuteMsg,
@@ -32,9 +30,9 @@ impl Cw721Contract {
         .into())
     }
 
-    pub fn query<Q: Querier, T: DeserializeOwned>(
+    pub fn query<T: DeserializeOwned>(
         &self,
-        querier: &Q,
+        querier: &QuerierWrapper,
         req: Cw721QueryMsg,
     ) -> StdResult<T> {
         let query = WasmQuery::Smart {
@@ -42,14 +40,14 @@ impl Cw721Contract {
             msg: to_binary(&req)?,
         }
         .into();
-        QuerierWrapper::new(querier).query(&query)
+        querier.query(&query)
     }
 
     /*** queries ***/
 
-    pub fn owner_of<Q: Querier, T: Into<String>>(
+    pub fn owner_of<T: Into<String>>(
         &self,
-        querier: &Q,
+        querier: &QuerierWrapper,
         token_id: T,
         include_expired: bool,
     ) -> StdResult<OwnerOfResponse> {
@@ -60,9 +58,9 @@ impl Cw721Contract {
         self.query(querier, req)
     }
 
-    pub fn approved_for_all<Q: Querier, T: Into<String>>(
+    pub fn approved_for_all<T: Into<String>>(
         &self,
-        querier: &Q,
+        querier: &QuerierWrapper,
         owner: T,
         include_expired: bool,
         start_after: Option<String>,
@@ -78,22 +76,22 @@ impl Cw721Contract {
         Ok(res.operators)
     }
 
-    pub fn num_tokens<Q: Querier>(&self, querier: &Q) -> StdResult<u64> {
+    pub fn num_tokens(&self, querier: &QuerierWrapper) -> StdResult<u64> {
         let req = Cw721QueryMsg::NumTokens {};
         let res: NumTokensResponse = self.query(querier, req)?;
         Ok(res.count)
     }
 
     /// With metadata extension
-    pub fn contract_info<Q: Querier>(&self, querier: &Q) -> StdResult<ContractInfoResponse> {
+    pub fn contract_info(&self, querier: &QuerierWrapper) -> StdResult<ContractInfoResponse> {
         let req = Cw721QueryMsg::ContractInfo {};
         self.query(querier, req)
     }
 
     /// With metadata extension
-    pub fn nft_info<Q: Querier, T: Into<String>>(
+    pub fn nft_info<T: Into<String>>(
         &self,
-        querier: &Q,
+        querier: &QuerierWrapper,
         token_id: T,
     ) -> StdResult<NftInfoResponse> {
         let req = Cw721QueryMsg::NftInfo {
@@ -103,9 +101,9 @@ impl Cw721Contract {
     }
 
     /// With metadata extension
-    pub fn all_nft_info<Q: Querier, T: Into<String>>(
+    pub fn all_nft_info<T: Into<String>>(
         &self,
-        querier: &Q,
+        querier: &QuerierWrapper,
         token_id: T,
         include_expired: bool,
     ) -> StdResult<AllNftInfoResponse> {
@@ -117,9 +115,9 @@ impl Cw721Contract {
     }
 
     /// With enumerable extension
-    pub fn tokens<Q: Querier, T: Into<String>>(
+    pub fn tokens<T: Into<String>>(
         &self,
-        querier: &Q,
+        querier: &QuerierWrapper,
         owner: T,
         start_after: Option<String>,
         limit: Option<u32>,
@@ -133,9 +131,9 @@ impl Cw721Contract {
     }
 
     /// With enumerable extension
-    pub fn all_tokens<Q: Querier>(
+    pub fn all_tokens(
         &self,
-        querier: &Q,
+        querier: &QuerierWrapper,
         start_after: Option<String>,
         limit: Option<u32>,
     ) -> StdResult<TokensResponse> {
@@ -144,12 +142,12 @@ impl Cw721Contract {
     }
 
     /// returns true if the contract supports the metadata extension
-    pub fn has_metadata<Q: Querier>(&self, querier: &Q) -> bool {
+    pub fn has_metadata(&self, querier: &QuerierWrapper) -> bool {
         self.contract_info(querier).is_ok()
     }
 
     /// returns true if the contract supports the enumerable extension
-    pub fn has_enumerable<Q: Querier>(&self, querier: &Q) -> bool {
+    pub fn has_enumerable(&self, querier: &QuerierWrapper) -> bool {
         self.tokens(querier, self.addr(), None, Some(1)).is_ok()
     }
 }


### PR DESCRIPTION
Closes #390

- [x] cw20
- [x] cw721

Other ones were already updated (like cw4)

Note that this is API breaking as I had to update multitests that actually use it, so I cannot release this in 0.8.1... 