### PR TITLE
Add CW-2981

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw2981"
+version = "0.8.1"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2981-base"
+version = "0.8.1"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.8.1",
+ "cw0 0.8.1",
+ "cw2",
+ "cw2981",
+ "cw721",
+ "cw721-base",
+ "percentage",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw3"
 version = "0.8.1"
 dependencies = [
@@ -911,6 +939,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +1035,15 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "percentage"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
+dependencies = [
+ "num",
+]
 
 [[package]]
 name = "pkcs8"

--- a/contracts/cw2981-base/.cargo/config
+++ b/contracts/cw2981-base/.cargo/config
@@ -1,0 +1,5 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/contracts/cw2981-base/Cargo.toml
+++ b/contracts/cw2981-base/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "cw2981-base"
+version = "0.8.1"
+authors = ["Alex Lynham <alex@lynh.am>"]
+edition = "2018"
+description = "Basic implementation of royalties for cw721 NFTs with token level royalties"
+license = "Apache-2.0"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "artifacts/*",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cw0 = { path = "../../packages/cw0", version = "0.8.1" }
+cw2 = { path = "../../packages/cw2", version = "0.8.1" }
+cw721 = { path = "../../packages/cw721", version = "0.8.1" }
+cw721-base = { path = "../../contracts/cw721-base", version = "0.8.1", features = ["library"] }
+cw2981 = { path = "../../packages/cw2981", version = "0.8.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.8.1" }
+cosmwasm-std = { version = "0.16.0" }
+schemars = "0.8.1"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.23" }
+percentage = { version = "0.1.0"}
+
+[dev-dependencies]
+cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/cw2981-base/README.md
+++ b/contracts/cw2981-base/README.md
@@ -1,0 +1,21 @@
+# CW-2981 Token-level Royalties
+
+An example of porting EIP-2981 to implement royalties at a token mint level.
+
+All of the CW-721 logic and behaviour you would expect for an NFT is implemented as normal, but additionally at mint time, royalty information can be attached to a token.
+
+Exposes two new query message types:
+
+```rust
+// Should be called on sale to see if royalties are owed
+// by the marketplace selling the NFT.
+// See https://eips.ethereum.org/EIPS/eip-2981
+RoyaltyInfo {
+    token_id: String,
+    // the denom of this sale must also be the denom returned by RoyaltiesInfoResponse
+    sale_price: u128,
+},
+
+// Called against the contract to signal that CW-2981 is implemented
+CheckRoyalties {},
+```

--- a/contracts/cw2981-base/examples/schema.rs
+++ b/contracts/cw2981-base/examples/schema.rs
@@ -1,0 +1,29 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+
+use cw721::{
+    AllNftInfoResponse, ApprovedForAllResponse, ContractInfoResponse, NftInfoResponse,
+    NumTokensResponse, OwnerOfResponse, TokensResponse,
+};
+use cw721_base::msg::{ExecuteMsg, InstantiateMsg, MinterResponse, QueryMsg};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(AllNftInfoResponse), &out_dir);
+    export_schema(&schema_for!(ApprovedForAllResponse), &out_dir);
+    export_schema(&schema_for!(ContractInfoResponse), &out_dir);
+    export_schema(&schema_for!(MinterResponse), &out_dir);
+    export_schema(&schema_for!(NftInfoResponse), &out_dir);
+    export_schema(&schema_for!(NumTokensResponse), &out_dir);
+    export_schema(&schema_for!(OwnerOfResponse), &out_dir);
+    export_schema(&schema_for!(TokensResponse), &out_dir);
+}

