### PR TITLE
Test storage-plus with iterator disabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1001,17 +1001,17 @@ jobs:
           keys:
             - cargocache-v2-storage-plus:1.53.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
-          name: Build library for native target
-          command: cargo build --locked
+          name: Build library for native target (no iterator)
+          command: cargo build --locked --no-default-features
       - run:
-          name: Run unit tests
-          command: cargo test --locked
+          name: Run unit tests (no iterator)
+          command: cargo test --locked --no-default-features
       - run:
           name: Build library for native target (with iterator)
-          command: cargo build --locked --features iterator
+          command: cargo build --locked
       - run:
           name: Run unit tests (with iterator)
-          command: cargo test --locked --features iterator
+          command: cargo test --locked
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -14,6 +14,6 @@ default = ["iterator"]
 iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "0.16.0", default-features = false }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -28,5 +28,4 @@ pub use path::Path;
 #[cfg(feature = "iterator")]
 pub use prefix::{range_with_prefix, Bound, Prefix};
 #[cfg(feature = "iterator")]
-pub use snapshot::SnapshotMap;
-pub use snapshot::{SnapshotItem, Strategy};
+pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -1,8 +1,8 @@
+#![cfg(feature = "iterator")]
 mod item;
 mod map;
 
 pub use item::SnapshotItem;
-#[cfg(feature = "iterator")]
 pub use map::SnapshotMap;
 
 use crate::{Bound, Map, Prefixer, PrimaryKey, U64Key};


### PR DESCRIPTION
Especially for storage-plus.

It seems some code fails already. It would be good to also make iterator optional for any other package that doesn't require it (I think that is most of the packages except multitest, but none of the contracts)