### PR TITLE
Prefix consolidation

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1,6 +1,3 @@
-// this module requires iterator to be useful at all
-#![cfg(feature = "iterator")]
-
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -126,17 +126,17 @@ where
     }
 
     // use prefix to scan -> range
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 
     // use sub_prefix to scan -> range
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 
     // use no_prefix to scan -> range
-    fn no_prefix(&self) -> Prefix<T> {
+    fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &[])
     }
 }

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1,3 +1,6 @@
+// this module requires iterator to be useful at all
+#![cfg(feature = "iterator")]
+
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -1,6 +1,3 @@
-// this module requires iterator to be useful at all
-#![cfg(feature = "iterator")]
-
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -171,17 +171,17 @@ where
     }
 
     // use prefix to scan -> range
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 
     // use sub_prefix to scan -> range
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 
     // use no_prefix to scan -> range
-    pub fn no_prefix(&self) -> Prefix<T> {
+    pub fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &[])
     }
 }

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -1,3 +1,6 @@
+// this module requires iterator to be useful at all
+#![cfg(feature = "iterator")]
+
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -1,6 +1,3 @@
-// this module requires iterator to be useful at all
-#![cfg(feature = "iterator")]
-
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -141,7 +141,7 @@ where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a>,
 {
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_function(
             self.idx_namespace,
             &p.prefix(),
@@ -150,7 +150,7 @@ where
         )
     }
 
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_function(
             self.idx_namespace,
             &p.prefix(),
@@ -159,7 +159,7 @@ where
         )
     }
 
-    fn no_prefix(&self) -> Prefix<T> {
+    fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_function(
             self.idx_namespace,
             &[],
@@ -332,19 +332,19 @@ where
         k.joined_key()
     }
 
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_function(self.idx_namespace, &p.prefix(), &[], |_, _, kv| {
             deserialize_unique_kv(kv)
         })
     }
 
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_function(self.idx_namespace, &p.prefix(), &[], |_, _, kv| {
             deserialize_unique_kv(kv)
         })
     }
 
-    fn no_prefix(&self) -> Prefix<T> {
+    fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_function(self.idx_namespace, &[], &[], |_, _, kv| {
             deserialize_unique_kv(kv)
         })

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -1,3 +1,6 @@
+// this module requires iterator to be useful at all
+#![cfg(feature = "iterator")]
+
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 

--- a/packages/storage-plus/src/iter_helpers.rs
+++ b/packages/storage-plus/src/iter_helpers.rs
@@ -7,6 +7,7 @@ use crate::de::Deserializable;
 use crate::helpers::encode_length;
 use crate::prefix::Pair2;
 
+#[allow(dead_code)]
 pub(crate) fn deserialize_v<T: DeserializeOwned>(kv: Pair) -> StdResult<Pair<T>> {
     let (k, v) = kv;
     let t = from_slice::<T>(&v)?;

--- a/packages/storage-plus/src/iter_helpers.rs
+++ b/packages/storage-plus/src/iter_helpers.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "iterator")]
+
 use serde::de::DeserializeOwned;
 
 use cosmwasm_std::Pair;

--- a/packages/storage-plus/src/iter_helpers.rs
+++ b/packages/storage-plus/src/iter_helpers.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "iterator")]
-
 use serde::de::DeserializeOwned;
 
 use cosmwasm_std::Pair;

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -13,11 +13,8 @@ mod prefix;
 mod snapshot;
 
 pub use endian::Endian;
-#[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};
-#[cfg(feature = "iterator")]
 pub use indexed_snapshot::IndexedSnapshotMap;
