### PR TITLE
Range with no prefix support

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::indexes::Index;
-use crate::keys::{EmptyPrefix, Prefixer, PrimaryKey};
+use crate::keys::{Prefixer, PrimaryKey};
 use crate::map::Map;
 use crate::prefix::{Bound, Prefix};
 use crate::Path;
@@ -138,8 +138,8 @@ where
     }
 
     // use no_prefix to scan -> range
-    fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
-        Prefix::new(self.pk_namespace, &p.prefix())
+    fn no_prefix(&self) -> Prefix<T> {
+        Prefix::new(self.pk_namespace, &[])
     }
 }
 
@@ -149,7 +149,6 @@ where
     K: PrimaryKey<'a>,
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
-    K::NoPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -163,8 +162,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix(K::NoPrefix::new())
-            .range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -136,6 +136,11 @@ where
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
+
+    // use no_prefix to scan -> range
+    fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
 }
 
 // short-cut for simple keys, rather than .prefix(()).range(...)
@@ -144,7 +149,7 @@ where
     K: PrimaryKey<'a>,
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
-    K::SubPrefix: EmptyPrefix,
+    K::NoPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -158,7 +163,7 @@ where
     where
         T: 'c,
     {
-        self.sub_prefix(K::SubPrefix::new())
+        self.no_prefix(K::NoPrefix::new())
             .range(store, min, max, order)
     }
 }

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -160,6 +160,11 @@ where
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
+
+    // use no_prefix to scan -> range
+    pub fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
 }
 
 // short-cut for simple keys, rather than .prefix(()).range(...)
@@ -168,7 +173,7 @@ where
     K: PrimaryKey<'a> + Prefixer<'a>,
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
-    K::SubPrefix: EmptyPrefix,
+    K::NoPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -182,7 +187,7 @@ where
     where
         T: 'c,
     {
-        self.sub_prefix(K::SubPrefix::new())
+        self.no_prefix(K::NoPrefix::new())
             .range(store, min, max, order)
     }
 }

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::keys::{EmptyPrefix, Prefixer, PrimaryKey};
+use crate::keys::{Prefixer, PrimaryKey};
 use crate::prefix::{Bound, Prefix};
 use crate::snapshot::SnapshotMap;
 use crate::{IndexList, Path, Strategy};
@@ -162,8 +162,8 @@ where
     }
 
     // use no_prefix to scan -> range
-    pub fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
-        Prefix::new(self.pk_namespace, &p.prefix())
+    pub fn no_prefix(&self) -> Prefix<T> {
+        Prefix::new(self.pk_namespace, &[])
     }
 }
 
@@ -173,7 +173,6 @@ where
     K: PrimaryKey<'a> + Prefixer<'a>,
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
-    K::NoPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -187,8 +186,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix(K::NoPrefix::new())
-            .range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{from_slice, Binary, Order, Pair, StdError, StdResult, Storage};
 
 use crate::helpers::namespaces_with_key;
-use crate::keys::EmptyPrefix;
 use crate::map::Map;
 use crate::{Bound, Prefix, Prefixer, PrimaryKey, U32Key};
 
@@ -138,10 +137,10 @@ where
         )
     }
 
-    fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
+    fn no_prefix(&self) -> Prefix<T> {
         Prefix::with_deserialization_function(
             self.idx_namespace,
-            &p.prefix(),
+            &[],
             self.pk_namespace,
             deserialize_multi_kv,
         )
@@ -177,7 +176,6 @@ impl<'a, K, T> MultiIndex<'a, K, T>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a>,
-    K::NoPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -191,8 +189,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix(K::NoPrefix::new())
-            .range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -202,8 +199,7 @@ where
         max: Option<Bound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
-        self.no_prefix(K::NoPrefix::new())
-            .keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 }
 
@@ -288,8 +284,8 @@ where
         })
     }
 
