### PR TITLE
Generic module types

### DIFF
--- a/contracts/cw20-escrow/src/integration_test.rs
+++ b/contracts/cw20-escrow/src/integration_test.rs
@@ -2,13 +2,9 @@
 
 use cosmwasm_std::{coins, to_binary, Addr, Empty, Uint128};
 use cw20::{Cw20Coin, Cw20Contract, Cw20ExecuteMsg};
-use cw_multi_test::{App, AppBuilder, Contract, ContractWrapper, Executor};
+use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 
 use crate::msg::{CreateMsg, DetailsResponse, ExecuteMsg, InstantiateMsg, QueryMsg, ReceiveMsg};
-
-fn mock_app() -> App {
-    AppBuilder::new().build()
-}
 
 pub fn contract_escrow() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
@@ -31,12 +27,16 @@ pub fn contract_cw20() -> Box<dyn Contract<Empty>> {
 #[test]
 // receive cw20 tokens and release upon approval
 fn escrow_happy_path_cw20_tokens() {
-    let mut router = mock_app();
-
     // set personal balance
     let owner = Addr::unchecked("owner");
     let init_funds = coins(2000, "btc");
-    router.init_bank_balance(&owner, init_funds).unwrap();
+
+    let mut router = App::new(|router, _, storage| {
+        router
+            .bank
+            .init_balance(storage, &owner, init_funds)
+            .unwrap();
+    });
 
     // set up cw20 contract with some tokens
     let cw20_id = router.store_code(contract_cw20());

--- a/contracts/cw3-fixed-multisig/src/integration_tests.rs
+++ b/contracts/cw3-fixed-multisig/src/integration_tests.rs
@@ -7,10 +7,10 @@ use cw0::Duration;
 use cw20::{BalanceResponse, MinterResponse};
 use cw20_base::msg::QueryMsg;
 use cw3::Vote;
-use cw_multi_test::{App, AppBuilder, Contract, ContractWrapper, Executor};
+use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 
 fn mock_app() -> App {
-    AppBuilder::new().build()
+    App::default()
 }
 
 pub fn contract_cw3_fixed_multisig() -> Box<dyn Contract<Empty>> {

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -4,9 +4,8 @@ use std::marker::PhantomData;
 use anyhow::Result as AnyResult;
 use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
 use cosmwasm_std::{
-    from_slice, to_vec, Addr, Api, Binary, BlockInfo, ContractResult,
-    CustomQuery, Empty, Querier, QuerierResult, QuerierWrapper, QueryRequest, Storage, SystemError,
-    SystemResult,
+    from_slice, to_vec, Addr, Api, Binary, BlockInfo, ContractResult, CustomQuery, Empty, Querier,
+    QuerierResult, QuerierWrapper, QueryRequest, Storage, SystemError, SystemResult,
 };
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
@@ -536,7 +535,7 @@ where
         match msg {
             CosmosMsg::Wasm(msg) => self.wasm.execute(api, storage, self, block, sender, msg),
             CosmosMsg::Bank(msg) => self.bank.execute(api, storage, self, block, sender, msg),
-            CosmosMsg::Custom(msg) => self.custom.execute(api, storage, block, sender, msg),
+            CosmosMsg::Custom(msg) => self.custom.execute(api, storage, self, block, sender, msg),
             _ => unimplemented!(),
         }
     }
@@ -555,7 +554,7 @@ where
         match request {
             QueryRequest::Wasm(req) => self.wasm.query(api, storage, &querier, block, req),
             QueryRequest::Bank(req) => self.bank.query(api, storage, &querier, block, req),
-            QueryRequest::Custom(req) => self.custom.query(api, storage, block, req),
+            QueryRequest::Custom(req) => self.custom.query(api, storage, &querier, block, req),
             _ => unimplemented!(),
         }
     }

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -388,6 +388,62 @@ impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT>
         }
     }
 