-#[cfg(feature = "iterator")]
 pub use indexes::{
     index_string, index_string_tuple, index_triple, index_tuple, Index, MultiIndex, UniqueIndex,
 };

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -24,6 +24,6 @@ pub use keys::{Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
-pub use prefix::{range_with_prefix, Bound, Prefix, Prefix2};
+pub use prefix::{range_with_prefix, Bound, Prefix};
 #[cfg(feature = "iterator")]
 pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -13,8 +13,11 @@ mod prefix;
 mod snapshot;
 
 pub use endian::Endian;
+#[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};
+#[cfg(feature = "iterator")]
 pub use indexed_snapshot::IndexedSnapshotMap;
+#[cfg(feature = "iterator")]
 pub use indexes::{
     index_string, index_string_tuple, index_triple, index_tuple, Index, MultiIndex, UniqueIndex,
 };

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -42,15 +42,18 @@ where
         Path::new(self.namespace, &k.key())
     }
 
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<T> {
+    #[cfg(feature = "iterator")]
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.namespace, &p.prefix())
     }
 
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+    #[cfg(feature = "iterator")]
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.namespace, &p.prefix())
     }
 
-    pub(crate) fn no_prefix(&self) -> Prefix<T> {
+    #[cfg(feature = "iterator")]
+    pub(crate) fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.namespace, &[])
     }
 
@@ -115,11 +118,11 @@ where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
 {
-    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix<T, K::SuperSuffix> {
+    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
         Prefix::new(self.namespace, &p.prefix())
     }
 
-    pub fn prefix_de(&self, p: K::Prefix) -> Prefix<T, K::Suffix> {
+    pub fn prefix_de(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
         Prefix::new(self.namespace, &p.prefix())
     }
 }
@@ -213,7 +216,7 @@ where
         self.no_prefix_de().keys_de(store, min, max, order)
     }
 
-    fn no_prefix_de(&self) -> Prefix<T, K> {
+    fn no_prefix_de(&self) -> Prefix<K, T> {
         Prefix::new(self.namespace, &[])
     }
 }

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -12,7 +12,7 @@ use crate::keys::Prefixer;
 use crate::keys::PrimaryKey;
 use crate::path::Path;
 #[cfg(feature = "iterator")]
-use crate::prefix::{namespaced_prefix_range, Bound, Pair2, Prefix, Prefix2, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Bound, Pair2, Prefix, PrefixBound};
 use cosmwasm_std::{from_slice, Addr, QuerierWrapper, StdError, StdResult, Storage};
 
 #[derive(Debug, Clone)]
@@ -115,12 +115,12 @@ where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
 {
-    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix2<K::SuperSuffix, T> {
-        Prefix2::new(self.namespace, &p.prefix())
+    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix<T, K::SuperSuffix> {
+        Prefix::new(self.namespace, &p.prefix())
     }
 
-    pub fn prefix_de(&self, p: K::Prefix) -> Prefix2<K::Suffix, T> {
-        Prefix2::new(self.namespace, &p.prefix())
+    pub fn prefix_de(&self, p: K::Prefix) -> Prefix<T, K::Suffix> {
+        Prefix::new(self.namespace, &p.prefix())
     }
 }
 
@@ -213,8 +213,8 @@ where
         self.no_prefix_de().keys_de(store, min, max, order)
     }
 
-    fn no_prefix_de(&self) -> Prefix2<K, T> {
-        Prefix2::new(self.namespace, &[])
+    fn no_prefix_de(&self) -> Prefix<T, K> {
+        Prefix::new(self.namespace, &[])
     }
 }
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -42,17 +42,14 @@ where
         Path::new(self.namespace, &k.key())
     }
 
-    #[cfg(feature = "iterator")]
     pub fn prefix(&self, p: K::Prefix) -> Prefix<T> {
         Prefix::new(self.namespace, &p.prefix())
     }
 
-    #[cfg(feature = "iterator")]
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
         Prefix::new(self.namespace, &p.prefix())
     }
 
-    #[cfg(feature = "iterator")]
     pub(crate) fn no_prefix(&self) -> Prefix<T> {
         Prefix::new(self.namespace, &[])
     }
