### PR TITLE
Improve in-code documentation of map primitives

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -15,8 +15,8 @@ pub trait IndexList<T> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<T>> + '_>;
 }
 
+// TODO: remove traits here and make this const fn new
 /// IndexedBucket works like a bucket but has a secondary index
-/// TODO: remove traits here and make this const fn new
 pub struct IndexedMap<'a, K, T, I>
 where
     K: PrimaryKey<'a>,
@@ -36,7 +36,7 @@ where
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
 {
-    /// TODO: remove traits here and make this const fn new
+    // TODO: remove traits here and make this const fn new
     pub fn new(pk_namespace: &'a str, indexes: I) -> Self {
         IndexedMap {
             pk_namespace: pk_namespace.as_bytes(),

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -33,7 +33,7 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
     ///
     /// let indexes = UniqueIndex::new(|d: &Data| U32Key::new(d.age), "data__age");
     ///
-    /// let ism: IndexedSnapshotMap<&[u8], Data, UniqueIndex<U32Key, Data>> = IndexedSnapshotMap::new(
+    /// IndexedSnapshotMap::<&[u8], Data, UniqueIndex<U32Key, Data>>::new(
     ///     "data",
     ///     "checkpoints",
     ///     "changelog",

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -33,7 +33,7 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
     ///
     /// let indexes = UniqueIndex::new(|d: &Data| U32Key::new(d.age), "data__age");
     ///
-    /// IndexedSnapshotMap::new(
+    /// let ism: IndexedSnapshotMap<&[u8], Data, UniqueIndex<U32Key, Data>> = IndexedSnapshotMap::new(
     ///     "data",
     ///     "checkpoints",
     ///     "changelog",

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -23,7 +23,17 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
     /// Examples:
     ///
     /// ```rust
-    /// let ism = IndexedSnapshotMap::new(
+    /// use cw_storage_plus::{IndexedSnapshotMap, Strategy, U32Key, UniqueIndex};
+    ///
+    /// #[derive(PartialEq, Debug, Clone)]
+    /// struct Data {
+    ///     pub name: String,
+    ///     pub age: u32,
+    /// }
+    ///
+    /// let indexes = UniqueIndex::new(|d: &Data| U32Key::new(d.age), "data__age");
+    ///
+    /// IndexedSnapshotMap::new(
     ///     "data",
     ///     "checkpoints",
     ///     "changelog",

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -20,6 +20,17 @@ pub struct IndexedSnapshotMap<'a, K, T, I> {
 }
 
 impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
+    /// Examples:
+    ///
+    /// ```rust
+    /// let ism = IndexedSnapshotMap::new(
+    ///     "data",
+    ///     "checkpoints",
+    ///     "changelog",
+    ///     Strategy::EveryBlock,
+    ///     indexes,
+    /// );
+    /// ```
     pub fn new(
         pk_namespace: &'a str,
         checkpoints: &'a str,

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -68,11 +68,20 @@ where
     /// ## Example:
     ///
     /// ```rust
+    /// use cw_storage_plus::MultiIndex;
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Deserialize, Serialize, Clone)]
+    /// struct Data {
+    ///     pub name: String,
+    ///     pub age: u32,
+    /// }
+    ///
     /// MultiIndex::new(
-    ///     |d: &TokenInfo, k: Vec<u8>| (d.owner.clone(), k),
-    ///     "tokens",
-    ///     "tokens__owner",
-    /// )
+    ///     |d: &Data, k: Vec<u8>| (d.age, k),
+    ///     "age",
+    ///     "age__owner",
+    /// );
     /// ```
     pub fn new(
         idx_fn: fn(&T, Vec<u8>) -> K,
@@ -244,7 +253,15 @@ impl<'a, K, T> UniqueIndex<'a, K, T> {
     /// ## Example:
     ///
     /// ```rust
-    /// let age = UniqueIndex::new(|d| U32Key::new(d.age), "data__age");
+    /// use cw_storage_plus::{U32Key, UniqueIndex};
+    ///
+    /// #[derive(PartialEq, Debug, Clone)]
+    /// struct Data {
+    ///     pub name: String,
+    ///     pub age: u32,
+    /// }
+    ///
+    /// UniqueIndex::new(|d: &Data| U32Key::new(d.age), "data__age");
     /// ```
     pub fn new(idx_fn: fn(&T) -> K, idx_namespace: &'a str) -> Self {
         UniqueIndex {

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -59,6 +59,21 @@ where
     T: Serialize + DeserializeOwned + Clone,
 {
     // TODO: make this a const fn
+    /// Create a new MultiIndex
+    ///
+    /// idx_fn - lambda creating index key from value (first argument) and primary key (second argument)
+    /// pk_namespace - prefix for the primary key
+    /// idx_namespace - prefix for the index value
+    ///
+    /// ## Example:
+    ///
+    /// ```rust
+    /// MultiIndex::new(
+    ///     |d: &TokenInfo, k: Vec<u8>| (d.owner.clone(), k),
+    ///     "tokens",
+    ///     "tokens__owner",
+    /// )
+    /// ```
     pub fn new(
         idx_fn: fn(&T, Vec<u8>) -> K,
         pk_namespace: &'a str,
@@ -203,6 +218,7 @@ where
     }
 }
 
+/// UniqueRef stores Binary(Vec[u8]) representation of private key and index value
 #[derive(Deserialize, Serialize)]
 pub(crate) struct UniqueRef<T> {
     // note, we collapse the pk - combining everything under the namespace - even if it is composite
@@ -220,6 +236,16 @@ pub struct UniqueIndex<'a, K, T> {
 
 impl<'a, K, T> UniqueIndex<'a, K, T> {
     // TODO: make this a const fn
+    /// Create a new UniqueIndex
+    ///
+    /// idx_fn - lambda creating index key from index value
+    /// idx_namespace - prefix for the index value
+    ///
+    /// ## Example:
+    ///
+    /// ```rust
+    /// let age = UniqueIndex::new(|d| U32Key::new(d.age), "data__age");
+    /// ```
     pub fn new(idx_fn: fn(&T) -> K, idx_namespace: &'a str) -> Self {
         UniqueIndex {
             index: idx_fn,

--- a/packages/storage-plus/src/indexes.rs
+++ b/packages/storage-plus/src/indexes.rs
@@ -255,7 +255,6 @@ impl<'a, K, T> UniqueIndex<'a, K, T> {
     /// ```rust
     /// use cw_storage_plus::{U32Key, UniqueIndex};
     ///
-    /// #[derive(PartialEq, Debug, Clone)]
     /// struct Data {
     ///     pub name: String,
     ///     pub age: u32,

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -20,7 +20,13 @@ impl<'a, T> SnapshotItem<'a, T> {
     /// Example:
     ///
     /// ```rust
-    /// SnapshotItem::new(snapshot_names!("foobar"), Strategy::EveryBlock)
+    /// use cw_storage_plus::{SnapshotItem, Strategy};
+    ///
+    /// let snapshot_item: SnapshotItem<'static, u64> =
+    ///     SnapshotItem::new("every",
+    ///                       "every__check",
+    ///                       "every__change",
+    ///                       Strategy::EveryBlock);
     /// ```
     pub const fn new(
         storage_key: &'a str,

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -22,11 +22,11 @@ impl<'a, T> SnapshotItem<'a, T> {
     /// ```rust
     /// use cw_storage_plus::{SnapshotItem, Strategy};
     ///
-    /// let snapshot_item: SnapshotItem<'static, u64> =
-    ///     SnapshotItem::new("every",
-    ///                       "every__check",
-    ///                       "every__change",
-    ///                       Strategy::EveryBlock);
+    /// SnapshotItem::<'static, u64>::new(
+    ///     "every",
+    ///     "every__check",
+    ///     "every__change",
+    ///     Strategy::EveryBlock);
     /// ```
     pub const fn new(
         storage_key: &'a str,

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -17,7 +17,11 @@ pub struct SnapshotItem<'a, T> {
 }
 
 impl<'a, T> SnapshotItem<'a, T> {
-    /// Usage: SnapshotItem::new(snapshot_names!("foobar"), Strategy::EveryBlock)
+    /// Example:
+    ///
+    /// ```rust
+    /// SnapshotItem::new(snapshot_names!("foobar"), Strategy::EveryBlock)
+    /// ```
     pub const fn new(
         storage_key: &'a str,
         checkpoints: &'a str,

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -26,11 +26,11 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
     /// ```rust
     /// use cw_storage_plus::{SnapshotMap, Strategy};
     ///
-    /// let sm: SnapshotMap<&[u8], &str> =
-    ///     SnapshotMap::new("never",
-    ///                      "never__check",
-    ///                      "never__change",
-    ///                      Strategy::EveryBlock
+    /// SnapshotMap::<&[u8], &str>::new(
+    ///     "never",
+    ///     "never__check",
+    ///     "never__change",
+    ///     Strategy::EveryBlock
     /// );
     /// ```
     pub const fn new(

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -24,7 +24,9 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
     /// Example:
     ///
     /// ```rust
-    /// SnapshotMap::new(snapshot_names!("foobar"), Strategy::EveryBlock)
+    /// use cw_storage_plus::{SnapshotMap, Strategy};
+    ///
+    /// SnapshotMap::new("never", "never__check", "never__change", Strategy::EveryBlock);
     /// ```
     pub const fn new(
         pk: &'a str,

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -21,7 +21,11 @@ pub struct SnapshotMap<'a, K, T> {
 }
 
 impl<'a, K, T> SnapshotMap<'a, K, T> {
-    /// Usage: SnapshotMap::new(snapshot_names!("foobar"), Strategy::EveryBlock)
+    /// Example:
+    ///
+    /// ```rust
+    /// SnapshotMap::new(snapshot_names!("foobar"), Strategy::EveryBlock)
+    /// ```
     pub const fn new(
         pk: &'a str,
         checkpoints: &'a str,

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -26,7 +26,12 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
     /// ```rust
     /// use cw_storage_plus::{SnapshotMap, Strategy};
     ///
-    /// SnapshotMap::new("never", "never__check", "never__change", Strategy::EveryBlock);
+    /// let sm: SnapshotMap<&[u8], &str> =
+    ///     SnapshotMap::new("never",
+    ///                      "never__check",
+    ///                      "never__change",
+    ///                      Strategy::EveryBlock
+    /// );
     /// ```
     pub const fn new(
         pk: &'a str,

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -11,7 +11,8 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 /// Structure holding a map of checkpoints composited from
-/// height as U64Key and checkpoint id.
+/// height (as U64Key) and counter of how many times it has
+/// been checkpointed (as u32).
 /// Stores all changes in changelog.
 #[derive(Debug, Clone)]
 pub(crate) struct Snapshot<'a, K, T> {
@@ -26,13 +27,6 @@ pub(crate) struct Snapshot<'a, K, T> {
 }
 
 impl<'a, K, T> Snapshot<'a, K, T> {
-    /// Example:
-    ///
-    /// ```rust
-    /// use cw_storage_plus::{Strategy};
-    ///
-    /// Snapshot::new("every__check", "every__change", Strategy::EveryBlock);
-    /// ```
     pub const fn new(
         checkpoints: &'a str,
         changelog: &'a str,

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -29,7 +29,9 @@ impl<'a, K, T> Snapshot<'a, K, T> {
     /// Example:
     ///
     /// ```rust
-    /// let snapshot = Snapshot::new("every__check", "every__change", Strategy::EveryBlock);
+    /// use cw_storage_plus::{Strategy};
+    ///
+    /// Snapshot::new("every__check", "every__change", Strategy::EveryBlock);
     /// ```
     pub const fn new(
         checkpoints: &'a str,

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -10,6 +10,9 @@ use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+/// Structure holding a map of checkpoints composited from
+/// height as U64Key and checkpoint id.
+/// Stores all changes in changelog.
 #[derive(Debug, Clone)]
 pub(crate) struct Snapshot<'a, K, T> {
     checkpoints: Map<'a, U64Key, u32>,
@@ -23,6 +26,11 @@ pub(crate) struct Snapshot<'a, K, T> {
 }
 
 impl<'a, K, T> Snapshot<'a, K, T> {
+    /// Example:
+    ///
+    /// ```rust
+    /// let snapshot = Snapshot::new("every__check", "every__change", Strategy::EveryBlock);
+    /// ```
     pub const fn new(
         checkpoints: &'a str,
         changelog: &'a str,


### PR DESCRIPTION
closes https://github.com/CosmWasm/cw-plus/issues/407

It's not a world-breaking change, but can improve work a bit - when IDE shows suggestion about structures, it often shows Rust's doc comments as well.