### PR TITLE
Unintuitive bound handling on multiindex - failing test

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -697,4 +697,53 @@ mod test {
         assert_eq!(datas[0], marias[0].1);
         assert_eq!(datas[1], marias[1].1);
     }
+
+    mod inclusive_bound {
+        use super::*;
+        use crate::U64Key;
+
+        struct Indexes<'a> {
+            secondary: MultiIndex<'a, (U64Key, Vec<u8>), u64>,
+        }
+
+        impl<'a> IndexList<u64> for Indexes<'a> {
+            fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<u64>> + '_> {
+                let v: Vec<&dyn Index<u64>> = vec![&self.secondary];
+                Box::new(v.into_iter())
+            }
+        }
+
+        #[test]
+        #[cfg(feature = "iterator")]
+        fn composite_key_failure() {
+            let indexes = Indexes {
+                secondary: MultiIndex::new(
+                    |secondary, k| (U64Key::new(*secondary), k),
+                    "test_map",
+                    "test_map__secondary",
+                ),
+            };
+            let map = IndexedMap::<&str, u64, Indexes>::new("test_map", indexes);
+            let mut store = MockStorage::new();
+
+            map.save(&mut store, "one", &1).unwrap();
+
+            let items: Vec<_> = map
+                .idx
+                .secondary
+                .range(
+                    &store,
+                    None,
+                    Some(Bound::inclusive((U64Key::new(1), vec![]).joined_key())),
+                    Order::Ascending,
+                )
+                .collect::<Result<_, _>>()
+                .unwrap();
+
+            // Strip the index from values (for simpler comparison)
+            let items: Vec<_> = items.into_iter().map(|(_, v)| v).collect();
+
+            assert_eq!(items, vec![1]);
+        }
+    }
 }


### PR DESCRIPTION
Prove test, the simplest I managed to provide.

The test scenario logic:

Have a multi index map indexed with some arbitrary index (`&str` in the example), and mapped to some value (`u64` in the test). The map can be however indexed by value itself - the secondary multiindex is created for this case. On range call I want to take all items with secondary items up to particular value, but it won't work - as it requires to provide second part of key, which is also a part of a bound. In practice if I call range this way, I don't know the "upper bound" of the primary index (it would be basically the highest index in the map), and it makes `Bound::inclusive` unuseable with many multi-index cases. Obviously in this very test I can fix it by changing `vec![]` to `b"one".to_owned()`, or even `b"z".to_owned()`, but it is a trap, as there is no guarantee in real world, that there is no item of index `"Zumba"` which should be inlcuded in range.

Currently the only workaround I see is never use `Bound::inclusive` for multi-index, and always use `Bound::exclusive(key+1)` but it is completely unintuitive, and even possibly not easy for more complex multi-keys.