-    fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
-        Prefix::with_deserialization_function(self.idx_namespace, &p.prefix(), &[], |_, _, kv| {
+    fn no_prefix(&self) -> Prefix<T> {
+        Prefix::with_deserialization_function(self.idx_namespace, &[], &[], |_, _, kv| {
             deserialize_unique_kv(kv)
         })
     }
@@ -309,7 +305,6 @@ impl<'a, K, T> UniqueIndex<'a, K, T>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a>,
-    K::NoPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -323,8 +318,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix(K::NoPrefix::new())
-            .range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -334,7 +328,6 @@ where
         max: Option<Bound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
-        self.no_prefix(K::NoPrefix::new())
-            .keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -119,15 +119,6 @@ impl<'a> Prefixer<'a> for &'a str {
     }
 }
 
-// this is a marker for the Map.range() helper, so we can detect () in Generic bounds
-pub trait EmptyPrefix {
-    fn new() -> Self;
-}
-
-impl EmptyPrefix for () {
-    fn new() {}
-}
-
 impl<'a> PrimaryKey<'a> for Vec<u8> {
     type Prefix = ();
     type SubPrefix = ();

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -8,6 +8,10 @@ use crate::Endian;
 pub trait PrimaryKey<'a>: Clone {
     type Prefix: Prefixer<'a>;
     type SubPrefix: Prefixer<'a>;
+    // FIXME: Use this after 'error[E0658]: associated type defaults are unstable' is resolved.
+    // See issue #29661 <https://github.com/rust-lang/rust/issues/29661>
+    // type NoPrefix: Prefixer<'a> = ();
+    type NoPrefix: Prefixer<'a>;
 
     /// returns a slice of key steps, which can be optionally combined
     fn key(&self) -> Vec<&[u8]>;
@@ -23,6 +27,7 @@ pub trait PrimaryKey<'a>: Clone {
 impl<'a> PrimaryKey<'a> for () {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![]
@@ -32,6 +37,7 @@ impl<'a> PrimaryKey<'a> for () {
 impl<'a> PrimaryKey<'a> for &'a [u8] {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -43,6 +49,7 @@ impl<'a> PrimaryKey<'a> for &'a [u8] {
 impl<'a> PrimaryKey<'a> for &'a str {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -54,6 +61,7 @@ impl<'a> PrimaryKey<'a> for &'a str {
 impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a>> PrimaryKey<'a> for (T, U) {
     type Prefix = T;
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         let mut keys = self.0.key();
@@ -68,6 +76,7 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a> + Prefixer<'a>, V: 
 {
     type Prefix = (T, U);
     type SubPrefix = T;
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         let mut keys = self.0.key();
@@ -131,6 +140,7 @@ impl EmptyPrefix for () {
 impl<'a> PrimaryKey<'a> for Vec<u8> {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![&self]
@@ -146,6 +156,7 @@ impl<'a> Prefixer<'a> for Vec<u8> {
 impl<'a> PrimaryKey<'a> for String {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![self.as_bytes()]
@@ -162,6 +173,7 @@ impl<'a> Prefixer<'a> for String {
 impl<'a> PrimaryKey<'a> for &'a Addr {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -179,6 +191,7 @@ impl<'a> Prefixer<'a> for &'a Addr {
 impl<'a> PrimaryKey<'a> for Addr {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -196,6 +209,7 @@ impl<'a> Prefixer<'a> for Addr {
 impl<'a, T: Endian + Clone> PrimaryKey<'a> for IntKey<T> {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         self.wrapped.key()

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -8,10 +8,6 @@ use crate::Endian;
 pub trait PrimaryKey<'a>: Clone {
     type Prefix: Prefixer<'a>;
     type SubPrefix: Prefixer<'a>;
-    // FIXME: Use this after 'error[E0658]: associated type defaults are unstable' is resolved.
-    // See issue #29661 <https://github.com/rust-lang/rust/issues/29661>
-    // type NoPrefix: Prefixer<'a> = ();
-    type NoPrefix: Prefixer<'a>;
 
     /// returns a slice of key steps, which can be optionally combined
     fn key(&self) -> Vec<&[u8]>;
@@ -27,7 +23,6 @@ pub trait PrimaryKey<'a>: Clone {
 impl<'a> PrimaryKey<'a> for () {
     type Prefix = ();
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![]
@@ -37,7 +32,6 @@ impl<'a> PrimaryKey<'a> for () {
 impl<'a> PrimaryKey<'a> for &'a [u8] {
     type Prefix = ();
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -49,7 +43,6 @@ impl<'a> PrimaryKey<'a> for &'a [u8] {
 impl<'a> PrimaryKey<'a> for &'a str {
     type Prefix = ();
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -61,7 +54,6 @@ impl<'a> PrimaryKey<'a> for &'a str {
 impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a>> PrimaryKey<'a> for (T, U) {
     type Prefix = T;
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         let mut keys = self.0.key();
@@ -76,7 +68,6 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a> + Prefixer<'a>, V: 
 {
     type Prefix = (T, U);
     type SubPrefix = T;
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         let mut keys = self.0.key();
@@ -140,7 +131,6 @@ impl EmptyPrefix for () {
 impl<'a> PrimaryKey<'a> for Vec<u8> {
     type Prefix = ();
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![&self]
@@ -156,7 +146,6 @@ impl<'a> Prefixer<'a> for Vec<u8> {
 impl<'a> PrimaryKey<'a> for String {
     type Prefix = ();
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![self.as_bytes()]
@@ -173,7 +162,6 @@ impl<'a> Prefixer<'a> for String {
 impl<'a> PrimaryKey<'a> for &'a Addr {
     type Prefix = ();
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -191,7 +179,6 @@ impl<'a> Prefixer<'a> for &'a Addr {
 impl<'a> PrimaryKey<'a> for Addr {
     type Prefix = ();
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -209,7 +196,6 @@ impl<'a> Prefixer<'a> for Addr {
 impl<'a, T: Endian + Clone> PrimaryKey<'a> for IntKey<T> {
     type Prefix = ();
     type SubPrefix = ();
-    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         self.wrapped.key()

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -3,9 +3,9 @@ use serde::Serialize;
 use std::marker::PhantomData;
 
 use crate::helpers::query_raw;
-use crate::keys::PrimaryKey;
 #[cfg(feature = "iterator")]
-use crate::keys::{EmptyPrefix, Prefixer};
+use crate::keys::Prefixer;
+use crate::keys::PrimaryKey;
 use crate::path::Path;
 #[cfg(feature = "iterator")]
 use crate::prefix::{Bound, Prefix};
@@ -49,8 +49,8 @@ where
     }
 
     #[cfg(feature = "iterator")]
-    fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
-        Prefix::new(self.namespace, &p.prefix())
+    pub(crate) fn no_prefix(&self) -> Prefix<T> {
+        Prefix::new(self.namespace, &[])
     }
 
     pub fn save(&self, store: &mut dyn Storage, k: K, data: &T) -> StdResult<()> {
@@ -114,7 +114,6 @@ impl<'a, K, T> Map<'a, K, T>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
-    K::NoPrefix: EmptyPrefix,
 {
     pub fn range<'c>(
         &self,
@@ -126,8 +125,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix(K::NoPrefix::new())
-            .range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -140,8 +138,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix(K::NoPrefix::new())
-            .keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use cosmwasm_std::{StdError, StdResult, Storage};
 
-use crate::keys::{EmptyPrefix, PrimaryKey};
+use crate::keys::PrimaryKey;
 use crate::map::Map;
 use crate::path::Path;
 use crate::prefix::Prefix;
@@ -64,6 +64,10 @@ where
 
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
         self.primary.sub_prefix(p)
+    }
+
+    fn no_prefix(&self) -> Prefix<T> {
+        self.primary.no_prefix()
     }
 
     /// load old value and store changelog
@@ -155,7 +159,6 @@ impl<'a, K, T> SnapshotMap<'a, K, T>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a>,
-    K::SubPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -169,8 +172,7 @@ where
     where
         T: 'c,
     {
-        self.sub_prefix(K::SubPrefix::new())
-            .range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 }
 


### PR DESCRIPTION
~~Adds a `NoPrefix` associated type, to use for `range()` short-cuts in `Map` along with the `EmptyPrefix` marker.~~ Just force the empty prefix in `Map::range`.

~~This type was missing from the impl. Adding it basically allows the added test case, where we iterate over a triple key without a prefix.~~ Removed it altogether for simplicity.

Can be reviewed / merged independently of #432. Already integrated in #432 branch.