### PR TITLE
Implement cw3-flex-multisig helper

### DIFF
--- a/contracts/cw3-flex-multisig/helpers.ts
+++ b/contracts/cw3-flex-multisig/helpers.ts
@@ -2,8 +2,9 @@ import axios from  "axios";
 import fs from "fs";
 import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { GasPrice, calculateFee, StdFee } from "@cosmjs/stargate";
-import {  DirectSecp256k1HdWallet, makeCosmoshubPath } from "@cosmjs/proto-signing";
+import {  DirectSecp256k1HdWallet, makeCosmoshubPath} from "@cosmjs/proto-signing";
 import { Slip10RawIndex } from "@cosmjs/crypto";
+import { Coin } from "@cosmjs/amino";
 import path from "path";
 /*
  * This is a set of helpers meant for use with @cosmjs/cli
@@ -214,7 +215,7 @@ interface MemberChangedHookMsg {
   readonly diffs: MemberDiff[];
 }
 
-type CosmosMsg = SendMsg | any
+type CosmosMsg = SendMsg | DelegateMsg | UndelegateMsg | RedelegateMsg | WithdrawMsg | any
 
 interface SendMsg {
   readonly bank: {
@@ -222,6 +223,43 @@ interface SendMsg {
       readonly from_address: string,
       readonly to_address: string,
       readonly amount: readonly Coin[],
+    }
+  }
+}
+
+interface DelegateMsg {
+  readonly staking: {
+    readonly delegate: {
+      readonly validator: string,
+      readonly amount: Coin,
+    }
+  }
+}
+
+interface UndelegateMsg {
+  readonly staking: {
+    readonly undelegate: {
+      readonly validator: string,
+      readonly amount: Coin,
+    }
+  }
+}
+
+interface RedelegateMsg {
+  readonly staking: {
+    readonly redelegate: {
+      readonly src_validator: string,
+      readonly dst_validator: string,
+      readonly amount: Coin,
+    }
+  }
+}
+
+interface WithdrawMsg {
+  readonly staking: {
+    readonly withdraw: {
+      readonly validator: string,
+      readonly recipient?: string,
     }
   }
 }


### PR DESCRIPTION
I am trying to implement cw3-flex-multisig helper.
Getting this error with current code:
```shell
▶ npx @cosmjs/cli@^0.26 --init helpers.ts
Initializing session for you. Have fun!
The following packages have been installed and can be imported:
@cosmjs/amino, @cosmjs/cosmwasm-stargate, @cosmjs/crypto, @cosmjs/encoding, @cosmjs/faucet-client, @cosmjs/launchpad, @cosmjs/math, @cosmjs/proto-signing, @cosmjs/stargate, @cosmjs/tendermint-rpc, @cosmjs/utils, axios
>> [eval].ts:80
    Vote = ;
           ^

SyntaxError: Unexpected token ';'
    at new Script (node:vm:100:7)
    at Object.executeJavaScriptAsync (/Users/orkunkl/.npm/_npx/45b61b9b8df9878c/node_modules/@cosmjs/cli/src/helpers.ts:16:18)
    at TsRepl.compileAndExecute (/Users/orkunkl/.npm/_npx/45b61b9b8df9878c/node_modules/@cosmjs/cli/src/tsrepl.ts:162:26)
    at reset (/Users/orkunkl/.npm/_npx/45b61b9b8df9878c/node_modules/@cosmjs/cli/src/tsrepl.ts:95:18)
    at TsRepl.start (/Users/orkunkl/.npm/_npx/45b61b9b8df9878c/node_modules/@cosmjs/cli/src/tsrepl.ts:98:11)
    at Object.main (/Users/orkunkl/.npm/_npx/45b61b9b8df9878c/node_modules/@cosmjs/cli/src/cli.ts:157:65)
```