@@ -128,7 +125,6 @@ where
 }
 
 // short-cut for simple keys, rather than .prefix(()).range(...)
-#[cfg(feature = "iterator")]
 impl<'a, K, T> Map<'a, K, T>
 where
     T: Serialize + DeserializeOwned,
@@ -232,7 +228,6 @@ mod test {
     use crate::U32Key;
     use crate::U8Key;
     use cosmwasm_std::testing::MockStorage;
-    #[cfg(feature = "iterator")]
     use cosmwasm_std::{Order, StdResult};
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -377,7 +372,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "iterator")]
     fn range_simple_key() {
         let mut store = MockStorage::new();
 
@@ -915,7 +909,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "iterator")]
     fn readme_with_range() -> StdResult<()> {
         let mut store = MockStorage::new();
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -128,6 +128,7 @@ where
 }
 
 // short-cut for simple keys, rather than .prefix(()).range(...)
+#[cfg(feature = "iterator")]
 impl<'a, K, T> Map<'a, K, T>
 where
     T: Serialize + DeserializeOwned,
@@ -231,6 +232,7 @@ mod test {
     use crate::U32Key;
     use crate::U8Key;
     use cosmwasm_std::testing::MockStorage;
+    #[cfg(feature = "iterator")]
     use cosmwasm_std::{Order, StdResult};
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -375,6 +377,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "iterator")]
     fn range_simple_key() {
         let mut store = MockStorage::new();
 
@@ -912,6 +915,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "iterator")]
     fn readme_with_range() -> StdResult<()> {
         let mut store = MockStorage::new();
 

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "iterator")]
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::marker::PhantomData;

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "iterator")]
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::marker::PhantomData;

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -88,7 +88,7 @@ pub fn default_deserializer_kv<K: Deserializable, T: DeserializeOwned>(
 }
 
 #[derive(Clone)]
-pub struct Prefix<T, K = Vec<u8>>
+pub struct Prefix<K = Vec<u8>, T = Vec<u8>>
 where
     K: Deserializable,
     T: Serialize + DeserializeOwned,
@@ -101,7 +101,7 @@ where
     de_fn: DeserializeKvFn<K, T>,
 }
 
-impl<K, T> Deref for Prefix<T, K>
+impl<K, T> Deref for Prefix<K, T>
 where
     K: Deserializable,
     T: Serialize + DeserializeOwned,
@@ -113,7 +113,7 @@ where
     }
 }
 
-impl<K, T> Prefix<T, K>
+impl<K, T> Prefix<K, T>
 where
     K: Deserializable,
     T: Serialize + DeserializeOwned,
@@ -322,7 +322,7 @@ mod test {
     fn ensure_proper_range_bounds() {
         let mut store = MockStorage::new();
         // manually create this - not testing nested prefixes here
-        let prefix: Prefix<u64, Vec<u8>> = Prefix {
+        let prefix: Prefix<Vec<u8>, u64> = Prefix {
             storage_prefix: b"foo".to_vec(),
             data: PhantomData::<u64>,
             pk_name: vec![],

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "iterator")]
-
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -68,15 +68,15 @@ where
         self.primary.key(k)
     }
 
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
         self.primary.prefix(p)
     }
 
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
         self.primary.sub_prefix(p)
     }
 
-    fn no_prefix(&self) -> Prefix<T> {
+    fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         self.primary.no_prefix()
     }
 

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "iterator")]
-
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -166,7 +164,6 @@ where
 }
 
 // short-cut for simple keys, rather than .prefix(()).range(...)
-#[cfg(feature = "iterator")]
 impl<'a, K, T> SnapshotMap<'a, K, T>
 where
     T: Serialize + DeserializeOwned + Clone,


### PR DESCRIPTION
Builds on top of #434.

Uses one `Prefix` impl for both `range` and `range_de`. At the expense of a "dummy" deserialization to `Vec<u8>`.