+    /// Overwrites default bank interface
+    pub fn with_staking<NewStaking: Staking>(
+        self,
+        staking: NewStaking,
+    ) -> AppBuilder<BankT, ApiT, StorageT, CustomT, WasmT, NewStaking, DistrT> {
+        let AppBuilder {
+            wasm,
+            api,
+            storage,
+            custom,
+            block,
+            bank,
+            distribution,
+            ..
+        } = self;
+
+        AppBuilder {
+            api,
+            block,
+            storage,
+            bank,
+            wasm,
+            custom,
+            staking,
+            distribution,
+        }
+    }
+
+    /// Overwrites default bank interface
+    pub fn with_distribution<NewDistribution: Distribution>(
+        self,
+        distribution: NewDistribution,
+    ) -> AppBuilder<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, NewDistribution> {
+        let AppBuilder {
+            wasm,
+            api,
+            storage,
+            custom,
+            block,
+            staking,
+            bank,
+            ..
+        } = self;
+
+        AppBuilder {
+            api,
+            block,
+            storage,
+            bank,
+            wasm,
+            custom,
+            staking,
+            distribution,
+        }
+    }
+
     /// Overwrites default initial block
     pub fn with_block(mut self, block: BlockInfo) -> Self {
         self.block = block;

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -576,11 +576,14 @@ where
 }
 
 pub struct Router<Bank, Custom, Wasm, Staking, Distr> {
+    // this can remain crate-only as all special functions are wired up to app currently
+    // we need to figure out another format for wasm, as some like sudo need to be called after init
     pub(crate) wasm: Wasm,
+    // these must be pub so we can initialize them (super user) on build
     pub bank: Bank,
     pub custom: Custom,
-    pub(crate) staking: Staking,
-    pub(crate) distribution: Distr,
+    pub staking: Staking,
+    pub distribution: Distr,
 }
 
 impl<BankT, CustomT, WasmT, StakingT, DistrT> Router<BankT, CustomT, WasmT, StakingT, DistrT>

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -17,6 +17,8 @@ const BALANCES: Map<&Addr, NativeBalance> = Map::new("balances");
 
 pub const NAMESPACE_BANK: &[u8] = b"bank";
 
+pub trait Bank: Module<ExecT = BankMsg, QueryT = BankQuery> {}
+
 #[derive(Default)]
 pub struct BankKeeper {}
 
@@ -95,6 +97,8 @@ fn coins_to_string(coins: &[Coin]) -> String {
         .map(|c| format!("{}{}", c.amount, c.denom))
         .join(",")
 }
+
+impl Bank for BankKeeper {}
 
 impl Module for BankKeeper {
     type ExecT = BankMsg;

--- a/packages/multi-test/src/custom_handler.rs
+++ b/packages/multi-test/src/custom_handler.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Storage};
+use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Querier, Storage};
 
 use anyhow::Result as AnyResult;
 use derivative::Derivative;
@@ -7,6 +7,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::rc::Rc;
 
+use crate::app::CosmosRouter;
 use crate::AppResponse;
 
 /// Custom message handler trait. Implementor of this trait is mocking environment behavior on
