### PR TITLE
Expose sudo powers on Router we give to Modules

### DIFF
--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -1319,7 +1319,7 @@ mod test {
             .unwrap();
         assert_eq!(1, count);
 
-        // sudo
+        // wasm_sudo call
         let msg = payout::SudoMsg { set_count: 25 };
         app.wasm_sudo(payout_addr.clone(), &msg).unwrap();
 
@@ -1329,7 +1329,23 @@ mod test {
             .query_wasm_smart(&payout_addr, &payout::QueryMsg::Count {})
             .unwrap();
         assert_eq!(25, count);
+
+        // we can do the same with sudo call
+        let msg = payout::SudoMsg { set_count: 49 };
+        let sudo_msg = WasmSudo {
+            contract_addr: payout_addr.clone(),
+            msg: to_vec(&msg).unwrap(),
+        };
+        app.sudo(sudo_msg.into()).unwrap();
+
+        let payout::CountResponse { count } = app
+            .wrap()
+            .query_wasm_smart(&payout_addr, &payout::QueryMsg::Count {})
+            .unwrap();
+        assert_eq!(49, count);
     }
+
+    // TODO custom handler dispatch to bank mint
 
     #[test]
     fn reflect_submessage_reply_works() {

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -26,8 +26,13 @@ pub fn next_block(block: &mut BlockInfo) {
 }
 
 /// Type alias for default build `App` to make its storing simpler in typical scenario
-pub type BasicApp<ExecC = Empty, QueryC = Empty> =
-    App<BankKeeper, MockApi, MockStorage, FailingModule<ExecC, QueryC>, WasmKeeper<ExecC, QueryC>>;
+pub type BasicApp<ExecC = Empty, QueryC = Empty> = App<
+    BankKeeper,
+    MockApi,
+    MockStorage,
+    FailingModule<ExecC, QueryC, Empty>,
+    WasmKeeper<ExecC, QueryC>,
+>;
 
 /// Router is a persisted state. You can query this.
 /// Execution generally happens on the RouterCache, which then can be atomically committed or rolled back.
@@ -36,7 +41,7 @@ pub struct App<
     Bank = BankKeeper,
     Api = MockApi,
     Storage = MockStorage,
-    Custom = FailingModule<Empty, Empty>,
+    Custom = FailingModule<Empty, Empty, Empty>,
     Wasm = WasmKeeper<Empty, Empty>,
     Staking = FailingStaking,
     Distr = FailingDistribution,
@@ -67,7 +72,7 @@ impl BasicApp {
         F: FnOnce(
             &mut Router<
                 BankKeeper,
-                FailingModule<Empty, Empty>,
+                FailingModule<Empty, Empty, Empty>,
                 WasmKeeper<Empty, Empty>,
                 FailingStaking,
                 FailingDistribution,
@@ -89,7 +94,7 @@ where
     F: FnOnce(
         &mut Router<
             BankKeeper,
-            FailingModule<ExecC, QueryC>,
+            FailingModule<ExecC, QueryC, Empty>,
             WasmKeeper<ExecC, QueryC>,
             FailingStaking,
             FailingDistribution,
@@ -162,7 +167,7 @@ impl Default
         BankKeeper,
         MockApi,
         MockStorage,
-        FailingModule<Empty, Empty>,
+        FailingModule<Empty, Empty, Empty>,
         WasmKeeper<Empty, Empty>,
         FailingStaking,
         FailingDistribution,
@@ -178,7 +183,7 @@ impl
         BankKeeper,
         MockApi,
         MockStorage,
-        FailingModule<Empty, Empty>,
+        FailingModule<Empty, Empty, Empty>,
         WasmKeeper<Empty, Empty>,
         FailingStaking,
         FailingDistribution,
@@ -204,7 +209,7 @@ impl<ExecC, QueryC>
         BankKeeper,
         MockApi,
         MockStorage,
-        FailingModule<ExecC, QueryC>,
+        FailingModule<ExecC, QueryC, Empty>,
         WasmKeeper<ExecC, QueryC>,
         FailingStaking,
         FailingDistribution,

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -25,10 +25,6 @@ pub enum BankSudo {
         to_address: String,
         amount: Vec<Coin>,
     },
-    Burn {
-        from_address: String,
-        amount: Vec<Coin>,
-    },
 }
 
 pub trait Bank: Module<ExecT = BankMsg, QueryT = BankQuery, SudoT = BankSudo> {}
@@ -166,14 +162,6 @@ impl Module for BankKeeper {
             BankSudo::Mint { to_address, amount } => {
                 let to_address = api.addr_validate(&to_address)?;
                 self.mint(&mut bank_storage, to_address, amount)?;
-                Ok(AppResponse::default())
-            }
-            BankSudo::Burn {
-                from_address,
-                amount,
-            } => {
-                let from_address = api.addr_validate(&from_address)?;
-                self.burn(&mut bank_storage, from_address, amount)?;
                 Ok(AppResponse::default())
             }
         }

--- a/packages/multi-test/src/custom_handler.rs
+++ b/packages/multi-test/src/custom_handler.rs
@@ -1,10 +1,10 @@
-use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Querier, Storage};
-
-use anyhow::Result as AnyResult;
+use anyhow::{bail, Result as AnyResult};
 use derivative::Derivative;
 use std::cell::{Ref, RefCell};
 use std::ops::Deref;
 use std::rc::Rc;
+
+use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Empty, Querier, Storage};
 
 use crate::app::CosmosRouter;
 use crate::{AppResponse, Module};
@@ -51,6 +51,7 @@ impl<ExecC, QueryC> CachingCustomHandler<ExecC, QueryC> {
 impl<Exec, Query> Module for CachingCustomHandler<Exec, Query> {
     type ExecT = Exec;
     type QueryT = Query;
+    type SudoT = Empty;
 
     // TODO: how to assert
     // where ExecC: Exec, QueryC: Query
@@ -65,6 +66,17 @@ impl<Exec, Query> Module for CachingCustomHandler<Exec, Query> {
     ) -> AnyResult<AppResponse> {
         self.state.execs.borrow_mut().push(msg);
         Ok(AppResponse::default())
+    }
+
+    fn sudo<ExecC, QueryC>(
+        &self,
+        _api: &dyn Api,
+        _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &BlockInfo,
+        msg: Self::SudoT,
+    ) -> AnyResult<AppResponse> {
+        bail!("Unexpected sudo msg {:?}", msg)
     }
 
     fn query(

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -19,7 +19,7 @@ mod transactions;
 mod untyped_msg;
 mod wasm;
 
-pub use crate::app::{custom_app, next_block, App, AppBuilder, BasicApp, Router};
+pub use crate::app::{custom_app, next_block, App, AppBuilder, BasicApp, BasicAppBuilder, Router};
 pub use crate::bank::{Bank, BankKeeper};
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};

--- a/packages/multi-test/src/module.rs
+++ b/packages/multi-test/src/module.rs
@@ -1,10 +1,12 @@
 use std::marker::PhantomData;
 
 use anyhow::{bail, Result as AnyResult};
-use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Querier, Storage};
+use cosmwasm_std::{Addr, Api, Binary, BlockInfo, CustomQuery, Querier, Storage};
 
 use crate::app::CosmosRouter;
 use crate::AppResponse;
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 
 pub trait Module {
     type ExecT;
@@ -21,7 +23,10 @@ pub trait Module {
         block: &BlockInfo,
         sender: Addr,
         msg: Self::ExecT,
-    ) -> AnyResult<AppResponse>;
+    ) -> AnyResult<AppResponse>
+    where
+        ExecC: std::fmt::Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
+        QueryC: CustomQuery + DeserializeOwned + 'static;
 
     /// sudo runs privileged actions, like minting tokens, or governance proposals.
     /// This allows modules to have full access to these privileged actions,
@@ -35,7 +40,10 @@ pub trait Module {
         router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
         block: &BlockInfo,
         msg: Self::SudoT,
-    ) -> AnyResult<AppResponse>;
+    ) -> AnyResult<AppResponse>
+    where
+        ExecC: std::fmt::Debug + Clone + PartialEq + JsonSchema + DeserializeOwned + 'static,
+        QueryC: CustomQuery + DeserializeOwned + 'static;
 
     fn query(
         &self,

--- a/packages/multi-test/src/staking.rs
+++ b/packages/multi-test/src/staking.rs
@@ -1,15 +1,26 @@
+use cosmwasm_std::{Decimal, DistributionMsg, Empty, StakingMsg, StakingQuery};
+use schemars::JsonSchema;
+
 use crate::module::FailingModule;
 use crate::Module;
-use cosmwasm_std::{DistributionMsg, Empty, StakingMsg, StakingQuery};
 
-pub trait Staking: Module<ExecT = StakingMsg, QueryT = StakingQuery> {}
+// We need to expand on this, but we will need this to properly test out staking
+#[derive(Clone, std::fmt::Debug, PartialEq, JsonSchema)]
+pub enum StakingSudo {
+    Slash {
+        validator: String,
+        percentage: Decimal,
+    },
+}
 
-pub type FailingStaking = FailingModule<StakingMsg, StakingQuery>;
+pub trait Staking: Module<ExecT = StakingMsg, QueryT = StakingQuery, SudoT = StakingSudo> {}
+
+pub type FailingStaking = FailingModule<StakingMsg, StakingQuery, StakingSudo>;
 
 impl Staking for FailingStaking {}
 
-pub trait Distribution: Module<ExecT = DistributionMsg, QueryT = Empty> {}
+pub trait Distribution: Module<ExecT = DistributionMsg, QueryT = Empty, SudoT = Empty> {}
 
-pub type FailingDistribution = FailingModule<DistributionMsg, Empty>;
+pub type FailingDistribution = FailingModule<DistributionMsg, Empty, Empty>;
 
 impl Distribution for FailingDistribution {}

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -862,13 +862,16 @@ mod test {
     use super::*;
     use crate::staking::{FailingDistribution, FailingStaking};
 
-    fn mock_router() -> Router<
+    /// Type alias for default build `Router` to make its reference in typical scenario
+    type BasicRouter<ExecC = Empty, QueryC = Empty> = Router<
         BankKeeper,
-        FailingModule<Empty, Empty>,
-        WasmKeeper<Empty, Empty>,
+        FailingModule<ExecC, QueryC, Empty>,
+        WasmKeeper<ExecC, QueryC>,
         FailingStaking,
         FailingDistribution,
-    > {
+    >;
+
+    fn mock_router() -> BasicRouter {
         Router {
             wasm: WasmKeeper::new(),
             bank: BankKeeper::new(),

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -31,6 +31,7 @@ const CONTRACTS: Map<&Addr, ContractData> = Map::new("contracts");
 pub const NAMESPACE_WASM: &[u8] = b"wasm";
 const CONTRACT_ATTR: &str = "_contract_addr";
 
+#[derive(Clone, std::fmt::Debug, PartialEq, JsonSchema)]
 pub struct WasmSudo {
     pub contract_addr: Addr,
     pub msg: Vec<u8>,

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use std::ops::Deref;
 
 use cosmwasm_std::{
-    Addr, Api, Attribute, BankMsg, Binary, BlockInfo, Coin, ContractInfo, ContractResult,
+    to_vec, Addr, Api, Attribute, BankMsg, Binary, BlockInfo, Coin, ContractInfo, ContractResult,
     CustomQuery, Deps, DepsMut, Env, Event, MessageInfo, Order, Querier, QuerierWrapper, Reply,
-    ReplyOn, Response, Storage, SubMsg, SubMsgExecutionResponse, TransactionInfo, WasmMsg,
-    WasmQuery,
+    ReplyOn, Response, StdResult, Storage, SubMsg, SubMsgExecutionResponse, TransactionInfo,
+    WasmMsg, WasmQuery,
 };
 use cosmwasm_storage::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 use prost::Message;
@@ -30,6 +30,20 @@ const CONTRACTS: Map<&Addr, ContractData> = Map::new("contracts");
 
 pub const NAMESPACE_WASM: &[u8] = b"wasm";
 const CONTRACT_ATTR: &str = "_contract_addr";
+
+pub struct WasmSudo {
+    pub contract_addr: Addr,
+    pub msg: Vec<u8>,
+}
+
+impl WasmSudo {
+    pub fn new<T: Serialize>(contract_addr: &Addr, msg: &T) -> StdResult<WasmSudo> {
+        Ok(WasmSudo {
+            contract_addr: contract_addr.clone(),
+            msg: to_vec(msg)?,
+        })
+    }
+}
 
 /// Contract Data includes information about contract, equivalent of `ContractInfo` in wasmd
 /// interface.


### PR DESCRIPTION
I came across this need when trying to implement a custom router that could perform privileged operations on contracts.

It actually seems like it can be generalised for all "governance proposals" and such as done in the sdk, which is a privileged interface to modules.

I implemented this for Wasm::Sudo and Bank::Mint

I also added a test for a CustomModule that makes these permissions calls to mint tokens (also needed by staking module) and came across a lot of usability issues with the UI, which I was able to sort out.

I am getting a much higher confidence we can start plugging in external implementations.