### PR TITLE
Multitest module query

### DIFF
--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -497,7 +497,7 @@ where
     StakingT: Staking,
     DistrT: Distribution,
 {
-    fn init_modules<F, T>(&mut self, init_fn: F) -> T
+    pub fn init_modules<F, T>(&mut self, init_fn: F) -> T
     where
         F: FnOnce(
             &mut Router<BankT, CustomT, WasmT, StakingT, DistrT>,
@@ -516,8 +516,8 @@ where
     }
 }
 
-// TODO: these are temporary helper functions so we can fix the Wasm trait, but not break all calling
-// contracts yet.
+// Helper functions to call some custom WasmKeeper logic.
+// They show how we can easily add such calls to other custom keepers (CustomT, StakingT, etc)
 impl<BankT, ApiT, StorageT, CustomT, StakingT, DistrT>
     App<
         BankT,
@@ -545,7 +545,6 @@ where
     }
 
     /// This allows to get `ContractData` for specific contract
-    /// TODO: deprecate
     pub fn contract_data(&self, address: &Addr) -> AnyResult<ContractData> {
         self.read_module(|router, _, storage| router.wasm.load_contract(storage, address))
     }

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -503,6 +503,13 @@ where
     {
         init_fn(&self.router, &self.api, &mut self.storage);
     }
+
+    pub fn read_module<F, T>(&self, query_fn: F) -> T
+    where
+        F: FnOnce(&Router<BankT, CustomT, WasmT, StakingT, DistrT>, &dyn Api, &dyn Storage) -> T,
+    {
+        query_fn(&self.router, &self.api, &self.storage)
+    }
 }
 
 impl<BankT, ApiT, StorageT, CustomT, WasmT, StakingT, DistrT>
@@ -571,8 +578,9 @@ where
     }
 
     /// This allows to get `ContractData` for specific contract
+    /// TODO: deprecate
     pub fn contract_data(&self, address: &Addr) -> AnyResult<ContractData> {
-        self.router.wasm.contract_data(&self.storage, address)
+        self.read_module(|router, _, storage| router.wasm.contract_data(storage, address))
     }
 
     /// Runs arbitrary CosmosMsg in "sudo" mode.


### PR DESCRIPTION
Let's use `init_modules` and `read_module` to access data from trait implementations.

Limit Wasm trait and use those methods to do the custom wasm calls (contract_data and store_code). This demos that we should be able to do anything we need for custom keepers with only the public API.

I tried to have `Wasm: Module` but ended up with some annoying type conflicts, so pushing that to later. Not critical.
