### PR TITLE
Fix cw721 query_all_tokens

### DIFF
--- a/contracts/cw721-base/src/query.rs
+++ b/contracts/cw721-base/src/query.rs
@@ -113,8 +113,7 @@ where
         limit: Option<u32>,
     ) -> StdResult<TokensResponse> {
         let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-        let start_addr = maybe_addr(deps.api, start_after)?;
-        let start = start_addr.map(|addr| Bound::exclusive(addr.as_ref()));
+        let start = start_after.map(Bound::exclusive);
 
         let tokens: StdResult<Vec<String>> = self
             .tokens


### PR DESCRIPTION
`token_id` is not a valid address, `maybe_addr` throw an error