--- a/contracts/cw2981-base/schema/all_nft_info_response.json
+++ b/contracts/cw2981-base/schema/all_nft_info_response.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AllNftInfoResponse",
+  "type": "object",
+  "required": [
+    "access",
+    "info"
+  ],
+  "properties": {
+    "access": {
+      "description": "Who can transfer the token",
+      "allOf": [
+        {
+          "$ref": "#/definitions/OwnerOfResponse"
+        }
+      ]
+    },
+    "info": {
+      "description": "Data on the token itself,",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NftInfoResponse"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "Approval": {
+      "type": "object",
+      "required": [
+        "expires",
+        "spender"
+      ],
+      "properties": {
+        "expires": {
+          "description": "When the Approval expires (maybe Expiration::never)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "spender": {
+          "description": "Account that can transfer/send the token",
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "anyOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "NftInfoResponse": {
+      "type": "object",
+      "required": [
+        "description",
+        "name"
+      ],
+      "properties": {
+        "description": {
+          "description": "Describes the asset to which this NFT represents",
+          "type": "string"
+        },
+        "image": {
+          "description": "\"A URI pointing to a resource with mime type image/* representing the asset to which this NFT represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive. TODO: Use https://docs.rs/url_serde for type-safety",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Identifies the asset to which this NFT represents",
+          "type": "string"
+        }
+      }
+    },
+    "OwnerOfResponse": {
+      "type": "object",
+      "required": [
+        "approvals",
+        "owner"
+      ],
+      "properties": {
+        "approvals": {
+          "description": "If set this address is approved to transfer/send the token as well",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Approval"
+          }
+        },
+        "owner": {
+          "description": "Owner of the token",
+          "type": "string"
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/approved_for_all_response.json
+++ b/contracts/cw2981-base/schema/approved_for_all_response.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ApprovedForAllResponse",
+  "type": "object",
+  "required": [
+    "operators"
+  ],
+  "properties": {
+    "operators": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Approval"
+      }
+    }
+  },
+  "definitions": {
+    "Approval": {
+      "type": "object",
+      "required": [
+        "expires",
+        "spender"
+      ],
+      "properties": {
+        "expires": {
+          "description": "When the Approval expires (maybe Expiration::never)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "spender": {
+          "description": "Account that can transfer/send the token",
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "anyOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/contract_info_response.json
+++ b/contracts/cw2981-base/schema/contract_info_response.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ContractInfoResponse",
+  "type": "object",
+  "required": [
+    "name",
+    "symbol"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "symbol": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/execute_msg.json
+++ b/contracts/cw2981-base/schema/execute_msg.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "description": "This is like Cw721ExecuteMsg but we add a Mint command for an owner to make this stand-alone. You will likely want to remove mint and use other control logic in any contract that inherits this.",
+  "anyOf": [
+    {
+      "description": "Transfer is a base message to move a token to another account without triggering actions",
+      "type": "object",
+      "required": [
+        "transfer_nft"
+      ],
+      "properties": {
+        "transfer_nft": {
+          "type": "object",
+          "required": [
+            "recipient",
+            "token_id"
+          ],
+          "properties": {
+            "recipient": {
+              "type": "string"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Send is a base message to transfer a token to a contract and trigger an action on the receiving contract.",
+      "type": "object",
+      "required": [
+        "send_nft"
+      ],
+      "properties": {
+        "send_nft": {
+          "type": "object",
+          "required": [
+            "contract",
+            "msg",
+            "token_id"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            },
+            "msg": {
+              "$ref": "#/definitions/Binary"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Allows operator to transfer / send the token from the owner's account. If expiration is set, then this allowance has a time/height limit",
+      "type": "object",
+      "required": [
+        "approve"
+      ],
+      "properties": {
+        "approve": {
+          "type": "object",
+          "required": [
+            "spender",
+            "token_id"
+          ],
+          "properties": {
+            "expires": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "spender": {
+              "type": "string"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Remove previously granted Approval",
+      "type": "object",
+      "required": [
+        "revoke"
+      ],
+      "properties": {
+        "revoke": {
+          "type": "object",
+          "required": [
+            "spender",
+            "token_id"
+          ],
+          "properties": {
+            "spender": {
+              "type": "string"
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Allows operator to transfer / send any token from the owner's account. If expiration is set, then this allowance has a time/height limit",
+      "type": "object",
+      "required": [
+        "approve_all"
+      ],
+      "properties": {
+        "approve_all": {
+          "type": "object",
+          "required": [
+            "operator"
+          ],
+          "properties": {
+            "expires": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "operator": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Remove previously granted ApproveAll permission",
+      "type": "object",
+      "required": [
+        "revoke_all"
+      ],
+      "properties": {
+        "revoke_all": {
+          "type": "object",
+          "required": [
+            "operator"
+          ],
+          "properties": {
+            "operator": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Mint a new NFT, can only be called by the contract minter",
+      "type": "object",
+      "required": [
+        "mint"
+      ],
+      "properties": {
+        "mint": {
+          "$ref": "#/definitions/MintMsg"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "anyOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "MintMsg": {
+      "type": "object",
+      "required": [
+        "name",
+        "owner",
+        "token_id"
+      ],
+      "properties": {
+        "description": {
+          "description": "Describes the asset to which this NFT represents (may be empty)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "description": "A URI pointing to an image representing the asset",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Identifies the asset to which this NFT represents",
+          "type": "string"
+        },
+        "owner": {
+          "description": "The owner of the newly minter NFT",
+          "type": "string"
+        },
+        "token_id": {
+          "description": "Unique ID of the NFT",
+          "type": "string"
+        }
+      }
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/instantiate_msg.json
+++ b/contracts/cw2981-base/schema/instantiate_msg.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "minter",
+    "name",
+    "symbol"
+  ],
+  "properties": {
+    "minter": {
+      "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
+      "type": "string"
+    },
+    "name": {
+      "description": "Name of the NFT contract",
+      "type": "string"
+    },
+    "symbol": {
+      "description": "Symbol of the NFT contract",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/minter_response.json
+++ b/contracts/cw2981-base/schema/minter_response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MinterResponse",
+  "description": "Shows who can mint these tokens",
+  "type": "object",
+  "required": [
+    "minter"
+  ],
+  "properties": {
+    "minter": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/nft_info_response.json
+++ b/contracts/cw2981-base/schema/nft_info_response.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "NftInfoResponse",
+  "type": "object",
+  "required": [
+    "description",
+    "name"
+  ],
+  "properties": {
+    "description": {
+      "description": "Describes the asset to which this NFT represents",
+      "type": "string"
+    },
+    "image": {
+      "description": "\"A URI pointing to a resource with mime type image/* representing the asset to which this NFT represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive. TODO: Use https://docs.rs/url_serde for type-safety",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "name": {
+      "description": "Identifies the asset to which this NFT represents",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/num_tokens_response.json
+++ b/contracts/cw2981-base/schema/num_tokens_response.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "NumTokensResponse",
+  "type": "object",
+  "required": [
+    "count"
+  ],
+  "properties": {
+    "count": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/owner_of_response.json
+++ b/contracts/cw2981-base/schema/owner_of_response.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OwnerOfResponse",
+  "type": "object",
+  "required": [
+    "approvals",
+    "owner"
+  ],
+  "properties": {
+    "approvals": {
+      "description": "If set this address is approved to transfer/send the token as well",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Approval"
+      }
+    },
+    "owner": {
+      "description": "Owner of the token",
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "Approval": {
+      "type": "object",
+      "required": [
+        "expires",
+        "spender"
+      ],
+      "properties": {
+        "expires": {
+          "description": "When the Approval expires (maybe Expiration::never)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "spender": {
+          "description": "Account that can transfer/send the token",
+          "type": "string"
+        }
+      }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "anyOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw2981-base/schema/query_msg.json
+++ b/contracts/cw2981-base/schema/query_msg.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "anyOf": [
+    {
+      "description": "Return the owner of the given token, error if token does not exist Return type: OwnerOfResponse",
+      "type": "object",
+      "required": [
+        "owner_of"
+      ],
+      "properties": {
+        "owner_of": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "include_expired": {
+              "description": "unset or false will filter out expired approvals, you must set to true to see them",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "List all operators that can access all of the owner's tokens Return type: `ApprovedForAllResponse`",
+      "type": "object",
+      "required": [
+        "approved_for_all"
+      ],
+      "properties": {
+        "approved_for_all": {
+          "type": "object",
+          "required": [
+            "owner"
+          ],
+          "properties": {
+            "include_expired": {
+              "description": "unset or false will filter out expired items, you must set to true to see them",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "owner": {
+              "type": "string"
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Total number of tokens issued",
+      "type": "object",
+      "required": [
+        "num_tokens"
+      ],
+      "properties": {
+        "num_tokens": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "With MetaData Extension. Returns top-level metadata about the contract: `ContractInfoResponse`",
+      "type": "object",
+      "required": [
+        "contract_info"
+      ],
+      "properties": {
+        "contract_info": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "With MetaData Extension. Returns metadata about one particular token, based on *ERC721 Metadata JSON Schema* but directly from the contract: `NftInfoResponse`",
+      "type": "object",
+      "required": [
+        "nft_info"
+      ],
+      "properties": {
+        "nft_info": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "With MetaData Extension. Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimization for clients: `AllNftInfo`",
+      "type": "object",
+      "required": [
+        "all_nft_info"
+      ],
+      "properties": {
+        "all_nft_info": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "include_expired": {
+              "description": "unset or false will filter out expired approvals, you must set to true to see them",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "With Enumerable extension. Returns all tokens owned by the given address, [] if unset. Return type: TokensResponse.",
+      "type": "object",
+      "required": [
+        "tokens"
+      ],
+      "properties": {
+        "tokens": {
+          "type": "object",
+          "required": [
+            "owner"
+          ],
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "owner": {
+              "type": "string"
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "With Enumerable extension. Requires pagination. Lists all token_ids controlled by the contract. Return type: TokensResponse.",
+      "type": "object",
+      "required": [
+        "all_tokens"
+      ],
+      "properties": {
+        "all_tokens": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "minter"
+      ],
+      "properties": {
+        "minter": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/cw2981-base/schema/tokens_response.json
+++ b/contracts/cw2981-base/schema/tokens_response.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TokensResponse",
+  "type": "object",
+  "required": [
+    "tokens"
+  ],
+  "properties": {
+    "tokens": {
+      "description": "Contains all token_ids in lexicographical ordering If there are more than `limit`, use `start_from` in future queries to achieve pagination.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/cw2981-base/src/contract.rs
+++ b/contracts/cw2981-base/src/contract.rs
@@ -1,0 +1,962 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+};
+
+use cw2::set_contract_version;
+use cw721::ContractInfoResponse;
+
+use cw721_base::contract::{
+    execute_approve, execute_approve_all, execute_revoke, execute_revoke_all, execute_send_nft,
+    execute_transfer_nft, query_all_approvals, query_all_nft_info, query_all_tokens,
+    query_contract_info, query_minter, query_nft_info, query_num_tokens, query_owner_of,
+    query_tokens,
+};
+use cw721_base::msg::InstantiateMsg;
+use cw721_base::state::{increment_tokens, tokens, TokenInfo, MINTER};
+
+use crate::msg::{ExecuteMsg, QueryMsg};
+use crate::state::{RoyaltiesInfo, CONTRACT_INFO, ROYALTIES_INFO};
+use cw2981::{CheckRoyaltiesResponse, RoyaltiesInfoResponse, TokenRoyaltiesMintMsg};
+
+use percentage::Percentage;
+
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:cw2981-token-level-royalties";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let info = ContractInfoResponse {
+        name: msg.name,
+        symbol: msg.symbol,
+    };
+    CONTRACT_INFO.save(deps.storage, &info)?;
+
+    let minter = deps.api.addr_validate(&msg.minter)?;
+    MINTER.save(deps.storage, &minter)?;
+
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, cw721_base::ContractError> {
+    match msg {
+        ExecuteMsg::Mint(msg) => execute_mint(deps, env, info, msg),
+        ExecuteMsg::Approve {
+            spender,
+            token_id,
+            expires,
+        } => execute_approve(deps, env, info, spender, token_id, expires),
+        ExecuteMsg::Revoke { spender, token_id } => {
+            execute_revoke(deps, env, info, spender, token_id)
+        }
+        ExecuteMsg::ApproveAll { operator, expires } => {
+            execute_approve_all(deps, env, info, operator, expires)
+        }
+        ExecuteMsg::RevokeAll { operator } => execute_revoke_all(deps, env, info, operator),
+        ExecuteMsg::TransferNft {
+            recipient,
+            token_id,
+        } => execute_transfer_nft(deps, env, info, recipient, token_id),
+        ExecuteMsg::SendNft {
+            contract,
+            token_id,
+            msg,
+        } => execute_send_nft(deps, env, info, contract, token_id, msg),
+    }
+}
+
+pub fn execute_mint(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: TokenRoyaltiesMintMsg,
+) -> Result<Response, cw721_base::ContractError> {
+    let minter = MINTER.load(deps.storage)?;
+
+    if info.sender != minter {
+        return Err(cw721_base::ContractError::Unauthorized {});
+    }
+
+    // a little sense check for somebody attempting something strange
+    if msg.royalty_payments
+        && (msg.royalty_percentage.is_none() || msg.royalty_payment_address.is_none())
+    {
+        return Err(cw721_base::ContractError::Std(StdError::GenericErr {
+            msg: String::from(
+                "Argument error: royalty_percentage and royalty_payment_address required",
+            ),
+        }));
+    }
+
+    // create the token
+    let token = TokenInfo {
+        owner: deps.api.addr_validate(&msg.owner)?,
+        approvals: vec![],
+        name: msg.name,
+        description: msg.description.unwrap_or_default(),
+        image: msg.image,
+    };
+    tokens().update(deps.storage, &msg.token_id, |old| match old {
+        Some(_) => Err(cw721_base::ContractError::Claimed {}),
+        None => Ok(token),
+    })?;
+    increment_tokens(deps.storage)?;
+
+    // create the royalties lookup
+    let payment_address = match msg.royalty_payment_address {
+        Some(addr) => Some(deps.api.addr_validate(&addr)?),
+        None => None,
+    };
+    let royalties_info = RoyaltiesInfo {
+        royalty_payments: msg.royalty_payments,
+        royalty_percentage: msg.royalty_percentage,
+        royalty_payment_address: payment_address,
+    };
+    ROYALTIES_INFO.update(deps.storage, &msg.token_id, |_| -> StdResult<_> {
+        Ok(royalties_info)
+    })?;
+
+    Ok(Response::new()
+        .add_attribute("action", "mint")
+        .add_attribute("minter", info.sender)
+        .add_attribute("token_id", msg.token_id))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::RoyaltyInfo {
+            token_id,
+            sale_price,
+        } => to_binary(&query_royalties_info(deps, token_id, sale_price)?),
+        QueryMsg::CheckRoyalties {} => to_binary(&check_royalties()?),
+        QueryMsg::Minter {} => to_binary(&query_minter(deps)?),
+        QueryMsg::ContractInfo {} => to_binary(&query_contract_info(deps)?),
+        QueryMsg::NftInfo { token_id } => to_binary(&query_nft_info(deps, token_id)?),
+        QueryMsg::OwnerOf {
+            token_id,
+            include_expired,
+        } => to_binary(&query_owner_of(
+            deps,
+            env,
+            token_id,
+            include_expired.unwrap_or(false),
+        )?),
+        QueryMsg::AllNftInfo {
+            token_id,
+            include_expired,
+        } => to_binary(&query_all_nft_info(
+            deps,
+            env,
+            token_id,
+            include_expired.unwrap_or(false),
+        )?),
+        QueryMsg::ApprovedForAll {
+            owner,
+            include_expired,
+            start_after,
+            limit,
+        } => to_binary(&query_all_approvals(
+            deps,
+            env,
+            owner,
+            include_expired.unwrap_or(false),
+            start_after,
+            limit,
+        )?),
+        QueryMsg::NumTokens {} => to_binary(&query_num_tokens(deps)?),
+        QueryMsg::Tokens {
+            owner,
+            start_after,
+            limit,
+        } => to_binary(&query_tokens(deps, owner, start_after, limit)?),
+        QueryMsg::AllTokens { start_after, limit } => {
+            to_binary(&query_all_tokens(deps, start_after, limit)?)
+        }
+    }
+}
+
+// NOTE: default behaviour here is to round down
+// EIP2981 specifies that the rounding behaviour is at the discretion of the implementer
+pub fn query_royalties_info(
+    deps: Deps,
+    token_id: String,
+    sale_price: u128,
+) -> StdResult<RoyaltiesInfoResponse> {
+    let royalties_info = ROYALTIES_INFO.may_load(deps.storage, &token_id)?.unwrap();
+
+    // if not configured, throw straight away
+    if !royalties_info.royalty_payments {
+        return Err(StdError::NotFound {
+            kind: String::from("Royalties not found for this token_id"),
+        });
+    }
+
+    let royalty_percentage = match royalties_info.royalty_percentage {
+        Some(pct) => Percentage::from(pct),
+        None => Percentage::from(0),
+    };
+    let royalty_from_sale_price = royalty_percentage.apply_to(sale_price);
+
+    let royalty_address = match royalties_info.royalty_payment_address {
+        Some(addr) => addr.to_string(),
+        None => String::from(""),
+    };
+    Ok(RoyaltiesInfoResponse {
+        address: royalty_address,
+        royalty_amount: royalty_from_sale_price,
+    })
+}
+
+// This contract implements CW-2981 so we return true
+pub fn check_royalties() -> StdResult<CheckRoyaltiesResponse> {
+    Ok(CheckRoyaltiesResponse {
+        royalty_payments: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ContractError;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::{from_binary, CosmosMsg, Uint128, WasmMsg};
+    use cw2981::TokenRoyaltiesMintMsg;
+    use cw721::{
+        ApprovedForAllResponse, Cw721ReceiveMsg, Expiration, NftInfoResponse, OwnerOfResponse,
+    };
+
+    use super::*;
+
+    const MINTER: &str = "merlin";
+    const CONTRACT_NAME: &str = "Magic Power";
+    const SYMBOL: &str = "MGK";
+
+    fn setup_contract(deps: DepsMut) {
+        let msg = InstantiateMsg {
+            name: CONTRACT_NAME.to_string(),
+            symbol: SYMBOL.to_string(),
+            minter: String::from(MINTER),
+        };
+        let info = mock_info("creator", &[]);
+        let res = instantiate(deps, mock_env(), info, msg).unwrap();
+        assert_eq!(0, res.messages.len());
+    }
+
+    #[test]
+    fn proper_instantiation() {
+        let mut deps = mock_dependencies(&[]);
+
+        let msg = InstantiateMsg {
+            name: CONTRACT_NAME.to_string(),
+            symbol: SYMBOL.to_string(),
+            minter: String::from(MINTER),
+        };
+        let info = mock_info("creator", &[]);
+
+        // we can just call .unwrap() to assert this was a success
+        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(0, res.messages.len());
+
+        // it worked, let's query the state
+        let res = query_minter(deps.as_ref()).unwrap();
+        assert_eq!(MINTER, res.minter);
+        let info = query_contract_info(deps.as_ref()).unwrap();
+        assert_eq!(
+            info,
+            ContractInfoResponse {
+                name: CONTRACT_NAME.to_string(),
+                symbol: SYMBOL.to_string(),
+            }
+        );
+
+        let count = query_num_tokens(deps.as_ref()).unwrap();
+        assert_eq!(0, count.count);
+
+        // list the token_ids
+        let tokens = query_all_tokens(deps.as_ref(), None, None).unwrap();
+        assert_eq!(0, tokens.tokens.len());
+    }
+
+    #[test]
+    fn minting_with_invalid_royalty_params_errors() {
+        let mut deps = mock_dependencies(&[]);
+        setup_contract(deps.as_mut());
+
+        let token_id = "petrify".to_string();
+        let name = "Petrify with Gaze".to_string();
+        let description = "Allows the owner to petrify anyone looking at him or her".to_string();
+
+        let mint_msg = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id.clone(),
+            owner: String::from("medusa"),
+            name: name.clone(),
+            description: Some(description.clone()),
+            image: None,
+            royalty_payments: true,
+            royalty_percentage: None,
+            royalty_payment_address: Some(String::from(MINTER)),
+        });
+
+        // random cannot mint
+        let random = mock_info("random", &[]);
+        let err = execute(deps.as_mut(), mock_env(), random, mint_msg.clone()).unwrap_err();
+        assert_eq!(ContractError::from(err), ContractError::Unauthorized {});
+
+        // minter can mint
+        let allowed = mock_info(MINTER, &[]);
+        let err_res = execute(deps.as_mut(), mock_env(), allowed, mint_msg).unwrap_err();
+
+        assert_eq!(
+            err_res,
+            cw721_base::ContractError::Std(StdError::GenericErr {
+                msg: String::from(
+                    "Argument error: royalty_percentage and royalty_payment_address required"
+                ),
+            })
+        );
+    }
+
+    #[test]
+    fn minting() {
+        let mut deps = mock_dependencies(&[]);
+        setup_contract(deps.as_mut());
+
+        let token_id = "petrify".to_string();
+        let name = "Petrify with Gaze".to_string();
+        let description = "Allows the owner to petrify anyone looking at him or her".to_string();
+
+        let mint_msg = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id.clone(),
+            owner: String::from("medusa"),
+            name: name.clone(),
+            description: Some(description.clone()),
+            image: None,
+            royalty_payments: true,
+            royalty_percentage: Some(10),
+            royalty_payment_address: Some(String::from(MINTER)),
+        });
+
+        // random cannot mint
+        let random = mock_info("random", &[]);
+        let err = execute(deps.as_mut(), mock_env(), random, mint_msg.clone()).unwrap_err();
+        assert_eq!(ContractError::from(err), ContractError::Unauthorized {});
+
+        // minter can mint
+        let allowed = mock_info(MINTER, &[]);
+        let _ = execute(deps.as_mut(), mock_env(), allowed, mint_msg).unwrap();
+
+        // ensure num tokens increases
+        let count = query_num_tokens(deps.as_ref()).unwrap();
+        assert_eq!(1, count.count);
+
+        // unknown nft returns error
+        let _ = query_nft_info(deps.as_ref(), "unknown".to_string()).unwrap_err();
+
+        // this nft info is correct
+        let info = query_nft_info(deps.as_ref(), token_id.clone()).unwrap();
+        assert_eq!(
+            info,
+            NftInfoResponse {
+                name,
+                description,
+                image: None,
+            }
+        );
+
+        // owner info is correct
+        let owner = query_owner_of(deps.as_ref(), mock_env(), token_id.clone(), true).unwrap();
+        assert_eq!(
+            owner,
+            OwnerOfResponse {
+                owner: String::from("medusa"),
+                approvals: vec![],
+            }
+        );
+
+        // royalties info is correct in case it was sold for 1_000_000 right away
+        let queried_royalties_info = query_royalties_info(
+            deps.as_ref(),
+            token_id.clone(),
+            Uint128::new(1_000_000).u128(),
+        )
+        .unwrap();
+        assert_eq!(
+            queried_royalties_info,
+            RoyaltiesInfoResponse {
+                address: String::from(MINTER),
+                royalty_amount: Uint128::new(100_000).u128()
+            }
+        );
+
+        // Cannot mint same token_id again
+        let mint_msg2 = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id.clone(),
+            owner: String::from("hercules"),
+            name: "copy cat".into(),
+            description: None,
+            image: None,
+            royalty_payments: true,
+            royalty_percentage: Some(10),
+            royalty_payment_address: Some(String::from(MINTER)),
+        });
+
+        let allowed = mock_info(MINTER, &[]);
+        let err = execute(deps.as_mut(), mock_env(), allowed, mint_msg2).unwrap_err();
+        assert_eq!(ContractError::from(err), ContractError::Claimed {});
+
+        // list the token_ids
+        let tokens = query_all_tokens(deps.as_ref(), None, None).unwrap();
+        assert_eq!(1, tokens.tokens.len());
+        assert_eq!(vec![token_id], tokens.tokens);
+    }
+
+    #[test]
+    fn transferring_nft() {
+        let mut deps = mock_dependencies(&[]);
+        setup_contract(deps.as_mut());
+
+        // Mint a token
+        let token_id = "melt".to_string();
+        let name = "Melting power".to_string();
+        let description = "Allows the owner to melt anyone looking at him or her".to_string();
+
+        let mint_msg = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id.clone(),
+            owner: String::from("venus"),
+            name,
+            description: Some(description),
+            image: None,
+            royalty_payments: true,
+            royalty_percentage: Some(7),
+            royalty_payment_address: Some(String::from(MINTER)),
+        });
+
+        let minter = mock_info(MINTER, &[]);
+        execute(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
+
+        // random cannot transfer
+        let random = mock_info("random", &[]);
+        let transfer_msg = ExecuteMsg::TransferNft {
+            recipient: String::from("random"),
+            token_id: token_id.clone(),
+        };
+
+        let err = execute(deps.as_mut(), mock_env(), random, transfer_msg).unwrap_err();
+        assert_eq!(ContractError::from(err), ContractError::Unauthorized {});
+
+        // owner can
+        let random = mock_info("venus", &[]);
+        let transfer_msg = ExecuteMsg::TransferNft {
+            recipient: String::from("random"),
+            token_id: token_id.clone(),
+        };
+
+        // check royalties info is correct at point of simulated sale
+        // note also this results in 92492.54
+        // so this test also documents that the behaviour is to round down
+        let queried_royalties_info = query_royalties_info(
+            deps.as_ref(),
+            token_id.clone(),
+            Uint128::new(1_321_322).u128(),
+        )
+        .unwrap();
+        assert_eq!(
+            queried_royalties_info,
+            RoyaltiesInfoResponse {
+                address: String::from(MINTER),
+                royalty_amount: Uint128::new(92_492).u128()
+            }
+        );
+
+        let res = execute(deps.as_mut(), mock_env(), random, transfer_msg).unwrap();
+
+        assert_eq!(
+            res,
+            Response::new()
+                .add_attribute("action", "transfer_nft")
+                .add_attribute("sender", "venus")
+                .add_attribute("recipient", "random")
+                .add_attribute("token_id", token_id)
+        );
+    }
+
+    #[test]
+    fn sending_nft() {
+        let mut deps = mock_dependencies(&[]);
+        setup_contract(deps.as_mut());
+
+        // Mint a token
+        let token_id = "melt".to_string();
+        let name = "Melting power".to_string();
+        let description = "Allows the owner to melt anyone looking at him or her".to_string();
+
+        let mint_msg = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id.clone(),
+            owner: String::from("venus"),
+            name,
+            description: Some(description),
+            image: None,
+            royalty_payments: true,
+            royalty_percentage: Some(7),
+            royalty_payment_address: Some(String::from(MINTER)),
+        });
+
+        let minter = mock_info(MINTER, &[]);
+        execute(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
+
+        let msg = to_binary("You now have the melting power").unwrap();
+        let target = String::from("another_contract");
+        let send_msg = ExecuteMsg::SendNft {
+            contract: target.clone(),
+            token_id: token_id.clone(),
+            msg: msg.clone(),
+        };
+
+        let random = mock_info("random", &[]);
+        let err = execute(deps.as_mut(), mock_env(), random, send_msg.clone()).unwrap_err();
+        assert_eq!(ContractError::from(err), ContractError::Unauthorized {});
+
+        // but owner can
+        let random = mock_info("venus", &[]);
+        let res = execute(deps.as_mut(), mock_env(), random, send_msg).unwrap();
+
+        // check royalties info is correct at point of hypothetical sale
+        let queried_royalties_info = query_royalties_info(
+            deps.as_ref(),
+            token_id.clone(),
+            Uint128::new(1_321_321).u128(),
+        )
+        .unwrap();
+        assert_eq!(
+            queried_royalties_info,
+            RoyaltiesInfoResponse {
+                address: String::from(MINTER),
+                royalty_amount: Uint128::new(92_492).u128(),
+            }
+        );
+
+        let payload = Cw721ReceiveMsg {
+            sender: String::from("venus"),
+            token_id: token_id.clone(),
+            msg,
+        };
+        let expected = payload.into_cosmos_msg(target.clone()).unwrap();
+        // ensure expected serializes as we think it should
+        match &expected {
+            CosmosMsg::Wasm(WasmMsg::Execute { contract_addr, .. }) => {
+                assert_eq!(contract_addr, &target)
+            }
+            m => panic!("Unexpected message type: {:?}", m),
+        }
+        // and make sure this is the request sent by the contract
+        assert_eq!(
+            res,
+            Response::new()
+                .add_message(expected)
+                .add_attribute("action", "send_nft")
+                .add_attribute("sender", "venus")
+                .add_attribute("recipient", "another_contract")
+                .add_attribute("token_id", token_id)
+        );
+    }
+
+    #[test]
+    fn approving_revoking() {
+        let mut deps = mock_dependencies(&[]);
+        setup_contract(deps.as_mut());
+
+        // Mint a token
+        let token_id = "grow".to_string();
+        let name = "Growing power".to_string();
+        let description = "Allows the owner to grow anything".to_string();
+
+        let mint_msg = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id.clone(),
+            owner: String::from("demeter"),
+            name,
+            description: Some(description),
+            image: None,
+            royalty_payments: false,
+            royalty_percentage: None,
+            royalty_payment_address: None,
+        });
+
+        let minter = mock_info(MINTER, &[]);
+        execute(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
+
+        // Give random transferring power
+        let approve_msg = ExecuteMsg::Approve {
+            spender: String::from("random"),
+            token_id: token_id.clone(),
+            expires: None,
+        };
+        let owner = mock_info("demeter", &[]);
+        let res = execute(deps.as_mut(), mock_env(), owner, approve_msg).unwrap();
+        assert_eq!(
+            res,
+            Response::new()
+                .add_attribute("action", "approve")
+                .add_attribute("sender", "demeter")
+                .add_attribute("spender", "random")
+                .add_attribute("token_id", token_id.clone())
+        );
+
+        // random can now transfer
+        let random = mock_info("random", &[]);
+        let transfer_msg = ExecuteMsg::TransferNft {
+            recipient: String::from("person"),
+            token_id: token_id.clone(),
+        };
+        execute(deps.as_mut(), mock_env(), random, transfer_msg).unwrap();
+
+        // Approvals are removed / cleared
+        let query_msg = QueryMsg::OwnerOf {
+            token_id: token_id.clone(),
+            include_expired: None,
+        };
+        let res: OwnerOfResponse =
+            from_binary(&query(deps.as_ref(), mock_env(), query_msg.clone()).unwrap()).unwrap();
+        assert_eq!(
+            res,
+            OwnerOfResponse {
+                owner: String::from("person"),
+                approvals: vec![],
+            }
+        );
+
+        // Approve, revoke, and check for empty, to test revoke
+        let approve_msg = ExecuteMsg::Approve {
+            spender: String::from("random"),
+            token_id: token_id.clone(),
+            expires: None,
+        };
+        let owner = mock_info("person", &[]);
+        execute(deps.as_mut(), mock_env(), owner.clone(), approve_msg).unwrap();
+
+        let revoke_msg = ExecuteMsg::Revoke {
+            spender: String::from("random"),
+            token_id,
+        };
+        execute(deps.as_mut(), mock_env(), owner, revoke_msg).unwrap();
+
+        // Approvals are now removed / cleared
+        let res: OwnerOfResponse =
+            from_binary(&query(deps.as_ref(), mock_env(), query_msg).unwrap()).unwrap();
+        assert_eq!(
+            res,
+            OwnerOfResponse {
+                owner: String::from("person"),
+                approvals: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn approving_all_revoking_all() {
+        let mut deps = mock_dependencies(&[]);
+        setup_contract(deps.as_mut());
+
+        // Mint a couple tokens (from the same owner)
+        let token_id1 = "grow1".to_string();
+        let name1 = "Growing power".to_string();
+        let description1 = "Allows the owner the power to grow anything".to_string();
+        let token_id2 = "grow2".to_string();
+        let name2 = "More growing power".to_string();
+        let description2 = "Allows the owner the power to grow anything even faster".to_string();
+
+        let mint_msg1 = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id1.clone(),
+            owner: String::from("demeter"),
+            name: name1,
+            description: Some(description1),
+            image: None,
+            royalty_payments: false,
+            royalty_percentage: None,
+            royalty_payment_address: None,
+        });
+
+        let minter = mock_info(MINTER, &[]);
+        execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg1).unwrap();
+
+        let mint_msg2 = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id2.clone(),
+            owner: String::from("demeter"),
+            name: name2,
+            description: Some(description2),
+            image: None,
+            royalty_payments: false,
+            royalty_percentage: None,
+            royalty_payment_address: None,
+        });
+
+        execute(deps.as_mut(), mock_env(), minter, mint_msg2).unwrap();
+
+        // paginate the token_ids
+        let tokens = query_all_tokens(deps.as_ref(), None, Some(1)).unwrap();
+        assert_eq!(1, tokens.tokens.len());
+        assert_eq!(vec![token_id1.clone()], tokens.tokens);
+        let tokens = query_all_tokens(deps.as_ref(), Some(token_id1.clone()), Some(3)).unwrap();
+        assert_eq!(1, tokens.tokens.len());
+        assert_eq!(vec![token_id2.clone()], tokens.tokens);
+
+        // demeter gives random full (operator) power over her tokens
+        let approve_all_msg = ExecuteMsg::ApproveAll {
+            operator: String::from("random"),
+            expires: None,
+        };
+        let owner = mock_info("demeter", &[]);
+        let res = execute(deps.as_mut(), mock_env(), owner, approve_all_msg).unwrap();
+        assert_eq!(
+            res,
+            Response::new()
+                .add_attribute("action", "approve_all")
+                .add_attribute("sender", "demeter")
+                .add_attribute("operator", "random")
+        );
+
+        // random can now transfer
+        let random = mock_info("random", &[]);
+        let transfer_msg = ExecuteMsg::TransferNft {
+            recipient: String::from("person"),
+            token_id: token_id1,
+        };
+        execute(deps.as_mut(), mock_env(), random.clone(), transfer_msg).unwrap();
+
+        // random can now send
+        let inner_msg = WasmMsg::Execute {
+            contract_addr: "another_contract".into(),
+            msg: to_binary("You now also have the growing power").unwrap(),
+            funds: vec![],
+        };
+        let msg: CosmosMsg = CosmosMsg::Wasm(inner_msg);
+
+        let send_msg = ExecuteMsg::SendNft {
+            contract: String::from("another_contract"),
+            token_id: token_id2,
+            msg: to_binary(&msg).unwrap(),
+        };
+        execute(deps.as_mut(), mock_env(), random, send_msg).unwrap();
+
+        // Approve_all, revoke_all, and check for empty, to test revoke_all
+        let approve_all_msg = ExecuteMsg::ApproveAll {
+            operator: String::from("operator"),
+            expires: None,
+        };
+        // person is now the owner of the tokens
+        let owner = mock_info("person", &[]);
+        execute(deps.as_mut(), mock_env(), owner, approve_all_msg).unwrap();
+
+        let res = query_all_approvals(
+            deps.as_ref(),
+            mock_env(),
+            String::from("person"),
+            true,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            res,
+            ApprovedForAllResponse {
+                operators: vec![cw721::Approval {
+                    spender: String::from("operator"),
+                    expires: Expiration::Never {}
+                }]
+            }
+        );
+
+        // second approval
+        let buddy_expires = Expiration::AtHeight(1234567);
+        let approve_all_msg = ExecuteMsg::ApproveAll {
+            operator: String::from("buddy"),
+            expires: Some(buddy_expires),
+        };
+        let owner = mock_info("person", &[]);
+        execute(deps.as_mut(), mock_env(), owner.clone(), approve_all_msg).unwrap();
+
+        // and paginate queries
+        let res = query_all_approvals(
+            deps.as_ref(),
+            mock_env(),
+            String::from("person"),
+            true,
+            None,
+            Some(1),
+        )
+        .unwrap();
+        assert_eq!(
+            res,
+            ApprovedForAllResponse {
+                operators: vec![cw721::Approval {
+                    spender: String::from("buddy"),
+                    expires: buddy_expires,
+                }]
+            }
+        );
+        let res = query_all_approvals(
+            deps.as_ref(),
+            mock_env(),
+            String::from("person"),
+            true,
+            Some(String::from("buddy")),
+            Some(2),
+        )
+        .unwrap();
+        assert_eq!(
+            res,
+            ApprovedForAllResponse {
+                operators: vec![cw721::Approval {
+                    spender: String::from("operator"),
+                    expires: Expiration::Never {}
+                }]
+            }
+        );
+
+        let revoke_all_msg = ExecuteMsg::RevokeAll {
+            operator: String::from("operator"),
+        };
+        execute(deps.as_mut(), mock_env(), owner, revoke_all_msg).unwrap();
+
+        // Approvals are removed / cleared without affecting others
+        let res = query_all_approvals(
+            deps.as_ref(),
+            mock_env(),
+            String::from("person"),
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            res,
+            ApprovedForAllResponse {
+                operators: vec![cw721::Approval {
+                    spender: String::from("buddy"),
+                    expires: buddy_expires,
+                }]
+            }
+        );
+
+        // ensure the filter works (nothing should be here
+        let mut late_env = mock_env();
+        late_env.block.height = 1234568; //expired
+        let res = query_all_approvals(
+            deps.as_ref(),
+            late_env,
+            String::from("person"),
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(0, res.operators.len());
+    }
+
+    #[test]
+    fn query_tokens_by_owner() {
+        let mut deps = mock_dependencies(&[]);
+        setup_contract(deps.as_mut());
+        let minter = mock_info(MINTER, &[]);
+
+        // Mint a couple tokens (from the same owner)
+        let token_id1 = "grow1".to_string();
+        let demeter = String::from("Demeter");
+        let token_id2 = "grow2".to_string();
+        let ceres = String::from("Ceres");
+        let token_id3 = "sing".to_string();
+
+        let mint_msg = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id1.clone(),
+            owner: demeter.clone(),
+            name: "Growing power".to_string(),
+            description: Some("Allows the owner the power to grow anything".to_string()),
+            image: None,
+            royalty_payments: false,
+            royalty_percentage: None,
+            royalty_payment_address: None,
+        });
+        execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg).unwrap();
+
+        // sense check a hypothetical sale
+        // NotFound should be thrown as royalties are not configured
+        let queried_royalties_info = query_royalties_info(
+            deps.as_ref(),
+            token_id1.clone(),
+            Uint128::new(1_000_000).u128(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            queried_royalties_info,
+            StdError::NotFound {
+                kind: String::from("Royalties not found for this token_id"),
+            }
+        );
+
+        let mint_msg = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id2.clone(),
+            owner: ceres.clone(),
+            name: "More growing power".to_string(),
+            description: Some(
+                "Allows the owner the power to grow anything even faster".to_string(),
+            ),
+            image: None,
+            royalty_payments: false,
+            royalty_percentage: None,
+            royalty_payment_address: None,
+        });
+        execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg).unwrap();
+
+        let mint_msg = ExecuteMsg::Mint(TokenRoyaltiesMintMsg {
+            token_id: token_id3.clone(),
+            owner: demeter.clone(),
+            name: "Sing a lullaby".to_string(),
+            description: Some("Calm even the most excited children".to_string()),
+            image: None,
+            royalty_payments: false,
+            royalty_percentage: None,
+            royalty_payment_address: None,
+        });
+        execute(deps.as_mut(), mock_env(), minter, mint_msg).unwrap();
+
+        // get all tokens in order:
+        let expected = vec![token_id1.clone(), token_id2.clone(), token_id3.clone()];
+        let tokens = query_all_tokens(deps.as_ref(), None, None).unwrap();
+        assert_eq!(&expected, &tokens.tokens);
+        // paginate
+        let tokens = query_all_tokens(deps.as_ref(), None, Some(2)).unwrap();
+        assert_eq!(&expected[..2], &tokens.tokens[..]);
+        let tokens = query_all_tokens(deps.as_ref(), Some(expected[1].clone()), None).unwrap();
+        assert_eq!(&expected[2..], &tokens.tokens[..]);
+
+        // get by owner
+        let by_ceres = vec![token_id2];
+        let by_demeter = vec![token_id1, token_id3];
+        // all tokens by owner
+        let tokens = query_tokens(deps.as_ref(), demeter.clone(), None, None).unwrap();
+        assert_eq!(&by_demeter, &tokens.tokens);
+        let tokens = query_tokens(deps.as_ref(), ceres, None, None).unwrap();
+        assert_eq!(&by_ceres, &tokens.tokens);
+
+        // paginate for demeter
+        let tokens = query_tokens(deps.as_ref(), demeter.clone(), None, Some(1)).unwrap();
+        assert_eq!(&by_demeter[..1], &tokens.tokens[..]);
+        let tokens =
+            query_tokens(deps.as_ref(), demeter, Some(by_demeter[0].clone()), Some(3)).unwrap();
+        assert_eq!(&by_demeter[1..], &tokens.tokens[..]);
+    }
+}

--- a/contracts/cw2981-base/src/error.rs
+++ b/contracts/cw2981-base/src/error.rs
@@ -1,0 +1,31 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("No royalties set for token_id")]
+    NoRoyaltiesSet {},
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("token_id already claimed")]
+    Claimed {},
+
+    #[error("Cannot set approval that is already expired")]
+    Expired {},
+}
+
+impl From<cw721_base::ContractError> for ContractError {
+    fn from(err: cw721_base::ContractError) -> Self {
+        match err {
+            cw721_base::ContractError::Std(error) => ContractError::Std(error),
+            cw721_base::ContractError::Unauthorized {} => ContractError::Unauthorized {},
+            cw721_base::ContractError::Claimed {} => ContractError::Claimed {},
+            cw721_base::ContractError::Expired {} => ContractError::Expired {},
+        }
+    }
+}

--- a/contracts/cw2981-base/src/lib.rs
+++ b/contracts/cw2981-base/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw2981-base/src/msg.rs
+++ b/contracts/cw2981-base/src/msg.rs
@@ -1,0 +1,122 @@
+use cosmwasm_std::Binary;
+use cw2981::TokenRoyaltiesMintMsg;
+use cw721::Expiration;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// This is like Cw721ExecuteMsg but we add a Mint command for an owner
+/// to make this stand-alone. You will likely want to remove mint and
+/// use other control logic in any contract that inherits this.
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    /// Transfer is a base message to move a token to another account without triggering actions
+    TransferNft { recipient: String, token_id: String },
+    /// Send is a base message to transfer a token to a contract and trigger an action
+    /// on the receiving contract.
+    SendNft {
+        contract: String,
+        token_id: String,
+        msg: Binary,
+    },
+    /// Allows operator to transfer / send the token from the owner's account.
+    /// If expiration is set, then this allowance has a time/height limit
+    Approve {
+        spender: String,
+        token_id: String,
+        expires: Option<Expiration>,
+    },
+    /// Remove previously granted Approval
+    Revoke { spender: String, token_id: String },
+    /// Allows operator to transfer / send any token from the owner's account.
+    /// If expiration is set, then this allowance has a time/height limit
+    ApproveAll {
+        operator: String,
+        expires: Option<Expiration>,
+    },
+    /// Remove previously granted ApproveAll permission
+    RevokeAll { operator: String },
+
+    /// Mint a new NFT, can only be called by the contract minter
+    Mint(TokenRoyaltiesMintMsg),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    // Should be called on sale to see if royalties are owed
+    // by the marketplace selling the NFT.
+    // See https://eips.ethereum.org/EIPS/eip-2981
+    RoyaltyInfo {
+        token_id: String,
+        // the denom of this sale must also be the denom returned by RoyaltiesInfoResponse
+        // this was originally implemented as a Coin
+        // however that would mean you couldn't buy using CW20s
+        // as CW20 is just mapping of addr -> balance
+        sale_price: u128,
+    },
+    // Called against contract to determine if this NFT
+    // implements royalties
+    CheckRoyalties {},
+    /// Return the owner of the given token, error if token does not exist
+    /// Return type: OwnerOfResponse
+    OwnerOf {
+        token_id: String,
+        /// unset or false will filter out expired approvals, you must set to true to see them
+        include_expired: Option<bool>,
+    },
+    /// List all operators that can access all of the owner's tokens
+    /// Return type: `ApprovedForAllResponse`
+    ApprovedForAll {
+        owner: String,
+        /// unset or false will filter out expired items, you must set to true to see them
+        include_expired: Option<bool>,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Total number of tokens issued
+    NumTokens {},
+
+    /// With MetaData Extension.
+    /// Returns top-level metadata about the contract: `ContractInfoResponse`
+    ContractInfo {},
+    /// With MetaData Extension.
+    /// Returns metadata about one particular token, based on *ERC721 Metadata JSON Schema*
+    /// but directly from the contract: `NftInfoResponse`
+    NftInfo {
+        token_id: String,
+    },
+    /// With MetaData Extension.
+    /// Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimization
+    /// for clients: `AllNftInfo`
+    AllNftInfo {
+        token_id: String,
+        /// unset or false will filter out expired approvals, you must set to true to see them
+        include_expired: Option<bool>,
+    },
+
+    /// With Enumerable extension.
+    /// Returns all tokens owned by the given address, [] if unset.
+    /// Return type: TokensResponse.
+    Tokens {
+        owner: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// With Enumerable extension.
+    /// Requires pagination. Lists all token_ids controlled by the contract.
+    /// Return type: TokensResponse.
+    AllTokens {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+
+    // Return the minter
+    Minter {},
+}
+
+/// Shows who can mint these tokens
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct MinterResponse {
+    pub minter: String,
+}

--- a/contracts/cw2981-base/src/state.rs
+++ b/contracts/cw2981-base/src/state.rs
@@ -1,0 +1,20 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::Addr;
+use cw721::ContractInfoResponse;
+use cw_storage_plus::{Item, Map};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct RoyaltiesInfo {
+    pub royalty_payments: bool,
+    /// This is how much the minter takes as a cut when sold
+    pub royalty_percentage: Option<u32>,
+    /// The payment address, may be different to or the same
+    /// as the minter addr
+    pub royalty_payment_address: Option<Addr>,
+}
+
+// maps token id to royalties info
+pub const ROYALTIES_INFO: Map<&str, RoyaltiesInfo> = Map::new("royalties_info");
+pub const CONTRACT_INFO: Item<ContractInfoResponse> = Item::new("nft_info");

--- a/packages/cw2981/.cargo/config
+++ b/packages/cw2981/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+schema = "run --example schema"

--- a/packages/cw2981/Cargo.toml
+++ b/packages/cw2981/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cw2981"
+version = "0.8.1"
+authors = ["Alex Lynham <alex@lynh.am>"]
+edition = "2018"
+description = "Definition and types for the CosmWasm-2981 NFT royalties interface"
+license = "Apache-2.0"
+repository = "https://github.com/CosmWasm/cw-plus"
+homepage = "https://cosmwasm.com"
+documentation = "https://docs.cosmwasm.com"
+
+[dependencies]
+cosmwasm-std = { version = "0.16.0" }
+schemars = "0.8.1"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+
+[dev-dependencies]
+cosmwasm-schema = { version = "0.16.0" }

--- a/packages/cw2981/README.md
+++ b/packages/cw2981/README.md
@@ -1,0 +1,27 @@
+# CW-2981 Spec: NFT Royalties
+
+CW-2981 is an un-opinionated minimal way of implementing royalties for NFTs, based on the [EIP-2981 NFT Royalty Standard](https://eips.ethereum.org/EIPS/eip-2981).
+
+Note that this package seeks to show the base implementation. As it is primarily a query interface, with the implementation left up to the contract author, more complicated patterns, like a time-decay (presumably tied to block height) on royalties, could be implemented.
+
+In order to achieve this, you would simply use the Queries defined here, implement custom Messages to store the required state, and custom query handlers to return the correct royalty to clients and marketplaces.
+
+### Messages
+
+There are two patterns for implementation provided here:
+
+1. Token-level royalties.
+If you want to implement token-level royalties, use a normal CW-721 instantiation message, and simply return `true` from a query handler matched to `CheckRoyalties` to signal that the contract implements CW-2981.
+2. Contract-level royalties.
+If you want all tokens minted by the contract to have the same royalty info, use `ContractRoyaltiesInstantiateMsg` to provide these parameters. You can set `royalty_payments` to `false` and provide `None` for the other parameters, and the contract will function as a normal CW-721.
+
+As alluded to above, you could also extend these examples with additional fields to provide custom math for the royalty percentage. The key is that the interface exposed by the queries (below) must be the same.
+
+### Queries
+
+Whether or not you are implementing royalties at contract-level or token level, two queries are defined:
+
+1. `RoyaltyInfo` this takes a `token_id` and `sale_price`, and should return `RoyaltiesInfoResponse`. It is denomination-agnostic, the assumption being that the same denomination that is passed in should be returned. This also means it supports e.g. the NFT being sold for a price in CW20.
+2. `CheckRoyalties` signals that this contract implements CW-2981 and thus marketplaces should check tokens on sale.
+
+

--- a/packages/cw2981/examples/schema.rs
+++ b/packages/cw2981/examples/schema.rs
@@ -1,0 +1,20 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+
+use cw2981::{CheckRoyaltiesResponse, Cw2981QueryMsg, RoyaltiesInfoResponse};
+use cw2981::{ContractRoyaltiesInstantiateMsg, TokenRoyaltiesMintMsg};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(ContractRoyaltiesInstantiateMsg), &out_dir);
+    export_schema(&schema_for!(Cw2981QueryMsg), &out_dir);
+    export_schema(&schema_for!(TokenRoyaltiesMintMsg), &out_dir);
+    export_schema(&schema_for!(RoyaltiesInfoResponse), &out_dir);
+    export_schema(&schema_for!(CheckRoyaltiesResponse), &out_dir);
+}

--- a/packages/cw2981/schema/check_royalties_response.json
+++ b/packages/cw2981/schema/check_royalties_response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CheckRoyaltiesResponse",
+  "description": "Shows if the contract implements royalties if royalty_payments is true, marketplaces should pay them",
+  "type": "object",
+  "required": [
+    "royalty_payments"
+  ],
+  "properties": {
+    "royalty_payments": {
+      "type": "boolean"
+    }
+  }
+}

--- a/packages/cw2981/schema/contract_royalties_instantiate_msg.json
+++ b/packages/cw2981/schema/contract_royalties_instantiate_msg.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ContractRoyaltiesInstantiateMsg",
+  "description": "To allow for royalties to be specified AT CONTRACT LEVEL (i.e. for all tokens managed by this contract), you would specify royalties at instantiation time",
+  "type": "object",
+  "required": [
+    "minter",
+    "name",
+    "royalty_payments",
+    "symbol"
+  ],
+  "properties": {
+    "minter": {
+      "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
+      "type": "string"
+    },
+    "name": {
+      "description": "Name of the NFT contract",
+      "type": "string"
+    },
+    "royalty_payment_address": {
+      "description": "Where should royalty payments be sent?",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "royalty_payments": {
+      "description": "Does this implement CW-2981",
+      "type": "boolean"
+    },
+    "royalty_percentage": {
+      "description": "What is the royalty percentage to use?",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "symbol": {
+      "description": "Symbol of the NFT contract",
+      "type": "string"
+    }
+  }
+}

--- a/packages/cw2981/schema/cw2981_query_msg.json
+++ b/packages/cw2981/schema/cw2981_query_msg.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Cw2981QueryMsg",
+  "description": "These are the queries you will need to define royalty options",
+  "anyOf": [
+    {
+      "type": "object",
+      "required": [
+        "royalty_info"
+      ],
+      "properties": {
+        "royalty_info": {
+          "type": "object",
+          "required": [
+            "sale_price",
+            "token_id"
+          ],
+          "properties": {
+            "sale_price": {
+              "type": "integer",
+              "format": "uint128",
+              "minimum": 0.0
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "check_royalties"
+      ],
+      "properties": {
+        "check_royalties": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/packages/cw2981/schema/royalties_info_response.json
+++ b/packages/cw2981/schema/royalties_info_response.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RoyaltiesInfoResponse",
+  "description": "Shows royalty info These are always the same, just the implementation changes depending on the granularity of the above queries.",
+  "type": "object",
+  "required": [
+    "address",
+    "royalty_amount"
+  ],
+  "properties": {
+    "address": {
+      "type": "string"
+    },
+    "royalty_amount": {
+      "type": "integer",
+      "format": "uint128",
+      "minimum": 0.0
+    }
+  }
+}

--- a/packages/cw2981/schema/token_royalties_mint_msg.json
+++ b/packages/cw2981/schema/token_royalties_mint_msg.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TokenRoyaltiesMintMsg",
+  "description": "To allow for royalties to be specified AT TOKEN LEVEL (i.e. different NFTs minted by this contract might have different royalty info), we make some changes to the base MintMsg This, or custom logic like it, should be used in contracts that implement 2981 royalties as defined by the query interface",
+  "type": "object",
+  "required": [
+    "name",
+    "owner",
+    "royalty_payments",
+    "token_id"
+  ],
+  "properties": {
+    "description": {
+      "description": "Describes the asset to which this NFT represents (may be empty)",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "image": {
+      "description": "A URI pointing to an image representing the asset",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "name": {
+      "description": "Identifies the asset to which this NFT represents",
+      "type": "string"
+    },
+    "owner": {
+      "description": "The owner of the newly minter NFT",
+      "type": "string"
+    },
+    "royalty_payment_address": {
+      "description": "The address that should be paid the royalty",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "royalty_payments": {
+      "description": "Whether or not royalties should be paid",
+      "type": "boolean"
+    },
+    "royalty_percentage": {
+      "description": "The percentage of sale that is owed note that in future this could be extended to have an additional parameter for e.g. decay so a royalty could decrease over time this is merely the base case",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "token_id": {
+      "description": "Unique ID of the NFT",
+      "type": "string"
+    }
+  }
+}

--- a/packages/cw2981/src/lib.rs
+++ b/packages/cw2981/src/lib.rs
@@ -1,0 +1,13 @@
+mod msg;
+mod query;
+
+pub use crate::msg::{ContractRoyaltiesInstantiateMsg, TokenRoyaltiesMintMsg};
+pub use crate::query::{CheckRoyaltiesResponse, Cw2981QueryMsg, RoyaltiesInfoResponse};
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        // test me
+    }
+}

--- a/packages/cw2981/src/msg.rs
+++ b/packages/cw2981/src/msg.rs
@@ -1,0 +1,58 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// To allow for royalties to be specified AT TOKEN LEVEL
+/// (i.e. different NFTs minted by this contract might
+/// have different royalty info),
+/// we make some changes to the base MintMsg
+/// This, or custom logic like it, should be used
+/// in contracts that implement 2981 royalties
+/// as defined by the query interface
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct TokenRoyaltiesMintMsg {
+    /// Unique ID of the NFT
+    pub token_id: String,
+    /// The owner of the newly minter NFT
+    pub owner: String,
+    /// Identifies the asset to which this NFT represents
+    pub name: String,
+    /// Describes the asset to which this NFT represents (may be empty)
+    pub description: Option<String>,
+    /// A URI pointing to an image representing the asset
+    pub image: Option<String>,
+
+    // params related to royalties
+    /// Whether or not royalties should be paid
+    pub royalty_payments: bool,
+    /// The percentage of sale that is owed
+    /// note that in future this could be extended
+    /// to have an additional parameter for e.g. decay
+    /// so a royalty could decrease over time
+    /// this is merely the base case
+    pub royalty_percentage: Option<u32>,
+    /// The address that should be paid the royalty
+    pub royalty_payment_address: Option<String>,
+}
+
+/// To allow for royalties to be specified AT CONTRACT LEVEL
+/// (i.e. for all tokens managed by this contract),
+/// you would specify royalties at instantiation time
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ContractRoyaltiesInstantiateMsg {
+    /// Name of the NFT contract
+    pub name: String,
+    /// Symbol of the NFT contract
+    pub symbol: String,
+
+    /// The minter is the only one who can create new NFTs.
+    /// This is designed for a base NFT that is controlled by an external program
+    /// or contract. You will likely replace this with custom logic in custom NFTs
+    pub minter: String,
+
+    /// Does this implement CW-2981
+    pub royalty_payments: bool,
+    /// What is the royalty percentage to use?
+    pub royalty_percentage: Option<u32>,
+    /// Where should royalty payments be sent?
+    pub royalty_payment_address: Option<String>,
+}

--- a/packages/cw2981/src/query.rs
+++ b/packages/cw2981/src/query.rs
@@ -1,0 +1,40 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// These are the queries you will need to define royalty options
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Cw2981QueryMsg {
+    // Should be called on sale to see if royalties are owed
+    // by the marketplace selling the NFT.
+    // See https://eips.ethereum.org/EIPS/eip-2981
+    RoyaltyInfo {
+        token_id: String,
+        // the denom of this sale must also be the denom returned by RoyaltiesInfoResponse
+        // this was originally implemented as a Coin
+        // however that would mean you couldn't buy using CW20s
+        // as CW20 is just mapping of addr -> balance
+        sale_price: u128,
+    },
+    // Called against contract to determine if this NFT contract
+    // implements royalties
+    CheckRoyalties {},
+}
+
+/// Shows royalty info
+/// These are always the same, just the implementation changes
+/// depending on the granularity of the above queries.
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct RoyaltiesInfoResponse {
+    pub address: String,
+    // Note that this must be the same denom as that passed in to RoyaltyInfo
+    // rounding up or down is at the discretion of the implementer
+    pub royalty_amount: u128,
+}
+
+/// Shows if the contract implements royalties
+/// if royalty_payments is true, marketplaces should pay them
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct CheckRoyaltiesResponse {
+    pub royalty_payments: bool,
+}


### PR DESCRIPTION
Appreciate this might need some refining and/or further discussion.

Wanted essentially to have a bare minimum example for the [EIP-2981 spec](https://eips.ethereum.org/EIPS/eip-2981) implemented in CW-land. This is my attempt at that.

In essence, it's a very light wrapper/extension for CW721 compliant contracts that adds two additional query messages:
- `RoyaltyInfo` to be called when selling an NFT, to find out what royalties are owed
- `CheckRoyalties` to be called on the contract, to see if it implements CW-2981

There's an example contract implemented that adds royalty information at token mint time, although it is also possible to add that as contract metadata at instantiation time (that instantiation message format is in the package).

The main thing as I understand it here is basically the shape of the queries, that can be called when a marketplace sells an NFT. The actual implementation might differ on a per contract basis (the example contract here just does a straight percentage).