### PR TITLE
Parse reply helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ version = "0.10.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
+ "prost",
  "schemars",
  "serde",
  "thiserror",

--- a/packages/cw0/Cargo.toml
+++ b/packages/cw0/Cargo.toml
@@ -17,5 +17,7 @@ schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
+prost = "0.8.0"
+
 [dev-dependencies]
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.0" }

--- a/packages/cw0/Cargo.toml
+++ b/packages/cw0/Cargo.toml
@@ -17,7 +17,6 @@ schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
-prost = "0.8.0"
-
 [dev-dependencies]
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.0" }
+prost = "0.8.0"

--- a/packages/cw0/src/lib.rs
+++ b/packages/cw0/src/lib.rs
@@ -2,11 +2,13 @@ mod balance;
 mod event;
 mod expiration;
 mod pagination;
+mod parse_reply;
 mod payment;
 
 pub use pagination::{
     calc_range_end, calc_range_start, calc_range_start_string, maybe_addr, maybe_canonical,
 };
+pub use parse_reply::parse_reply_instantiate_data;
 pub use payment::{may_pay, must_pay, nonpayable, one_coin, PaymentError};
 
 pub use crate::balance::NativeBalance;

--- a/packages/cw0/src/lib.rs
+++ b/packages/cw0/src/lib.rs
@@ -8,7 +8,7 @@ mod payment;
 pub use pagination::{
     calc_range_end, calc_range_start, calc_range_start_string, maybe_addr, maybe_canonical,
 };
-pub use parse_reply::parse_reply_instantiate_data;
+pub use parse_reply::{parse_reply_execute_data, parse_reply_instantiate_data};
 pub use payment::{may_pay, must_pay, nonpayable, one_coin, PaymentError};
 
 pub use crate::balance::NativeBalance;