@@ -22,6 +23,7 @@ pub trait CustomHandler {
         &self,
         api: &dyn Api,
         storage: &mut dyn Storage,
+        router: &dyn CosmosRouter<ExecC = Self::ExecC, QueryC = Self::QueryC>,
         block: &BlockInfo,
         sender: Addr,
         msg: Self::ExecC,
@@ -31,6 +33,7 @@ pub trait CustomHandler {
         &self,
         api: &dyn Api,
         storage: &dyn Storage,
+        querier: &dyn Querier,
         block: &BlockInfo,
         msg: Self::QueryC,
     ) -> AnyResult<Binary>;
@@ -64,6 +67,7 @@ where
         &self,
         _api: &dyn Api,
         _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = Self::ExecC, QueryC = Self::QueryC>,
         _block: &BlockInfo,
         sender: Addr,
         msg: Self::ExecC,
@@ -75,6 +79,7 @@ where
         &self,
         _api: &dyn Api,
         _storage: &dyn Storage,
+        _querier: &dyn Querier,
         _block: &BlockInfo,
         msg: Self::QueryC,
     ) -> AnyResult<Binary> {
@@ -129,6 +134,7 @@ impl<Exec, Query> CustomHandler for CachingCustomHandler<Exec, Query> {
         &self,
         _api: &dyn Api,
         _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = Self::ExecC, QueryC = Self::QueryC>,
         _block: &BlockInfo,
         _sender: Addr,
         msg: Exec,
@@ -141,6 +147,7 @@ impl<Exec, Query> CustomHandler for CachingCustomHandler<Exec, Query> {
         &self,
         _api: &dyn Api,
         _storage: &dyn Storage,
+        _querier: &dyn Querier,
         _block: &BlockInfo,
         msg: Query,
     ) -> AnyResult<Binary> {

--- a/packages/multi-test/src/custom_handler.rs
+++ b/packages/multi-test/src/custom_handler.rs
@@ -3,89 +3,11 @@ use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Querier, Storage};
 use anyhow::Result as AnyResult;
 use derivative::Derivative;
 use std::cell::{Ref, RefCell};
-use std::marker::PhantomData;
 use std::ops::Deref;
 use std::rc::Rc;
 
 use crate::app::CosmosRouter;
-use crate::AppResponse;
-
-/// Custom message handler trait. Implementor of this trait is mocking environment behavior on
-/// given custom message.
-pub trait CustomHandler {
-    /// Custom exec message for this handler
-    type ExecC;
-
-    /// Custom query message for this handler
-    type QueryC;
-
-    fn execute(
-        &self,
-        api: &dyn Api,
-        storage: &mut dyn Storage,
-        router: &dyn CosmosRouter<ExecC = Self::ExecC, QueryC = Self::QueryC>,
-        block: &BlockInfo,
-        sender: Addr,
-        msg: Self::ExecC,
-    ) -> AnyResult<AppResponse>;
-
-    fn query(
-        &self,
-        api: &dyn Api,
-        storage: &dyn Storage,
-        querier: &dyn Querier,
-        block: &BlockInfo,
-        msg: Self::QueryC,
-    ) -> AnyResult<Binary>;
-}
-
-/// Custom handler implementation panicking on each call. Assuming, that unless specific behavior
-/// is implemented, custom messages should not be send.
-pub struct PanickingCustomHandler<ExecC, QueryC>(PhantomData<ExecC>, PhantomData<QueryC>);
-
-impl<Exec, Query> PanickingCustomHandler<Exec, Query> {
-    pub fn new() -> Self {
-        PanickingCustomHandler(PhantomData, PhantomData)
-    }
-}
-
-impl<Exec, Query> Default for PanickingCustomHandler<Exec, Query> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<Exec, Query> CustomHandler for PanickingCustomHandler<Exec, Query>
-where
-    Exec: std::fmt::Debug,
-    Query: std::fmt::Debug,
-{
-    type ExecC = Exec;
-    type QueryC = Query;
-
-    fn execute(
-        &self,
-        _api: &dyn Api,
-        _storage: &mut dyn Storage,
-        _router: &dyn CosmosRouter<ExecC = Self::ExecC, QueryC = Self::QueryC>,
-        _block: &BlockInfo,
-        sender: Addr,
-        msg: Self::ExecC,
-    ) -> AnyResult<AppResponse> {
-        panic!("Unexpected custom exec msg {:?} from {:?}", msg, sender)
-    }
-
-    fn query(
-        &self,
-        _api: &dyn Api,
-        _storage: &dyn Storage,
-        _querier: &dyn Querier,
-        _block: &BlockInfo,
-        msg: Self::QueryC,
-    ) -> AnyResult<Binary> {
-        panic!("Unexpected custom query {:?}", msg)
-    }
-}
+use crate::{AppResponse, Module};
 
 /// Internal state of `CachingCustomHandler` wrapping internal mutability so it is not exposed to
 /// user. Those have to be shared internal state, as after mock is passed to app it is not
@@ -126,18 +48,20 @@ impl<ExecC, QueryC> CachingCustomHandler<ExecC, QueryC> {
     }
 }
 
-impl<Exec, Query> CustomHandler for CachingCustomHandler<Exec, Query> {
-    type ExecC = Exec;
-    type QueryC = Query;
+impl<Exec, Query> Module for CachingCustomHandler<Exec, Query> {
+    type ExecT = Exec;
+    type QueryT = Query;
 
-    fn execute(
+    // TODO: how to assert
+    // where ExecC: Exec, QueryC: Query
+    fn execute<ExecC, QueryC>(
         &self,
         _api: &dyn Api,
         _storage: &mut dyn Storage,
-        _router: &dyn CosmosRouter<ExecC = Self::ExecC, QueryC = Self::QueryC>,
+        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
         _block: &BlockInfo,
         _sender: Addr,
-        msg: Exec,
+        msg: Self::ExecT,
     ) -> AnyResult<AppResponse> {
         self.state.execs.borrow_mut().push(msg);
         Ok(AppResponse::default())
@@ -149,9 +73,9 @@ impl<Exec, Query> CustomHandler for CachingCustomHandler<Exec, Query> {
         _storage: &dyn Storage,
         _querier: &dyn Querier,
         _block: &BlockInfo,
-        msg: Query,
+        request: Self::QueryT,
     ) -> AnyResult<Binary> {
-        self.state.queries.borrow_mut().push(msg);
+        self.state.queries.borrow_mut().push(request);
         Ok(Binary::default())
     }
 }

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -21,7 +21,6 @@ mod wasm;
 pub use crate::app::{custom_app, next_block, App, AppBuilder, BasicApp, Router};
 pub use crate::bank::{Bank, BankKeeper};
 pub use crate::contracts::{Contract, ContractWrapper};
-pub use crate::custom_handler::CustomHandler;
 pub use crate::executor::{AppResponse, Executor};
 pub use crate::module::Module;
 pub use crate::wasm::{parse_contract_addr, Wasm, WasmKeeper};

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -12,6 +12,7 @@ mod contracts;
 pub mod custom_handler;
 pub mod error;
 mod executor;
+mod module;
 mod test_helpers;
 mod transactions;
 mod untyped_msg;

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -19,7 +19,7 @@ mod untyped_msg;
 mod wasm;
 
 pub use crate::app::{custom_app, next_block, App, AppBuilder, BasicApp, Router};
-pub use crate::bank::BankKeeper;
+pub use crate::bank::{Bank, BankKeeper};
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::custom_handler::CustomHandler;
 pub use crate::executor::{AppResponse, Executor};

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -19,8 +19,9 @@ mod untyped_msg;
 mod wasm;
 
 pub use crate::app::{custom_app, next_block, App, AppBuilder, BasicApp, Router};
-pub use crate::bank::{Bank, BankKeeper};
+pub use crate::bank::BankKeeper;
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::custom_handler::CustomHandler;
 pub use crate::executor::{AppResponse, Executor};
+pub use crate::module::Module;
 pub use crate::wasm::{parse_contract_addr, Wasm, WasmKeeper};

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -13,6 +13,7 @@ pub mod custom_handler;
 pub mod error;
 mod executor;
 mod module;
+mod staking;
 mod test_helpers;
 mod transactions;
 mod untyped_msg;

--- a/packages/multi-test/src/module.rs
+++ b/packages/multi-test/src/module.rs
@@ -1,0 +1,71 @@
+use std::marker::PhantomData;
+
+use anyhow::Result as AnyResult;
+use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Querier, Storage};
+
+use crate::app::CosmosRouter;
+use crate::AppResponse;
+
+pub trait Module<ExecT, QueryT> {
+    fn execute<ExecC, QueryC>(
+        &self,
+        api: &dyn Api,
+        storage: &mut dyn Storage,
+        router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        block: &BlockInfo,
+        sender: Addr,
+        msg: ExecT,
+    ) -> AnyResult<AppResponse>;
+
+    fn query(
+        &self,
+        api: &dyn Api,
+        storage: &dyn Storage,
+        querier: &dyn Querier,
+        block: &BlockInfo,
+        request: QueryT,
+    ) -> AnyResult<Binary>;
+}
+
+pub struct PanickingModule<ExecT, QueryT>(PhantomData<(ExecT, QueryT)>);
+
+impl<Exec, Query> PanickingModule<Exec, Query> {
+    pub fn new() -> Self {
+        PanickingModule(PhantomData)
+    }
+}
+
+impl<Exec, Query> Default for PanickingModule<Exec, Query> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<ExecT, QueryT> Module<ExecT, QueryT> for PanickingModule<ExecT, QueryT>
+where
+    ExecT: std::fmt::Debug,
+    QueryT: std::fmt::Debug,
+{
+    fn execute<ExecC, QueryC>(
+        &self,
+        _api: &dyn Api,
+        _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &BlockInfo,
+        sender: Addr,
+        msg: ExecT,
+    ) -> AnyResult<AppResponse> {
+        panic!("Unexpected exec msg {:?} from {:?}", msg, sender)
+    }
+
+    fn query(
+        &self,
+        _api: &dyn Api,
+        _storage: &dyn Storage,
+        _querier: &dyn Querier,
+        _block: &BlockInfo,
+        request: QueryT,
+    ) -> AnyResult<Binary> {
+        panic!("Unexpected custom query {:?}", request)
+    }
+}

--- a/packages/multi-test/src/module.rs
+++ b/packages/multi-test/src/module.rs
@@ -6,7 +6,10 @@ use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Querier, Storage};
 use crate::app::CosmosRouter;
 use crate::AppResponse;
 
-pub trait Module<ExecT, QueryT> {
+pub trait Module {
+    type ExecT;
+    type QueryT;
+
     fn execute<ExecC, QueryC>(
         &self,
         api: &dyn Api,
@@ -14,7 +17,7 @@ pub trait Module<ExecT, QueryT> {
         router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
         block: &BlockInfo,
         sender: Addr,
-        msg: ExecT,
+        msg: Self::ExecT,
     ) -> AnyResult<AppResponse>;
 
     fn query(
@@ -23,7 +26,7 @@ pub trait Module<ExecT, QueryT> {
         storage: &dyn Storage,
         querier: &dyn Querier,
         block: &BlockInfo,
-        request: QueryT,
+        request: Self::QueryT,
     ) -> AnyResult<Binary>;
 }
 
@@ -41,11 +44,14 @@ impl<Exec, Query> Default for PanickingModule<Exec, Query> {
     }
 }
 
-impl<ExecT, QueryT> Module<ExecT, QueryT> for PanickingModule<ExecT, QueryT>
+impl<Exec, Query> Module for PanickingModule<Exec, Query>
 where
-    ExecT: std::fmt::Debug,
-    QueryT: std::fmt::Debug,
+    Exec: std::fmt::Debug,
+    Query: std::fmt::Debug,
 {
+    type ExecT = Exec;
+    type QueryT = Query;
+
     fn execute<ExecC, QueryC>(
         &self,
         _api: &dyn Api,
@@ -53,7 +59,7 @@ where
         _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
         _block: &BlockInfo,
         sender: Addr,
-        msg: ExecT,
+        msg: Self::ExecT,
     ) -> AnyResult<AppResponse> {
         panic!("Unexpected exec msg {:?} from {:?}", msg, sender)
     }
@@ -64,7 +70,7 @@ where
         _storage: &dyn Storage,
         _querier: &dyn Querier,
         _block: &BlockInfo,
-        request: QueryT,
+        request: Self::QueryT,
     ) -> AnyResult<Binary> {
         panic!("Unexpected custom query {:?}", request)
     }

--- a/packages/multi-test/src/module.rs
+++ b/packages/multi-test/src/module.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use anyhow::Result as AnyResult;
+use anyhow::{bail, Result as AnyResult};
 use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Querier, Storage};
 
 use crate::app::CosmosRouter;
@@ -30,21 +30,21 @@ pub trait Module {
     ) -> AnyResult<Binary>;
 }
 
-pub struct PanickingModule<ExecT, QueryT>(PhantomData<(ExecT, QueryT)>);
+pub struct FailingModule<ExecT, QueryT>(PhantomData<(ExecT, QueryT)>);
 
-impl<Exec, Query> PanickingModule<Exec, Query> {
+impl<Exec, Query> FailingModule<Exec, Query> {
     pub fn new() -> Self {
-        PanickingModule(PhantomData)
+        FailingModule(PhantomData)
     }
 }
 
-impl<Exec, Query> Default for PanickingModule<Exec, Query> {
+impl<Exec, Query> Default for FailingModule<Exec, Query> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Exec, Query> Module for PanickingModule<Exec, Query>
+impl<Exec, Query> Module for FailingModule<Exec, Query>
 where
     Exec: std::fmt::Debug,
     Query: std::fmt::Debug,
@@ -61,7 +61,7 @@ where
         sender: Addr,
         msg: Self::ExecT,
     ) -> AnyResult<AppResponse> {
-        panic!("Unexpected exec msg {:?} from {:?}", msg, sender)
+        bail!("Unexpected exec msg {:?} from {:?}", msg, sender)
     }
 
     fn query(
@@ -72,6 +72,6 @@ where
         _block: &BlockInfo,
         request: Self::QueryT,
     ) -> AnyResult<Binary> {
-        panic!("Unexpected custom query {:?}", request)
+        bail!("Unexpected custom query {:?}", request)
     }
 }

--- a/packages/multi-test/src/staking.rs
+++ b/packages/multi-test/src/staking.rs
@@ -1,0 +1,15 @@
+use crate::module::FailingModule;
+use crate::Module;
+use cosmwasm_std::{DistributionMsg, Empty, StakingMsg, StakingQuery};
+
+pub trait Staking: Module<ExecT = StakingMsg, QueryT = StakingQuery> {}
+
+pub type FailingStaking = FailingModule<StakingMsg, StakingQuery>;
+
+impl Staking for FailingStaking {}
+
+pub trait Distribution: Module<ExecT = DistributionMsg, QueryT = Empty> {}
+
+pub type FailingDistribution = FailingModule<DistributionMsg, Empty>;
+
+impl Distribution for FailingDistribution {}

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -856,23 +856,22 @@ pub fn parse_contract_addr(data: &Option<Binary>) -> AnyResult<Addr> {
 
 #[cfg(test)]
 mod test {
-    use crate::custom_handler::PanickingCustomHandler;
     use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{coin, from_slice, to_vec, BankMsg, Coin, CosmosMsg, Empty, StdError};
 
     use crate::app::Router;
+    use crate::bank::BankKeeper;
+    use crate::module::FailingModule;
     use crate::test_helpers::contracts::{error, payout};
     use crate::transactions::StorageTransaction;
-    use crate::BankKeeper;
 
     use super::*;
 
-    fn mock_router(
-    ) -> Router<BankKeeper, PanickingCustomHandler<Empty, Empty>, WasmKeeper<Empty, Empty>> {
+    fn mock_router() -> Router<BankKeeper, FailingModule<Empty, Empty>, WasmKeeper<Empty, Empty>> {
         Router {
             wasm: WasmKeeper::new(),
             bank: BankKeeper::new(),
-            custom: PanickingCustomHandler::new(),
+            custom: FailingModule::new(),
         }
     }
 

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -866,12 +866,21 @@ mod test {
     use crate::transactions::StorageTransaction;
 
     use super::*;
+    use crate::staking::{FailingDistribution, FailingStaking};
 
-    fn mock_router() -> Router<BankKeeper, FailingModule<Empty, Empty>, WasmKeeper<Empty, Empty>> {
+    fn mock_router() -> Router<
+        BankKeeper,
+        FailingModule<Empty, Empty>,
+        WasmKeeper<Empty, Empty>,
+        FailingStaking,
+        FailingDistribution,
+    > {
         Router {
             wasm: WasmKeeper::new(),
             bank: BankKeeper::new(),
             custom: FailingModule::new(),
+            staking: FailingStaking::new(),
+            distribution: FailingDistribution::new(),
         }
     }
 


### PR DESCRIPTION
Closes #387 

Start work on generic modules.

- [x] Define a `Module` type generic of any Msg, Query
- [x] Implement this for Bank
- [x] Do all initialisation on App::build()
- [x] Simplify Apis, eg. using Bank = Module<BankMsg, BankQuery> alias
- [x] Contract tests pass
- [x] Use this for CustomHandler
- [x] Add Panicking implementations for Staking, Distribution

TODO in a future PR:

- Use Module for WasmHandler (this is a bit too central and too many special entry-points - we need to expose Sudo somehow)
- Clean up APIs some more (with usage)