### PR TITLE
Use traits to remove repeating implementations

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -136,6 +136,11 @@ where
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
+
+    // use no_prefix to scan -> range
+    fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
 }
 
 // short-cut for simple keys, rather than .prefix(()).range(...)
@@ -144,7 +149,7 @@ where
     K: PrimaryKey<'a>,
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
-    K::SubPrefix: EmptyPrefix,
+    K::NoPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -158,7 +163,7 @@ where
     where
         T: 'c,
     {
-        self.sub_prefix(K::SubPrefix::new())
+        self.no_prefix(K::NoPrefix::new())
             .range(store, min, max, order)
     }
 }

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -160,6 +160,11 @@ where
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
+
+    // use no_prefix to scan -> range
+    pub fn no_prefix(&self, p: K::NoPrefix) -> Prefix<T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
 }
 
 // short-cut for simple keys, rather than .prefix(()).range(...)
@@ -168,7 +173,7 @@ where
     K: PrimaryKey<'a> + Prefixer<'a>,
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
-    K::SubPrefix: EmptyPrefix,
+    K::NoPrefix: EmptyPrefix,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -182,7 +187,7 @@ where
     where
         T: 'c,
     {
-        self.sub_prefix(K::SubPrefix::new())
+        self.no_prefix(K::NoPrefix::new())
             .range(store, min, max, order)
     }
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -8,6 +8,10 @@ use crate::Endian;
 pub trait PrimaryKey<'a>: Clone {
     type Prefix: Prefixer<'a>;
     type SubPrefix: Prefixer<'a>;
+    // FIXME: Use this after 'error[E0658]: associated type defaults are unstable' is resolved.
+    // See issue #29661 <https://github.com/rust-lang/rust/issues/29661>
+    // type NoPrefix: Prefixer<'a> = ();
+    type NoPrefix: Prefixer<'a>;
 
     /// returns a slice of key steps, which can be optionally combined
     fn key(&self) -> Vec<&[u8]>;
@@ -23,6 +27,7 @@ pub trait PrimaryKey<'a>: Clone {
 impl<'a> PrimaryKey<'a> for () {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![]
@@ -32,6 +37,7 @@ impl<'a> PrimaryKey<'a> for () {
 impl<'a> PrimaryKey<'a> for &'a [u8] {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -43,6 +49,7 @@ impl<'a> PrimaryKey<'a> for &'a [u8] {
 impl<'a> PrimaryKey<'a> for &'a str {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -54,6 +61,7 @@ impl<'a> PrimaryKey<'a> for &'a str {
 impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a>> PrimaryKey<'a> for (T, U) {
     type Prefix = T;
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         let mut keys = self.0.key();
@@ -68,6 +76,7 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a>, U: PrimaryKey<'a> + Prefixer<'a>, V: 
 {
     type Prefix = (T, U);
     type SubPrefix = T;
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         let mut keys = self.0.key();
@@ -131,6 +140,7 @@ impl EmptyPrefix for () {
 impl<'a> PrimaryKey<'a> for Vec<u8> {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![&self]
@@ -146,6 +156,7 @@ impl<'a> Prefixer<'a> for Vec<u8> {
 impl<'a> PrimaryKey<'a> for String {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         vec![self.as_bytes()]
@@ -162,6 +173,7 @@ impl<'a> Prefixer<'a> for String {
 impl<'a> PrimaryKey<'a> for &'a Addr {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -179,6 +191,7 @@ impl<'a> Prefixer<'a> for &'a Addr {
 impl<'a> PrimaryKey<'a> for Addr {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         // this is simple, we don't add more prefixes
@@ -196,6 +209,7 @@ impl<'a> Prefixer<'a> for Addr {
 impl<'a, T: Endian + Clone> PrimaryKey<'a> for IntKey<T> {
     type Prefix = ();
     type SubPrefix = ();
+    type NoPrefix = ();
 
     fn key(&self) -> Vec<&[u8]> {
         self.wrapped.key()

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 
 use crate::helpers::nested_namespaces_with_key;
 use crate::iter_helpers::{concat, deserialize_kv, trim};
+use crate::keys::Prefixer;
 use crate::Endian;
 
 /// Bound is used to defines the two ends of a range, more explicit than Option<u8>
@@ -43,6 +44,28 @@ impl Bound {
 }
 
 type DeserializeFn<T> = fn(&dyn Storage, &[u8], Pair) -> StdResult<Pair<T>>;
+
+pub trait PrefixT<'a, P: Prefixer<'a>, T: Serialize + DeserializeOwned> {
+    fn get_pk_namespace(&self) -> &[u8];
+
+    // use no_prefix to scan -> range
+    #[cfg(feature = "iterator")]
+    fn no_prefix(&self, p: P) -> Prefix<T> {
+        Prefix::new(self.get_pk_namespace(), &p.prefix())
+    }
+
+    // use sub_prefix to scan -> range
+    #[cfg(feature = "iterator")]
+    fn sub_prefix(&self, p: P) -> Prefix<T> {
+        Prefix::new(self.get_pk_namespace(), &p.prefix())
+    }
+
+    // use prefix to scan -> range
+    #[cfg(feature = "iterator")]
+    fn prefix(&self, p: P) -> Prefix<T> {
+        Prefix::new(self.get_pk_namespace(), &p.prefix())
+    }
+}
 
 #[derive(Clone)]
 pub struct Prefix<T>

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{StdError, StdResult, Storage};
 use crate::keys::{EmptyPrefix, PrimaryKey};
 use crate::map::Map;
 use crate::path::Path;
-use crate::prefix::Prefix;
+use crate::prefix::{Prefix, PrefixT};
 use crate::snapshot::Snapshot;
 use crate::{Bound, Prefixer, Strategy};
 

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -5,7 +5,7 @@ pub use item::SnapshotItem;
 #[cfg(feature = "iterator")]
 pub use map::SnapshotMap;
 
-use crate::{Bound, Map, Prefixer, PrimaryKey, U64Key};
+use crate::{prefix::PrefixT, Bound, Map, Prefixer, PrimaryKey, U64Key};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Implementation is still not finished, but proposition stands.
I'm fighting with some weird error during test compilation which I don't fully understand:
```
error[E0277]: the trait bound `&[u8; 5]: keys::Prefixer<'_>` is not satisfied
   --> packages/storage-plus/src/map.rs:374:21
    |
374 |             .prefix(b"owner")
    |                     ^^^^^^^^ the trait `keys::Prefixer<'_>` is not implemented for `&[u8; 5]`
    |
    = help: the following implementations were found:
              <&'a [u8] as keys::Prefixer<'a>>
```
(because it IS [implemented](https://github.com/CosmWasm/cw-plus/blob/main/packages/storage-plus/src/keys.rs#L92) - I think I messed something with lifetimes)
and since it's Sunday I don't have much patience to tackle it, so I'll pick it up tommorow.