--- a/packages/cw0/src/parse_reply.rs
+++ b/packages/cw0/src/parse_reply.rs
@@ -1,0 +1,83 @@
+use prost::Message;
+use thiserror::Error;
+
+use cosmwasm_std::Reply;
+
+#[derive(Clone, PartialEq, Message)]
+pub struct MsgInstantiateContractResponse {
+    #[prost(string, tag = "1")]
+    pub contract_address: ::prost::alloc::string::String,
+    #[prost(bytes, tag = "2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+
+pub fn parse_reply_instantiate_data(
+    msg: Reply,
+) -> Result<MsgInstantiateContractResponse, ParseReplyError> {
+    let id = msg.id;
+    let res: MsgInstantiateContractResponse = Message::decode(
+        msg.result
+            .into_result()
+            .map_err(ParseReplyError::SubMsgFailure)?
+            .data
+            .ok_or_else(|| ParseReplyError::ParseFailure {
+                id,
+                err: "Missing reply data".to_owned(),
+            })?
+            .as_slice(),
+    )
+    .map_err(|err| ParseReplyError::ParseFailure {
+        id,
+        err: err.to_string(),
+    })?;
+
+    Ok(res)
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ParseReplyError {
+    #[error("Failure response from sub-message: {0}")]
+    SubMsgFailure(String),
+
+    #[error("Invalid reply from sub-message {id}: {err}")]
+    ParseFailure { id: u64, err: String },
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm_std::{ContractResult, SubMsgExecutionResponse};
+
+    #[test]
+    fn parse_reply_instantiate_data_works() {
+        let instantiate_reply_data: &str = "Contract #1";
+        let instantiate_reply = MsgInstantiateContractResponse {
+            contract_address: instantiate_reply_data.to_string(),
+            data: vec![],
+        };
+        let mut encoded_instantiate_reply =
+            Vec::<u8>::with_capacity(instantiate_reply.encoded_len());
+        // The data must encode successfully
+        instantiate_reply
+            .encode(&mut encoded_instantiate_reply)
+            .unwrap();
+
+        // Build reply message
+        let msg = Reply {
+            id: 1,
+            result: ContractResult::Ok(SubMsgExecutionResponse {
+                events: vec![],
+                data: Some(encoded_instantiate_reply.into()),
+            }),
+        };
+
+        let res = parse_reply_instantiate_data(msg).unwrap();
+        assert_eq!(
+            res,
+            MsgInstantiateContractResponse {
+                contract_address: instantiate_reply_data.into(),
+                data: vec![],
+            }
+        );
+    }
+}

--- a/packages/cw0/src/parse_reply.rs
+++ b/packages/cw0/src/parse_reply.rs
@@ -1,35 +1,57 @@
-use prost::Message;
 use thiserror::Error;
 
-use cosmwasm_std::Reply;
+use cosmwasm_std::{Binary, Reply};
 
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MsgInstantiateContractResponse {
-    #[prost(string, tag = "1")]
-    pub contract_address: ::prost::alloc::string::String,
-    #[prost(bytes, tag = "2")]
-    pub data: ::prost::alloc::vec::Vec<u8>,
+    pub contract_address: String,
+    pub data: Option<Binary>, // FIXME: Confirm if Option
 }
 
 pub fn parse_reply_instantiate_data(
     msg: Reply,
 ) -> Result<MsgInstantiateContractResponse, ParseReplyError> {
     let id = msg.id;
-    let res: MsgInstantiateContractResponse = Message::decode(
-        msg.result
-            .into_result()
-            .map_err(ParseReplyError::SubMsgFailure)?
-            .data
-            .ok_or_else(|| ParseReplyError::ParseFailure {
-                id,
-                err: "Missing reply data".to_owned(),
-            })?
-            .as_slice(),
-    )
-    .map_err(|err| ParseReplyError::ParseFailure {
-        id,
-        err: err.to_string(),
-    })?;
+    let data = msg
+        .result
+        .into_result()
+        .map_err(ParseReplyError::SubMsgFailure)?
+        .data
+        .ok_or_else(|| ParseReplyError::ParseFailure {
+            id,
+            err: "Missing reply data".to_owned(),
+        })?;
+    // Manual protobuf decoding
+    let data = data.0;
+    println!("reply data 0: {:#?}", data);
+    // FIXME: avoid panics
+    let (wire_type, data) = data.as_slice().split_at(1);
+    println!("reply data 1: {:#?}", data);
+    if wire_type[0] != b'\x0a' {
+        return Err(ParseReplyError::ParseFailure { id, err: "failed to decode Protobuf message: MsgInstantiateContractResponse.contract_address: invalid wire type".to_owned() });
+    }
+    let (len, data) = data.split_at(1);
+    println!("reply data 2: {:#?}", data);
+    let (contract_addr, data) = data.split_at(len[0] as usize);
+    println!("reply data 3: {:#?}", data);
+    let (wire_type, data) = data.split_at(1);
+    if wire_type[0] != b'\x12' {
+        return Err(ParseReplyError::ParseFailure { id, err: "failed to decode Protobuf message: MsgInstantiateContractResponse.data: invalid wire type".to_owned() });
+    }
+    let (len, data) = data.split_at(1);
+    println!("reply data 4: {:#?}", data);
+    let (data, _rest) = data.split_at(len[0] as usize);
+    println!("reply data 5: {:#?}", data);
+    let data = if data.is_empty() {
+        None
+    } else {
+        Some(Binary(data.to_vec()))
+    };
+
+    let res = MsgInstantiateContractResponse {
+        contract_address: String::from_utf8(contract_addr.to_vec())?,
+        data,
+    };
 
     Ok(res)
 }
@@ -41,19 +63,31 @@ pub enum ParseReplyError {
 
     #[error("Invalid reply from sub-message {id}: {err}")]
     ParseFailure { id: u64, err: String },
+
+    #[error("Error occurred while converting from UTF-8")]
+    FromUtf8(#[from] std::string::FromUtf8Error),
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use cosmwasm_std::{ContractResult, SubMsgExecutionResponse};
+    use prost::Message;
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct MsgInstantiateContractResponse {
+        #[prost(string, tag = "1")]
+        pub contract_address: ::prost::alloc::string::String,
+        #[prost(bytes, tag = "2")]
+        pub data: ::prost::alloc::vec::Vec<u8>,
+    }
 
     #[test]
     fn parse_reply_instantiate_data_works() {
         let instantiate_reply_data: &str = "Contract #1";
         let instantiate_reply = MsgInstantiateContractResponse {
             contract_address: instantiate_reply_data.to_string(),
-            data: vec![],
+            data: vec![1u8, 2, 3, 4],
         };
         let mut encoded_instantiate_reply =
             Vec::<u8>::with_capacity(instantiate_reply.encoded_len());
@@ -74,9 +108,9 @@ mod test {
         let res = parse_reply_instantiate_data(msg).unwrap();
         assert_eq!(
             res,
-            MsgInstantiateContractResponse {
+            super::MsgInstantiateContractResponse {
                 contract_address: instantiate_reply_data.into(),
-                data: vec![],
+                data: Some(Binary(vec![1u8, 2, 3, 4])),
             }
         );
     }


### PR DESCRIPTION
Closes #480.

Events helpers not implemented, but they don't require protobuf, so, can be deserialized directly. In any case, we can add them in a follow-up.