### PR TITLE
Upgrade to cosmwasm 1.0.0-soon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -944,7 +944,7 @@ jobs:
       - run:
           name: Install check_contract
           # Uses --debug for compilation speed
-          command: cargo install --debug --version 0.16.0 --features iterator --example check_contract -- cosmwasm-vm
+          command: cargo install --debug --version 1.0.0-soon --features iterator --example check_contract -- cosmwasm-vm
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,10 +145,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-crypto"
+version = "1.0.0-soon"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e50906ff6d449cdcb67b43e683d86904cfaf8c4c8b711c6e788e183616a0d"
+dependencies = [
+ "digest 0.9.0",
+ "ed25519-zebra",
+ "k256",
+ "rand_core 0.5.1",
+ "thiserror",
+]
+
+[[package]]
 name = "cosmwasm-derive"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be68adf023b7d37de680cb901d2a1179473fee3aa25435ad0b3c7267ae965cdb"
+dependencies = [
+ "syn",
+]
+
+[[package]]
+name = "cosmwasm-derive"
+version = "1.0.0-soon"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a64f0d5e854945849d6e1daf6d407ff0fa04ef69b3cfc822e8cde7bd8e369b"
 dependencies = [
  "syn",
 ]
@@ -164,14 +186,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-schema"
+version = "1.0.0-soon"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89558d4ec22e363d99c65032f393e5552d8927a9c738726b46f4a2fc0e927e0"
+dependencies = [
+ "schemars",
+ "serde_json",
+]
+
+[[package]]
 name = "cosmwasm-std"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a14b383575cc9a579d1bb5b7d5eaee74fda8449c25f9d6c736fee282dc025013"
 dependencies = [
  "base64",
- "cosmwasm-crypto",
- "cosmwasm-derive",
+ "cosmwasm-crypto 0.16.1",
+ "cosmwasm-derive 0.16.1",
+ "schemars",
+ "serde",
+ "serde-json-wasm",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "cosmwasm-std"
+version = "1.0.0-soon"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b8139bdf25f1011177e35bbc7f9aca30d7c816a4482ba4d83192579fb87276"
+dependencies = [
+ "base64",
+ "cosmwasm-crypto 1.0.0-soon",
+ "cosmwasm-derive 1.0.0-soon",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -185,7 +233,17 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e70e058e316453284cf5561fbebc4fde68f5dfd99a57dc7146e1892465f1c6"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 0.16.1",
+ "serde",
+]
+
+[[package]]
+name = "cosmwasm-storage"
+version = "1.0.0-soon"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bca08b43328b14b4786d2a2ce5177264b4356e4d0ca2d9cc4b9d8785cd4f40f"
+dependencies = [
+ "cosmwasm-std 1.0.0-soon",
  "serde",
 ]
 
@@ -243,7 +301,7 @@ dependencies = [
 name = "cw-controllers"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "schemars",
@@ -258,8 +316,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecca04ea07d99e8cb7031c58ec5a7d8f581d597621353f1ecbee9e2829169d27"
 dependencies = [
  "anyhow",
- "cosmwasm-std",
- "cosmwasm-storage",
+ "cosmwasm-std 0.16.1",
+ "cosmwasm-storage 0.16.1",
  "cw-storage-plus 0.8.1",
  "cw0 0.8.1",
  "itertools",
@@ -274,8 +332,8 @@ name = "cw-multi-test"
 version = "0.9.0"
 dependencies = [
  "anyhow",
- "cosmwasm-std",
- "cosmwasm-storage",
+ "cosmwasm-std 1.0.0-soon",
+ "cosmwasm-storage 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "derivative",
@@ -292,7 +350,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e867b9972b83b32e00e878dfbff48299ba26618dabeb19b9c56fae176dc225"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 0.16.1",
  "schemars",
  "serde",
 ]
@@ -301,7 +359,7 @@ dependencies = [
 name = "cw-storage-plus"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.0.0-soon",
  "schemars",
  "serde",
 ]
@@ -312,7 +370,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c497f885a40918a02df7d938c81809965fa05cfc21b3dc591e9950237b5de0a9"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 0.16.1",
  "schemars",
  "serde",
  "thiserror",
@@ -322,7 +380,7 @@ dependencies = [
 name = "cw0"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "schemars",
  "serde",
@@ -333,8 +391,8 @@ dependencies = [
 name = "cw1"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "schemars",
  "serde",
 ]
@@ -343,8 +401,8 @@ dependencies = [
 name = "cw1-subkeys"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "cw1",
@@ -361,8 +419,8 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-multi-test 0.8.1",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -378,8 +436,8 @@ dependencies = [
 name = "cw1155"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw0 0.9.0",
  "schemars",
  "serde",
@@ -389,8 +447,8 @@ dependencies = [
 name = "cw1155-base"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "cw1155",
@@ -404,7 +462,7 @@ dependencies = [
 name = "cw2"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "schemars",
  "serde",
@@ -414,8 +472,8 @@ dependencies = [
 name = "cw20"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw0 0.9.0",
  "schemars",
  "serde",
@@ -425,8 +483,8 @@ dependencies = [
 name = "cw20-atomic-swap"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "cw2",
@@ -442,8 +500,8 @@ dependencies = [
 name = "cw20-base"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "cw2",
@@ -457,8 +515,8 @@ dependencies = [
 name = "cw20-bonding"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "cw2",
@@ -476,8 +534,8 @@ dependencies = [
 name = "cw20-escrow"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-multi-test 0.9.0",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -493,8 +551,8 @@ dependencies = [
 name = "cw20-ics20"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "cw2",
@@ -508,8 +566,8 @@ dependencies = [
 name = "cw20-merkle-airdrop"
 version = "0.7.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 0.16.1",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "cw2",
@@ -526,8 +584,8 @@ dependencies = [
 name = "cw20-staking"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-controllers",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -543,8 +601,8 @@ dependencies = [
 name = "cw3"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw0 0.9.0",
  "schemars",
  "serde",
@@ -554,8 +612,8 @@ dependencies = [
 name = "cw3-fixed-multisig"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-multi-test 0.9.0",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -572,8 +630,8 @@ dependencies = [
 name = "cw3-flex-multisig"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-multi-test 0.9.0",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -590,8 +648,8 @@ dependencies = [
 name = "cw4"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "schemars",
  "serde",
@@ -601,8 +659,8 @@ dependencies = [
 name = "cw4-group"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-controllers",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -617,8 +675,8 @@ dependencies = [
 name = "cw4-stake"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-controllers",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -634,8 +692,8 @@ dependencies = [
 name = "cw721"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw0 0.9.0",
  "schemars",
  "serde",
@@ -645,8 +703,8 @@ dependencies = [
 name = "cw721-base"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
  "cw2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,16 +177,6 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534e3160bea28e7a0e1b63532c1b5ce558c5a400030777b73d21316a1309a6f7"
-dependencies = [
- "schemars",
- "serde_json",
-]
-
-[[package]]
-name = "cosmwasm-schema"
 version = "1.0.0-soon"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89558d4ec22e363d99c65032f393e5552d8927a9c738726b46f4a2fc0e927e0"
@@ -391,7 +381,7 @@ dependencies = [
 name = "cw1"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "schemars",
  "serde",
@@ -401,7 +391,7 @@ dependencies = [
 name = "cw1-subkeys"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -419,7 +409,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-multi-test 0.8.1",
  "cw-storage-plus 0.9.0",
@@ -436,7 +426,7 @@ dependencies = [
 name = "cw1155"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw0 0.9.0",
  "schemars",
@@ -447,7 +437,7 @@ dependencies = [
 name = "cw1155-base"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -472,7 +462,7 @@ dependencies = [
 name = "cw20"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw0 0.9.0",
  "schemars",
@@ -483,7 +473,7 @@ dependencies = [
 name = "cw20-atomic-swap"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -500,7 +490,7 @@ dependencies = [
 name = "cw20-base"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -515,7 +505,7 @@ dependencies = [
 name = "cw20-bonding"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -534,7 +524,7 @@ dependencies = [
 name = "cw20-escrow"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-multi-test 0.9.0",
  "cw-storage-plus 0.9.0",
@@ -551,7 +541,7 @@ dependencies = [
 name = "cw20-ics20"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -566,7 +556,7 @@ dependencies = [
 name = "cw20-merkle-airdrop"
 version = "0.7.0"
 dependencies = [
- "cosmwasm-schema 0.16.1",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",
@@ -584,7 +574,7 @@ dependencies = [
 name = "cw20-staking"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-controllers",
  "cw-storage-plus 0.9.0",
@@ -601,7 +591,7 @@ dependencies = [
 name = "cw3"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw0 0.9.0",
  "schemars",
@@ -612,7 +602,7 @@ dependencies = [
 name = "cw3-fixed-multisig"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-multi-test 0.9.0",
  "cw-storage-plus 0.9.0",
@@ -630,7 +620,7 @@ dependencies = [
 name = "cw3-flex-multisig"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-multi-test 0.9.0",
  "cw-storage-plus 0.9.0",
@@ -648,7 +638,7 @@ dependencies = [
 name = "cw4"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "schemars",
@@ -659,7 +649,7 @@ dependencies = [
 name = "cw4-group"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-controllers",
  "cw-storage-plus 0.9.0",
@@ -675,7 +665,7 @@ dependencies = [
 name = "cw4-stake"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-controllers",
  "cw-storage-plus 0.9.0",
@@ -692,7 +682,7 @@ dependencies = [
 name = "cw721"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw0 0.9.0",
  "schemars",
@@ -703,7 +693,7 @@ dependencies = [
 name = "cw721-base"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-soon",
+ "cosmwasm-schema",
  "cosmwasm-std 1.0.0-soon",
  "cw-storage-plus 0.9.0",
  "cw0 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 dependencies = [
  "backtrace",
 ]
@@ -127,22 +127,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
-
-[[package]]
-name = "cosmwasm-crypto"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a965098e28b1338513185746efe1f57c974aebb9e3869ded3361dc3bffbc780d"
-dependencies = [
- "digest 0.9.0",
- "ed25519-zebra",
- "k256",
- "rand_core 0.5.1",
- "thiserror",
-]
+checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
 
 [[package]]
 name = "cosmwasm-crypto"
@@ -155,15 +142,6 @@ dependencies = [
  "k256",
  "rand_core 0.5.1",
  "thiserror",
-]
-
-[[package]]
-name = "cosmwasm-derive"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be68adf023b7d37de680cb901d2a1179473fee3aa25435ad0b3c7267ae965cdb"
-dependencies = [
- "syn",
 ]
 
 [[package]]
@@ -187,44 +165,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14b383575cc9a579d1bb5b7d5eaee74fda8449c25f9d6c736fee282dc025013"
-dependencies = [
- "base64",
- "cosmwasm-crypto 0.16.1",
- "cosmwasm-derive 0.16.1",
- "schemars",
- "serde",
- "serde-json-wasm",
- "thiserror",
- "uint",
-]
-
-[[package]]
-name = "cosmwasm-std"
 version = "1.0.0-soon"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b8139bdf25f1011177e35bbc7f9aca30d7c816a4482ba4d83192579fb87276"
 dependencies = [
  "base64",
- "cosmwasm-crypto 1.0.0-soon",
- "cosmwasm-derive 1.0.0-soon",
+ "cosmwasm-crypto",
+ "cosmwasm-derive",
  "schemars",
  "serde",
  "serde-json-wasm",
  "thiserror",
  "uint",
-]
-
-[[package]]
-name = "cosmwasm-storage"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e70e058e316453284cf5561fbebc4fde68f5dfd99a57dc7146e1892465f1c6"
-dependencies = [
- "cosmwasm-std 0.16.1",
- "serde",
 ]
 
 [[package]]
@@ -233,7 +185,7 @@ version = "1.0.0-soon"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bca08b43328b14b4786d2a2ce5177264b4356e4d0ca2d9cc4b9d8785cd4f40f"
 dependencies = [
- "cosmwasm-std 1.0.0-soon",
+ "cosmwasm-std",
  "serde",
 ]
 
@@ -254,9 +206,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.4"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc209804a22c34a98fe26a32d997ac64d4284816f65cf1a529c4e31a256218a0"
+checksum = "51e7ef8604ba15f1ea2cef61e17577e630ee39aef7f94305d138dbf1a216ada3"
 dependencies = [
  "generic-array 0.14.4",
  "rand_core 0.6.3",
@@ -291,27 +243,9 @@ dependencies = [
 name = "cw-controllers"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw-multi-test"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecca04ea07d99e8cb7031c58ec5a7d8f581d597621353f1ecbee9e2829169d27"
-dependencies = [
- "anyhow",
- "cosmwasm-std 0.16.1",
- "cosmwasm-storage 0.16.1",
- "cw-storage-plus 0.8.1",
- "cw0 0.8.1",
- "itertools",
- "prost",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "schemars",
  "serde",
  "thiserror",
@@ -322,10 +256,10 @@ name = "cw-multi-test"
 version = "0.9.0"
 dependencies = [
  "anyhow",
- "cosmwasm-std 1.0.0-soon",
- "cosmwasm-storage 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus",
+ "cw0",
  "derivative",
  "itertools",
  "prost",
@@ -336,42 +270,19 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e867b9972b83b32e00e878dfbff48299ba26618dabeb19b9c56fae176dc225"
-dependencies = [
- "cosmwasm-std 0.16.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw-storage-plus"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-std 1.0.0-soon",
+ "cosmwasm-std",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw0"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c497f885a40918a02df7d938c81809965fa05cfc21b3dc591e9950237b5de0a9"
-dependencies = [
- "cosmwasm-std 0.16.1",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw0"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
  "schemars",
  "serde",
  "thiserror",
@@ -382,7 +293,7 @@ name = "cw1"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
+ "cosmwasm-std",
  "schemars",
  "serde",
 ]
@@ -392,9 +303,9 @@ name = "cw1-subkeys"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "cw1",
  "cw1-whitelist",
  "cw2",
@@ -410,10 +321,10 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-multi-test 0.8.1",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus",
+ "cw0",
  "cw1",
  "cw2",
  "derivative",
@@ -427,8 +338,8 @@ name = "cw1155"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw0",
  "schemars",
  "serde",
 ]
@@ -438,9 +349,9 @@ name = "cw1155-base"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "cw1155",
  "cw2",
  "schemars",
@@ -452,8 +363,8 @@ dependencies = [
 name = "cw2"
 version = "0.9.0"
 dependencies = [
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]
@@ -463,8 +374,8 @@ name = "cw20"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw0",
  "schemars",
  "serde",
 ]
@@ -474,9 +385,9 @@ name = "cw20-atomic-swap"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "hex 0.3.2",
@@ -491,9 +402,9 @@ name = "cw20-base"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "schemars",
@@ -506,9 +417,9 @@ name = "cw20-bonding"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -525,10 +436,10 @@ name = "cw20-escrow"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-multi-test 0.9.0",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -542,9 +453,9 @@ name = "cw20-ics20"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "schemars",
@@ -557,16 +468,16 @@ name = "cw20-merkle-airdrop"
 version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "hex 0.4.3",
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "thiserror",
 ]
 
@@ -575,10 +486,10 @@ name = "cw20-staking"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
+ "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -592,8 +503,8 @@ name = "cw3"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw0",
  "schemars",
  "serde",
 ]
@@ -603,10 +514,10 @@ name = "cw3-fixed-multisig"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-multi-test 0.9.0",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -621,10 +532,10 @@ name = "cw3-flex-multisig"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-multi-test 0.9.0",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw3",
  "cw4",
@@ -639,8 +550,8 @@ name = "cw4"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]
@@ -650,10 +561,10 @@ name = "cw4-group"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
+ "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw4",
  "schemars",
@@ -666,10 +577,10 @@ name = "cw4-stake"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
+ "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw20",
  "cw4",
@@ -683,8 +594,8 @@ name = "cw721"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw0",
  "schemars",
  "serde",
 ]
@@ -694,9 +605,9 @@ name = "cw721-base"
 version = "0.9.0"
 dependencies = [
  "cosmwasm-schema",
- "cosmwasm-std 1.0.0-soon",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw0",
  "cw2",
  "cw721",
  "schemars",
@@ -706,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
+checksum = "2adca118c71ecd9ae094d4b68257b3fdfcb711a612b9eec7b5a0d27a5a70a5b4"
 dependencies = [
  "const-oid",
 ]
@@ -770,7 +681,7 @@ dependencies = [
  "hex 0.4.3",
  "rand_core 0.5.1",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "thiserror",
 ]
 
@@ -934,14 +845,14 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.9.6",
+ "sha2 0.9.8",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "memchr"
@@ -991,9 +902,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
+checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der",
  "spki",
@@ -1060,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5446d1cf2dfe2d6367c8b27f2082bdf011e60e76fa1fcd140047f535156d6e7"
+checksum = "e0f1028de22e436bb35fce070310ee57d57b5e59ae77b4e3f24ce4773312b813"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -1083,9 +994,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6ab463ae35acccb5cba66c0084c985257b797d288b6050cc2f6ac1b266cb78"
+checksum = "885c12e31e1e1a44805b867da9176a3a710e0c9965aeff020db13cf82ee9dbe1"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -1095,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902fdfbcf871ae8f653bddf4b2c05905ddaabc08f69d32a915787e3be0d31356"
+checksum = "3dd851dbc056c0aaae2b164205b502572cf082274a877436f4546e1cf4211aad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1147,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1170,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -1193,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
 dependencies = [
  "der",
 ]
@@ -1214,9 +1125,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1225,18 +1136,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1245,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "uint"

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -23,12 +23,12 @@ cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw1 = { path = "../../packages/cw1", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw1-whitelist = { path = "../cw1-whitelist", version = "0.9.0", features = ["library"] }
-cosmwasm-std = { version = "0.16.0", features = ["staking"] }
+cosmwasm-std = { version = "1.0.0-soon", features = ["staking"] }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }
 cw1-whitelist = { path = "../cw1-whitelist", version = "0.9.0", features = ["library", "test-utils"] }

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -22,7 +22,7 @@ test-utils = []
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw1 = { path = "../../packages/cw1", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0", features = ["staking"] }
+cosmwasm-std = { version = "1.0.0-soon", features = ["staking"] }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -31,6 +31,6 @@ thiserror = { version = "1.0.23" }
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1"
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }
 cw-multi-test = "0.8.1"
 derivative = "2"

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -32,5 +32,5 @@ thiserror = { version = "1.0.23" }
 anyhow = "1"
 assert_matches = "1"
 cosmwasm-schema = { version = "1.0.0-soon" }
-cw-multi-test = "0.8.1"
+cw-multi-test = { path = "../../packages/multi-test", version = "0.9.0" }
 derivative = "2"

--- a/contracts/cw1-whitelist/src/integration_tests.rs
+++ b/contracts/cw1-whitelist/src/integration_tests.rs
@@ -1,20 +1,14 @@
 use crate::msg::{AdminListResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use anyhow::{anyhow, Result};
 use assert_matches::assert_matches;
-use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
 use cosmwasm_std::{to_binary, Addr, CosmosMsg, Empty, QueryRequest, StdError, WasmMsg, WasmQuery};
 use cw1::Cw1Contract;
-use cw_multi_test::{App, AppResponse, BankKeeper, Contract, ContractWrapper, Executor};
+use cw_multi_test::{App, AppResponse, Contract, ContractWrapper, Executor};
 use derivative::Derivative;
 use serde::{de::DeserializeOwned, Serialize};
 
 fn mock_app() -> App {
-    let env = mock_env();
-    let api = MockApi::default();
-    let bank = BankKeeper::new();
-    let storage = MockStorage::new();
-
-    App::new(api, env.block, bank, storage)
+    App::default()
 }
 
 fn contract_cw1() -> Box<dyn Contract<Empty>> {

--- a/contracts/cw1155-base/Cargo.toml
+++ b/contracts/cw1155-base/Cargo.toml
@@ -22,10 +22,10 @@ cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw1155 = { path = "../../packages/cw1155", version = "0.9.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/contracts/cw20-atomic-swap/Cargo.toml
+++ b/contracts/cw20-atomic-swap/Cargo.toml
@@ -18,7 +18,7 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -27,4 +27,4 @@ hex = "0.3.1"
 sha2 = "0.8.0"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -22,10 +22,10 @@ cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/contracts/cw20-bonding/Cargo.toml
+++ b/contracts/cw20-bonding/Cargo.toml
@@ -25,7 +25,7 @@ cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
 cw20-base = { path = "../../contracts/cw20-base", version = "0.9.0", features = ["library"] }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0", default-features = false, features = ["staking"] }
+cosmwasm-std = { version = "1.0.0-soon", default-features = false, features = ["staking"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
@@ -34,4 +34,4 @@ integer-sqrt = { version = "0.1.5" }
 integer-cbrt = { version = "0.1.2" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/contracts/cw20-escrow/Cargo.toml
+++ b/contracts/cw20-escrow/Cargo.toml
@@ -21,13 +21,13 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }
 cw-multi-test = { path = "../../packages/multi-test", version = "0.9.0" }
 cw20-base = { path = "../cw20-base", version = "0.9.0", features = ["library"] }

--- a/contracts/cw20-ics20/Cargo.toml
+++ b/contracts/cw20-ics20/Cargo.toml
@@ -21,11 +21,11 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0", features = ["stargate"] }
+cosmwasm-std = { version = "1.0.0-soon", features = ["stargate"] }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/contracts/cw20-merkle-airdrop/Cargo.toml
+++ b/contracts/cw20-merkle-airdrop/Cargo.toml
@@ -31,5 +31,5 @@ hex = "0.4"
 sha2 = { version = "0.9.5", default-features = false }
 
 [dev-dependencies]
-cosmwasm-schema = "0.16.0"
+cosmwasm-schema = "1.0.0-soon"
 serde_json = "1.0"

--- a/contracts/cw20-merkle-airdrop/Cargo.toml
+++ b/contracts/cw20-merkle-airdrop/Cargo.toml
@@ -22,7 +22,7 @@ library = []
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-staking/Cargo.toml
+++ b/contracts/cw20-staking/Cargo.toml
@@ -25,11 +25,11 @@ cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
 cw-controllers = { path = "../../packages/controllers", version = "0.9.0" }
 cw20-base = { path = "../../contracts/cw20-base", version = "0.9.0", features = ["library"] }
-cosmwasm-std = { version = "0.16.0", features = ["staking"] }
+cosmwasm-std = { version = "1.0.0-soon", features = ["staking"] }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -22,13 +22,13 @@ cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw3 = { path = "../../packages/cw3", version = "0.9.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
 cw20-base = { path = "../cw20-base", version = "0.9.0", features = ["library"] }
 cw-multi-test = { path = "../../packages/multi-test", version = "0.9.0" }

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -23,12 +23,12 @@ cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw3 = { path = "../../packages/cw3", version = "0.9.0" }
 cw4 = { path = "../../packages/cw4", version = "0.9.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }
 cw4-group = { path = "../cw4-group", version = "0.9.0" }
 cw-multi-test = { path = "../../packages/multi-test", version = "0.9.0" }

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -31,10 +31,10 @@ cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw4 = { path = "../../packages/cw4", version = "0.9.0" }
 cw-controllers = { path = "../../packages/controllers", version = "0.9.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -32,10 +32,10 @@ cw4 = { path = "../../packages/cw4", version = "0.9.0" }
 cw20 = { path = "../../packages/cw20", version = "0.9.0" }
 cw-controllers = { path = "../../packages/controllers", version = "0.9.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -29,10 +29,10 @@ cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw2 = { path = "../../packages/cw2", version = "0.9.0" }
 cw721 = { path = "../../packages/cw721", version = "0.9.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/packages/controllers/Cargo.toml
+++ b/packages/controllers/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.cosmwasm.com"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 cw0 = { path = "../cw0", version = "0.9.0" }
 cw-storage-plus = { path = "../storage-plus", version = "0.9.0" }
 schemars = "0.8.1"

--- a/packages/cw0/Cargo.toml
+++ b/packages/cw0/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.cosmwasm.com"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }

--- a/packages/cw1/Cargo.toml
+++ b/packages/cw1/Cargo.toml
@@ -10,9 +10,9 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/packages/cw1155/Cargo.toml
+++ b/packages/cw1155/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cosmwasm-std = { version = "0.16.0", default-features = false }
+cosmwasm-std = { version = "1.0.0-soon", default-features = false }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw2/src/lib.rs
+++ b/packages/cw2/src/lib.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Querier, QuerierWrapper, QueryRequest, StdResult, Storage, WasmQuery};
+use cosmwasm_std::{Empty, Querier, QuerierWrapper, QueryRequest, StdResult, Storage, WasmQuery};
 use cw_storage_plus::Item;
 
 pub const CONTRACT: Item<ContractVersion> = Item::new("contract_info");
@@ -50,7 +50,7 @@ pub fn query_contract_info<Q: Querier, T: Into<String>>(
         contract_addr: contract_addr.into(),
         key: CONTRACT.as_slice().into(),
     });
-    QuerierWrapper::new(querier).query(&req)
+    QuerierWrapper::<Empty>::new(querier).query(&req)
 }
 
 #[cfg(test)]

--- a/packages/cw20/Cargo.toml
+++ b/packages/cw20/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/packages/cw20/src/helpers.rs
+++ b/packages/cw20/src/helpers.rs
@@ -2,7 +2,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    to_binary, Addr, CosmosMsg, Querier, QuerierWrapper, StdResult, Uint128, WasmMsg, WasmQuery,
+    to_binary, Addr, CosmosMsg, Empty, Querier, QuerierWrapper, StdResult, Uint128, WasmMsg,
+    WasmQuery,
 };
 
 use crate::{
@@ -46,7 +47,7 @@ impl Cw20Contract {
             msg: to_binary(&msg)?,
         }
         .into();
-        let res: BalanceResponse = QuerierWrapper::new(querier).query(&query)?;
+        let res: BalanceResponse = QuerierWrapper::<Empty>::new(querier).query(&query)?;
         Ok(res.balance)
     }
 
@@ -59,7 +60,7 @@ impl Cw20Contract {
             msg: to_binary(&msg)?,
         }
         .into();
-        QuerierWrapper::new(querier).query(&query)
+        QuerierWrapper::<Empty>::new(querier).query(&query)
     }
 
     /// Get allowance of spender to use owner's account
@@ -78,7 +79,7 @@ impl Cw20Contract {
             msg: to_binary(&msg)?,
         }
         .into();
-        QuerierWrapper::new(querier).query(&query)
+        QuerierWrapper::<Empty>::new(querier).query(&query)
     }
 
     /// Find info on who can mint, and how much
@@ -89,7 +90,7 @@ impl Cw20Contract {
             msg: to_binary(&msg)?,
         }
         .into();
-        QuerierWrapper::new(querier).query(&query)
+        QuerierWrapper::<Empty>::new(querier).query(&query)
     }
 
     /// returns true if the contract supports the allowance extension

--- a/packages/cw3/Cargo.toml
+++ b/packages/cw3/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/packages/cw4/Cargo.toml
+++ b/packages/cw4/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cw-storage-plus = { path = "../storage-plus", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cosmwasm-std = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-soon" }

--- a/packages/cw721/src/helpers.rs
+++ b/packages/cw721/src/helpers.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use cosmwasm_std::{
-    to_binary, Addr, CosmosMsg, Querier, QuerierWrapper, StdResult, WasmMsg, WasmQuery,
+    to_binary, Addr, CosmosMsg, Empty, Querier, QuerierWrapper, StdResult, WasmMsg, WasmQuery,
 };
 
 use crate::{
@@ -42,7 +42,7 @@ impl Cw721Contract {
             msg: to_binary(&req)?,
         }
         .into();
-        QuerierWrapper::new(querier).query(&query)
+        QuerierWrapper::<Empty>::new(querier).query(&query)
     }
 
     /*** queries ***/

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -20,8 +20,8 @@ backtrace = ["anyhow/backtrace"]
 [dependencies]
 cw0 = { path = "../../packages/cw0", version = "0.9.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0"}
-cosmwasm-std = { version = "0.16.0", features = ["staking"] }
-cosmwasm-storage = { version = "0.16.0" }
+cosmwasm-std = { version = "1.0.0-soon", features = ["staking"] }
+cosmwasm-storage = { version = "1.0.0-soon" }
 itertools = "0.10.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -5,7 +5,8 @@ use std::ops::Deref;
 use cosmwasm_std::{
     Addr, Api, Attribute, BankMsg, Binary, BlockInfo, Coin, ContractInfo, ContractResult,
     CustomQuery, Deps, DepsMut, Env, Event, MessageInfo, Order, Querier, QuerierWrapper, Reply,
-    ReplyOn, Response, Storage, SubMsg, SubMsgExecutionResponse, WasmMsg, WasmQuery,
+    ReplyOn, Response, Storage, SubMsg, SubMsgExecutionResponse, TransactionInfo, WasmMsg,
+    WasmQuery,
 };
 use cosmwasm_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 use prost::Message;
@@ -651,6 +652,7 @@ where
             contract: ContractInfo {
                 address: address.into(),
             },
+            transaction: Some(TransactionInfo { index: 0 }),
         }
     }
 

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -14,6 +14,6 @@ default = ["iterator"]
 iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
-cosmwasm-std = { version = "0.16.0", default-features = false }
+cosmwasm-std = { version = "1.0.0-soon", default-features = false }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }


### PR DESCRIPTION
Closes #427

I fixed the compile errors (even if I wish to do this better in the helpers later), but the tests fail for odd reasons. For example, try `cargo test` in `cw1-whitelist`. I get:

```
error[E0308]: mismatched types
  --> contracts/cw1-whitelist/src/integration_tests.rs:17:19
   |
17 |     App::new(api, env.block, bank, storage)
   |                   ^^^^^^^^^ expected struct `cosmwasm_std::types::BlockInfo`, found struct `BlockInfo`
   |
   = note: perhaps two different versions of crate `cosmwasm_std` are being used?
```

Quite confused here, as these are aliases (cosmwasm_std::BlockInfo and cosmwasm_std::types::BlockInfo) and I did check that Cargo.toml is updated to 1.0.0-soon.

I'd be happy if anyone can investigate (and fix)