### PR TITLE
Fix improper assert_matches usage

### DIFF
--- a/contracts/cw1-whitelist/src/integration_tests.rs
+++ b/contracts/cw1-whitelist/src/integration_tests.rs
@@ -115,8 +115,6 @@ fn proxy_freeze_message() {
             AdminListResponse {
                 mutable,
                 ..
-            }) => {
-            assert!(!mutable)
-        }
+            }) if !mutable
     );
 }


### PR DESCRIPTION
By mistake I used incorrect pattern while adding `assert_matches` there.