### PR TITLE
Release 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,128 @@
 
 ## [Unreleased](https://github.com/CosmWasm/cw-plus/tree/HEAD)
 
-[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.10.0-soon4...HEAD)
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.10.1...HEAD)
 
-## [v0.10.0](https://github.com/CosmWasm/cw-plus/tree/v0.10.0) + [v0.10.0-soon4](https://github.com/CosmWasm/cw-plus/tree/v0.10.0-soon4) +  [v0.10.0-soon3](https://github.com/CosmWasm/cw-plus/tree/v0.10.0-soon3) +  [v0.10.0-soon2](https://github.com/CosmWasm/cw-plus/tree/v0.10.0-soon2) +  [v0.10.0-soon](https://github.com/CosmWasm/cw-plus/tree/v0.10.0-soon) (2021-10-11)
+**Closed issues:**
 
-[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.9.1...v0.10.0)
+- Multitest has errors with reply data [\#516](https://github.com/CosmWasm/cw-plus/issues/516)
+
+**Merged pull requests:**
+
+- cw1-whitelist-ng: Slight messages parsing improvement [\#523](https://github.com/CosmWasm/cw-plus/pull/523) ([hashedone](https://github.com/hashedone))
+- ics20: Handle send errors with reply [\#520](https://github.com/CosmWasm/cw-plus/pull/520) ([ethanfrey](https://github.com/ethanfrey))
+- Proper execute responses [\#519](https://github.com/CosmWasm/cw-plus/pull/519) ([ethanfrey](https://github.com/ethanfrey))
+- Publish MsgInstantiate / Execute responses [\#518](https://github.com/CosmWasm/cw-plus/pull/518) ([maurolacy](https://github.com/maurolacy))
+- Fix instaniate reply data [\#517](https://github.com/CosmWasm/cw-plus/pull/517) ([ethanfrey](https://github.com/ethanfrey))
+- Use protobuf de helpers [\#515](https://github.com/CosmWasm/cw-plus/pull/515) ([maurolacy](https://github.com/maurolacy))
+- Add tests for the claims controller [\#514](https://github.com/CosmWasm/cw-plus/pull/514) ([sgoya](https://github.com/sgoya))
+- Implement cw3-flex-multisig helper [\#479](https://github.com/CosmWasm/cw-plus/pull/479) ([orkunkl](https://github.com/orkunkl))
+
+## [v0.10.1](https://github.com/CosmWasm/cw-plus/tree/v0.10.1) (2021-10-26)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.10.0...v0.10.1)
+
+**Closed issues:**
+
+- Reimplement cw1-whitelist contract in terms of semantic structures [\#494](https://github.com/CosmWasm/cw-plus/issues/494)
+- Helper transfer method failed to execute message [\#492](https://github.com/CosmWasm/cw-plus/issues/492)
+- Add helpers for parsing the protobuf MsgInstantiate and MsgExecute responses [\#480](https://github.com/CosmWasm/cw-plus/issues/480)
+
+**Merged pull requests:**
+
+- Prepare 0.10.1 release [\#513](https://github.com/CosmWasm/cw-plus/pull/513) ([ethanfrey](https://github.com/ethanfrey))
+- Added cw1-whitelist-ng to CI [\#512](https://github.com/CosmWasm/cw-plus/pull/512) ([hashedone](https://github.com/hashedone))
+- cw1-subkeys-ng: Additional follow up improvements [\#506](https://github.com/CosmWasm/cw-plus/pull/506) ([hashedone](https://github.com/hashedone))
+- Parse reply helpers [\#502](https://github.com/CosmWasm/cw-plus/pull/502) ([maurolacy](https://github.com/maurolacy))
+- cw1-whitelist-ng: Contract implementation in terms of semantical structures [\#499](https://github.com/CosmWasm/cw-plus/pull/499) ([hashedone](https://github.com/hashedone))
+- range\_de for IndexMap [\#498](https://github.com/CosmWasm/cw-plus/pull/498) ([uint](https://github.com/uint))
+- Implement range\_de for SnapshotMap [\#497](https://github.com/CosmWasm/cw-plus/pull/497) ([uint](https://github.com/uint))
+- Fix publish script [\#486](https://github.com/CosmWasm/cw-plus/pull/486) ([ethanfrey](https://github.com/ethanfrey))
+- Implement cw4-group typescript helper [\#476](https://github.com/CosmWasm/cw-plus/pull/476) ([orkunkl](https://github.com/orkunkl))
+
+## [v0.10.0](https://github.com/CosmWasm/cw-plus/tree/v0.10.0) (2021-10-11)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.10.0-soon4...v0.10.0)
 
 **Closed issues:**
 
 - Question about `MultiIndex` [\#466](https://github.com/CosmWasm/cw-plus/issues/466)
 - More multitest improvements [\#266](https://github.com/CosmWasm/cw-plus/issues/266)
 - Update to cosmwasm v1.0.0-soon2 [\#473](https://github.com/CosmWasm/cw-plus/issues/473)
+- Allow NFTs to include custom data [\#440](https://github.com/CosmWasm/cw-plus/issues/440)
+- Refactor Admin cw-controller to better represent actual functionality [\#424](https://github.com/CosmWasm/cw-plus/issues/424)
+- Implement `PrimaryKey` for `Timestamp` [\#419](https://github.com/CosmWasm/cw-plus/issues/419)
+- storage-plus: Improve in-code documentation of map primitives, in particular `MultiIndex` [\#407](https://github.com/CosmWasm/cw-plus/issues/407)
+- Remove use of dyn in multitest Router [\#404](https://github.com/CosmWasm/cw-plus/issues/404)
+- Define generic multitest module [\#387](https://github.com/CosmWasm/cw-plus/issues/387)
+
+**Merged pull requests:**
+
+- Update CHANGELOG [\#485](https://github.com/CosmWasm/cw-plus/pull/485) ([ethanfrey](https://github.com/ethanfrey))
+- Release 0.10.0 [\#483](https://github.com/CosmWasm/cw-plus/pull/483) ([ethanfrey](https://github.com/ethanfrey))
+- Upgrade CosmWasm to 1.0.0-beta [\#482](https://github.com/CosmWasm/cw-plus/pull/482) ([webmaster128](https://github.com/webmaster128))
+- Full deserialization for `range` [\#432](https://github.com/CosmWasm/cw-plus/pull/432) ([maurolacy](https://github.com/maurolacy))
+
+## [v0.10.0-soon4](https://github.com/CosmWasm/cw-plus/tree/v0.10.0-soon4) (2021-10-07)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.10.0-soon3...v0.10.0-soon4)
+
+**Fixed bugs:**
+
+- Fix improper assert\_matches usage [\#459](https://github.com/CosmWasm/cw-plus/pull/459) ([ueco-jb](https://github.com/ueco-jb))
+
+**Closed issues:**
+
+- Update to cosmwasm v1.0.0-soon2 [\#473](https://github.com/CosmWasm/cw-plus/issues/473)
 - Add ensure! macro [\#468](https://github.com/CosmWasm/cw-plus/issues/468)
 - Better return values from range/prefix [\#198](https://github.com/CosmWasm/cw-plus/issues/198)
+
+**Merged pull requests:**
+
+- Release v0.10.0-soon4 [\#477](https://github.com/CosmWasm/cw-plus/pull/477) ([ethanfrey](https://github.com/ethanfrey))
+- Update to CosmWasm 1.0.0-soon2  [\#475](https://github.com/CosmWasm/cw-plus/pull/475) ([ethanfrey](https://github.com/ethanfrey))
+- Allow error type conversions in ensure! and ensure\_eq! [\#474](https://github.com/CosmWasm/cw-plus/pull/474) ([webmaster128](https://github.com/webmaster128))
+- Improve error handling / remove FIXMEs [\#470](https://github.com/CosmWasm/cw-plus/pull/470) ([maurolacy](https://github.com/maurolacy))
+- Add ensure [\#469](https://github.com/CosmWasm/cw-plus/pull/469) ([ethanfrey](https://github.com/ethanfrey))
+- Key deserializer improvements [\#467](https://github.com/CosmWasm/cw-plus/pull/467) ([maurolacy](https://github.com/maurolacy))
+- Upgrade to cosmwasm/workspace-optimizer:0.12.3 [\#465](https://github.com/CosmWasm/cw-plus/pull/465) ([webmaster128](https://github.com/webmaster128))
+- Prefix consolidation [\#439](https://github.com/CosmWasm/cw-plus/pull/439) ([maurolacy](https://github.com/maurolacy))
+- Full deserialization for `range` [\#432](https://github.com/CosmWasm/cw-plus/pull/432) ([maurolacy](https://github.com/maurolacy))
+
+## [v0.10.0-soon3](https://github.com/CosmWasm/cw-plus/tree/v0.10.0-soon3) (2021-09-29)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.10.0-soon2...v0.10.0-soon3)
+
+**Merged pull requests:**
+
+- Prepare release v0.10.0-soon3 [\#457](https://github.com/CosmWasm/cw-plus/pull/457) ([ethanfrey](https://github.com/ethanfrey))
+- Expose essential multitest types [\#456](https://github.com/CosmWasm/cw-plus/pull/456) ([ethanfrey](https://github.com/ethanfrey))
+
+## [v0.10.0-soon2](https://github.com/CosmWasm/cw-plus/tree/v0.10.0-soon2) (2021-09-28)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.9.1...v0.10.0-soon2)
+
+**Merged pull requests:**
+
+- Release 0.10.0-soon2 [\#455](https://github.com/CosmWasm/cw-plus/pull/455) ([ethanfrey](https://github.com/ethanfrey))
+- Expose sudo powers on Router we give to Modules [\#453](https://github.com/CosmWasm/cw-plus/pull/453) ([ethanfrey](https://github.com/ethanfrey))
+- Forward port 440 demo metadata extension [\#452](https://github.com/CosmWasm/cw-plus/pull/452) ([ethanfrey](https://github.com/ethanfrey))
+- Forward port 440-customize-nft [\#451](https://github.com/CosmWasm/cw-plus/pull/451) ([ethanfrey](https://github.com/ethanfrey))
+
+## [v0.9.1](https://github.com/CosmWasm/cw-plus/tree/v0.9.1) (2021-09-23)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.10.0-soon...v0.9.1)
+
+**Closed issues:**
+
+- Allow NFTs to include custom data [\#440](https://github.com/CosmWasm/cw-plus/issues/440)
+
+## [v0.10.0-soon](https://github.com/CosmWasm/cw-plus/tree/v0.10.0-soon) (2021-09-22)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.9.0...v0.10.0-soon)
+
+**Closed issues:**
+
 - Contracts for Token Sale and Vesting period [\#444](https://github.com/CosmWasm/cw-plus/issues/444)
 - small updates on storage-plus docs [\#435](https://github.com/CosmWasm/cw-plus/issues/435)
 - Unintuitive behavior of range on multi-index [\#430](https://github.com/CosmWasm/cw-plus/issues/430)
@@ -30,23 +139,6 @@
 
 **Merged pull requests:**
 
-- Release 0.10.0 [\#483](https://github.com/CosmWasm/cw-plus/pull/483) ([ethanfrey](https://github.com/ethanfrey))
-- Upgrade CosmWasm to 1.0.0-beta [\#482](https://github.com/CosmWasm/cw-plus/pull/482) ([webmaster128](https://github.com/webmaster128))
-- Release v0.10.0-soon4 [\#477](https://github.com/CosmWasm/cw-plus/pull/477) ([ethanfrey](https://github.com/ethanfrey))
-- Update to CosmWasm 1.0.0-soon2  [\#475](https://github.com/CosmWasm/cw-plus/pull/475) ([ethanfrey](https://github.com/ethanfrey))
-- Allow error type conversions in ensure! and ensure\_eq! [\#474](https://github.com/CosmWasm/cw-plus/pull/474) ([webmaster128](https://github.com/webmaster128))
-- Improve error handling / remove FIXMEs [\#470](https://github.com/CosmWasm/cw-plus/pull/470) ([maurolacy](https://github.com/maurolacy))
-- Add ensure [\#469](https://github.com/CosmWasm/cw-plus/pull/469) ([ethanfrey](https://github.com/ethanfrey))
-- Key deserializer improvements [\#467](https://github.com/CosmWasm/cw-plus/pull/467) ([maurolacy](https://github.com/maurolacy))
-- Upgrade to cosmwasm/workspace-optimizer:0.12.3 [\#465](https://github.com/CosmWasm/cw-plus/pull/465) ([webmaster128](https://github.com/webmaster128))
-- Prefix consolidation [\#439](https://github.com/CosmWasm/cw-plus/pull/439) ([maurolacy](https://github.com/maurolacy))
-- Full deserialization for `range` [\#432](https://github.com/CosmWasm/cw-plus/pull/432) ([maurolacy](https://github.com/maurolacy))
-- Prepare release v0.10.0-soon3 [\#457](https://github.com/CosmWasm/cw-plus/pull/457) ([ethanfrey](https://github.com/ethanfrey))
-- Expose essential multitest types [\#456](https://github.com/CosmWasm/cw-plus/pull/456) ([ethanfrey](https://github.com/ethanfrey))
-- Release 0.10.0-soon2 [\#455](https://github.com/CosmWasm/cw-plus/pull/455) ([ethanfrey](https://github.com/ethanfrey))
-- Expose sudo powers on Router we give to Modules [\#453](https://github.com/CosmWasm/cw-plus/pull/453) ([ethanfrey](https://github.com/ethanfrey))
-- Forward port 440 demo metadata extension [\#452](https://github.com/CosmWasm/cw-plus/pull/452) ([ethanfrey](https://github.com/ethanfrey))
-- Forward port 440-customize-nft [\#451](https://github.com/CosmWasm/cw-plus/pull/451) ([ethanfrey](https://github.com/ethanfrey))
 - Release 0.10.0-soon [\#448](https://github.com/CosmWasm/cw-plus/pull/448) ([ethanfrey](https://github.com/ethanfrey))
 - Add proper prefix\_range helper when you want to iterate over the prefix space [\#446](https://github.com/CosmWasm/cw-plus/pull/446) ([ethanfrey](https://github.com/ethanfrey))
 - Improve in-code documentation of map primitives [\#443](https://github.com/CosmWasm/cw-plus/pull/443) ([ueco-jb](https://github.com/ueco-jb))
@@ -62,20 +154,6 @@
 - Simplify router args [\#422](https://github.com/CosmWasm/cw-plus/pull/422) ([ethanfrey](https://github.com/ethanfrey))
 - Snapshot item 2 [\#418](https://github.com/CosmWasm/cw-plus/pull/418) ([maurolacy](https://github.com/maurolacy))
 - Removing dyn from Router [\#410](https://github.com/CosmWasm/cw-plus/pull/410) ([hashedone](https://github.com/hashedone))
-
-**Fixed bugs:**
-
-- Fix improper assert\_matches usage [\#459](https://github.com/CosmWasm/cw-plus/pull/459) ([ueco-jb](https://github.com/ueco-jb))
-
-
-## [v0.9.1](https://github.com/CosmWasm/cw-plus/tree/v0.9.1) (2021-09-23)
-
-[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.10.0-soon...v0.9.1)
-
-**Closed issues:**
-
-- Allow NFTs to include custom data [\#440](https://github.com/CosmWasm/cw-plus/issues/440)
-
 
 ## [v0.9.0](https://github.com/CosmWasm/cw-plus/tree/v0.9.0) (2021-09-14)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "cw0"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "cw1"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-subkeys"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist-ng"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "cw1155"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "cw1155-base"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-atomic-swap"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-bonding"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-escrow"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-ics20"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-staking"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "cw3"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-fixed-multisig"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-flex-multisig"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "cw4"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-group"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-stake"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@
 
 | Contracts               | Download                                                                                                                      | Docs                                                                     |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------  | -------------------------------------------------------------------------|
-| cw1-subkeys             | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw1_subkeys.wasm)                        | [![Docs](https://docs.rs/cw1-subkeys/badge.svg)](https://docs.rs/cw1-subkeys)    |
-| cw1-whitelist           | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw1_whitelist.wasm)          | [![Docs](https://docs.rs/cw1-whitelist/badge.svg)](https://docs.rs/cw1-whitelist)    |
-| cw3-fixed-multisig      | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw3_fixed_multisig.wasm)          | [![Docs](https://docs.rs/cw3-fixed-multisig/badge.svg)](https://docs.rs/cw3-fixed-multisig)    |
-| cw3-flex-multisig       | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw3_flex_multisig.wasm)          | [![Docs](https://docs.rs/cw3-flex-multisig/badge.svg)](https://docs.rs/cw3-flex-multisig)    |
-| cw4-group               | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw4_group.wasm)          | [![Docs](https://docs.rs/cw4-group/badge.svg)](https://docs.rs/cw4-group)    |
-| cw4-stake               | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw4_stake.wasm)          | [![Docs](https://docs.rs/cw4-stake/badge.svg)](https://docs.rs/cw4-stake)    |
-| cw20-atomic-swap        | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw20_atomic_swap.wasm)          | [![Docs](https://docs.rs/cw20-atomic-swap/badge.svg)](https://docs.rs/cw20-atomic-swap)    |
-| cw20-base               | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw20_base.wasm)          | [![Docs](https://docs.rs/cw20-base/badge.svg)](https://docs.rs/cw20-base)    |
-| cw20-bonding            | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw20_bonding.wasm)          | [![Docs](https://docs.rs/cw20-bonding/badge.svg)](https://docs.rs/cw20-bonding)    |
-| cw20-escrow             | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw20_escrow.wasm)          | [![Docs](https://docs.rs/cw20-escrow/badge.svg)](https://docs.rs/cw20-escrow)    |
-| cw20-ics20              | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw20_ics20.wasm)          | [![Docs](https://docs.rs/cw20-ics20/badge.svg)](https://docs.rs/cw20-ics20)    |
-| cw20-staking            | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw20_staking.wasm)          | [![Docs](https://docs.rs/cw20-staking/badge.svg)](https://docs.rs/cw20-staking)    |
-| cw20-merkle-airdrop     | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw20_merkle_airdrop.wasm)          | [![Docs](https://docs.rs/cw20-merkle-airdrop/badge.svg)](https://docs.rs/cw20-merkle-airdrop)    |
-| cw1155-base             | [Release v0.10.1](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.1/cw1155_base.wasm)          | [![Docs](https://docs.rs/cw1155-base/badge.svg)](https://docs.rs/cw1155-base)    |
+| cw1-subkeys             | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw1_subkeys.wasm)                        | [![Docs](https://docs.rs/cw1-subkeys/badge.svg)](https://docs.rs/cw1-subkeys)    |
+| cw1-whitelist           | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw1_whitelist.wasm)          | [![Docs](https://docs.rs/cw1-whitelist/badge.svg)](https://docs.rs/cw1-whitelist)    |
+| cw3-fixed-multisig      | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw3_fixed_multisig.wasm)          | [![Docs](https://docs.rs/cw3-fixed-multisig/badge.svg)](https://docs.rs/cw3-fixed-multisig)    |
+| cw3-flex-multisig       | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw3_flex_multisig.wasm)          | [![Docs](https://docs.rs/cw3-flex-multisig/badge.svg)](https://docs.rs/cw3-flex-multisig)    |
+| cw4-group               | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw4_group.wasm)          | [![Docs](https://docs.rs/cw4-group/badge.svg)](https://docs.rs/cw4-group)    |
+| cw4-stake               | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw4_stake.wasm)          | [![Docs](https://docs.rs/cw4-stake/badge.svg)](https://docs.rs/cw4-stake)    |
+| cw20-atomic-swap        | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw20_atomic_swap.wasm)          | [![Docs](https://docs.rs/cw20-atomic-swap/badge.svg)](https://docs.rs/cw20-atomic-swap)    |
+| cw20-base               | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw20_base.wasm)          | [![Docs](https://docs.rs/cw20-base/badge.svg)](https://docs.rs/cw20-base)    |
+| cw20-bonding            | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw20_bonding.wasm)          | [![Docs](https://docs.rs/cw20-bonding/badge.svg)](https://docs.rs/cw20-bonding)    |
+| cw20-escrow             | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw20_escrow.wasm)          | [![Docs](https://docs.rs/cw20-escrow/badge.svg)](https://docs.rs/cw20-escrow)    |
+| cw20-ics20              | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw20_ics20.wasm)          | [![Docs](https://docs.rs/cw20-ics20/badge.svg)](https://docs.rs/cw20-ics20)    |
+| cw20-staking            | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw20_staking.wasm)          | [![Docs](https://docs.rs/cw20-staking/badge.svg)](https://docs.rs/cw20-staking)    |
+| cw20-merkle-airdrop     | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw20_merkle_airdrop.wasm)          | [![Docs](https://docs.rs/cw20-merkle-airdrop/badge.svg)](https://docs.rs/cw20-merkle-airdrop)    |
+| cw1155-base             | [Release v0.10.2](https://github.com/CosmWasm/cw-plus/releases/download/v0.10.2/cw1155_base.wasm)          | [![Docs](https://docs.rs/cw1155-base/badge.svg)](https://docs.rs/cw1155-base)    |
 
 
 Note that `cw721` and `cw721-base` have moved to the new [`cw-nfts` repo](https://github.com/CosmWasm/cw-nfts)

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-subkeys"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement subkeys for authorizing native tokens as a cw1 proxy contract"
@@ -19,16 +19,16 @@ library = []
 test-utils = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw1 = { path = "../../packages/cw1", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.10.1", features = ["library"] }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw1 = { path = "../../packages/cw1", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.10.2", features = ["library"] }
 cosmwasm-std = { version = "1.0.0-beta", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.10.1", features = ["library", "test-utils"] }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.10.2", features = ["library", "test-utils"] }

--- a/contracts/cw1-whitelist-ng/Cargo.toml
+++ b/contracts/cw1-whitelist-ng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist-ng"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Bartłomiej Kuras <bartk@confio.gmbh>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -22,20 +22,20 @@ querier = ["library"]
 multitest = ["cw-multi-test", "anyhow"]
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw1 = { path = "../../packages/cw1", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw1 = { path = "../../packages/cw1", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.10.1", optional = true }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.10.2", optional = true }
 anyhow = { version = "1", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1"
 cosmwasm-schema = { version = "1.0.0-beta" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.10.1" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.10.2" }
 derivative = "2"

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -19,11 +19,11 @@ library = []
 test-utils = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw1 = { path = "../../packages/cw1", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw1 = { path = "../../packages/cw1", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
@@ -32,5 +32,5 @@ thiserror = { version = "1.0.23" }
 anyhow = "1"
 assert_matches = "1"
 cosmwasm-schema = { version = "1.0.0-beta" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.10.1" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.10.2" }
 derivative = "2"

--- a/contracts/cw1155-base/Cargo.toml
+++ b/contracts/cw1155-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155-base"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-1155 compliant token"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw1155 = { path = "../../packages/cw1155", version = "0.10.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw1155 = { path = "../../packages/cw1155", version = "0.10.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-atomic-swap/Cargo.toml
+++ b/contracts/cw20-atomic-swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-atomic-swap"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Mauro Lacy <maurolacy@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of Atomic Swaps"
@@ -15,11 +15,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-base"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-20 compliant token"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-bonding/Cargo.toml
+++ b/contracts/cw20-bonding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-bonding"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement basic bonding curve to issue cw20 tokens"
@@ -20,11 +20,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
-cw20-base = { path = "../../contracts/cw20-base", version = "0.10.1", features = ["library"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
+cw20-base = { path = "../../contracts/cw20-base", version = "0.10.2", features = ["library"] }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta", default-features = false, features = ["staking"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-escrow/Cargo.toml
+++ b/contracts/cw20-escrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-escrow"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of an escrow that accepts CosmWasm-20 tokens as well as native tokens"
@@ -18,16 +18,16 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.10.1" }
-cw20-base = { path = "../cw20-base", version = "0.10.1", features = ["library"] }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.10.2" }
+cw20-base = { path = "../cw20-base", version = "0.10.2", features = ["library"] }

--- a/contracts/cw20-ics20/Cargo.toml
+++ b/contracts/cw20-ics20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-ics20"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "IBC Enabled contracts that receives CW20 tokens and sends them over ICS20 to a remote chain"
@@ -18,11 +18,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta", features = ["stargate"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw20-merkle-airdrop/Cargo.toml
+++ b/contracts/cw20-merkle-airdrop/Cargo.toml
@@ -19,11 +19,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw20-staking/Cargo.toml
+++ b/contracts/cw20-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-staking"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement simple staking derivatives as a cw20 token"
@@ -20,13 +20,13 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
-cw-controllers = { path = "../../packages/controllers", version = "0.10.1" }
-cw20-base = { path = "../../contracts/cw20-base", version = "0.10.1", features = ["library"] }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.10.2" }
+cw20-base = { path = "../../contracts/cw20-base", version = "0.10.2", features = ["library"] }
 cosmwasm-std = { version = "1.0.0-beta", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-fixed-multisig"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with an fixed group multisig"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw3 = { path = "../../packages/cw3", version = "0.10.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw3 = { path = "../../packages/cw3", version = "0.10.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -29,6 +29,6 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
-cw20-base = { path = "../cw20-base", version = "0.10.1", features = ["library"] }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.10.1" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
+cw20-base = { path = "../cw20-base", version = "0.10.2", features = ["library"] }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.10.2" }

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-flex-multisig"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with multiple voting patterns and dynamic groups"
@@ -18,11 +18,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw3 = { path = "../../packages/cw3", version = "0.10.1" }
-cw4 = { path = "../../packages/cw4", version = "0.10.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw3 = { path = "../../packages/cw3", version = "0.10.2" }
+cw4 = { path = "../../packages/cw4", version = "0.10.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -30,5 +30,5 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }
-cw4-group = { path = "../cw4-group", version = "0.10.1" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.10.1" }
+cw4-group = { path = "../cw4-group", version = "0.10.2" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.10.2" }

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-group"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple cw4 implementation of group membership controlled by admin "
@@ -26,11 +26,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw4 = { path = "../../packages/cw4", version = "0.10.1" }
-cw-controllers = { path = "../../packages/controllers", version = "0.10.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw4 = { path = "../../packages/cw4", version = "0.10.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.10.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-stake"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CW4 implementation of group based on staked tokens"
@@ -26,12 +26,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw2 = { path = "../../packages/cw2", version = "0.10.1" }
-cw4 = { path = "../../packages/cw4", version = "0.10.1" }
-cw20 = { path = "../../packages/cw20", version = "0.10.1" }
-cw-controllers = { path = "../../packages/controllers", version = "0.10.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw2 = { path = "../../packages/cw2", version = "0.10.2" }
+cw4 = { path = "../../packages/cw4", version = "0.10.2" }
+cw20 = { path = "../../packages/cw20", version = "0.10.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.10.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/controllers/Cargo.toml
+++ b/packages/controllers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-controllers"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common controllers we can reuse in many contracts"
@@ -13,8 +13,8 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta" }
-cw0 = { path = "../cw0", version = "0.10.1" }
-cw-storage-plus = { path = "../storage-plus", version = "0.10.1" }
+cw0 = { path = "../cw0", version = "0.10.2" }
+cw-storage-plus = { path = "../storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }

--- a/packages/cw0/Cargo.toml
+++ b/packages/cw0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw0"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common helpers for other cw specs"
@@ -18,5 +18,5 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
 [dev-dependencies]
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 prost = "0.9"

--- a/packages/cw1/Cargo.toml
+++ b/packages/cw1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1 interface"

--- a/packages/cw1155/Cargo.toml
+++ b/packages/cw1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1155 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw2"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-2 interface"
@@ -11,6 +11,6 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta", default-features = false }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw20/Cargo.toml
+++ b/packages/cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-20 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw3/Cargo.toml
+++ b/packages/cw3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw4/Cargo.toml
+++ b/packages/cw4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-4 Interface: Groups Members"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-storage-plus = { path = "../storage-plus", version = "0.10.1" }
+cw-storage-plus = { path = "../storage-plus", version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-multi-test"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Test helpers for multi-contract interactions"
@@ -18,8 +18,8 @@ staking = ["cosmwasm-std/staking"]
 backtrace = ["anyhow/backtrace"]
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.10.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.1"}
+cw0 = { path = "../../packages/cw0", version = "0.10.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.10.2"}
 cosmwasm-std = { version = "1.0.0-beta", features = ["staking"] }
 cosmwasm-storage = { version = "1.0.0-beta" }
 itertools = "0.10.1"

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-storage-plus"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Enhanced/experimental storage engines"


### PR DESCRIPTION
Let's release this with the multitest fixes, and keep the renaming of `cw0` to `utils` (along with index key deserialization stuff)  for 0.11.0.