### PR TITLE
Add `prefix_de` to `IndexedMap`

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1041,6 +1041,213 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
+    fn prefix_de_simple_string_key() {
+        let mut store = MockStorage::new();
+        let map = build_map();
+
+        // save data
+        let (pks, datas) = save_data(&mut store, &map);
+
+        // Let's prefix and iterate.
+        // This is similar to calling range() directly, but added here for completeness / prefix_de
+        // type checks
+        let all: StdResult<Vec<_>> = map
+            .prefix_de(())
+            .range_de(&store, None, None, Order::Ascending)
+            .collect();
+        let all = all.unwrap();
+        assert_eq!(
+            all,
+            pks.clone()
+                .into_iter()
+                .map(str::to_string)
+                .zip(datas.clone().into_iter())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn prefix_de_composite_key() {
+        let mut store = MockStorage::new();
+
+        let indexes = DataCompositeMultiIndex {
+            name_age: MultiIndex::new(
+                |d, k| index_triple(&d.name, d.age, k),
+                "data",
+                "data__name_age",
+            ),
+        };
+        let map = IndexedMap::new("data", indexes);
+
+        // save data
+        let data1 = Data {
+            name: "Maria".to_string(),
+            last_name: "".to_string(),
+            age: 42,
+        };
+        let pk1: (&str, &str) = ("1", "5627");
+        map.save(&mut store, pk1, &data1).unwrap();
+
+        let data2 = Data {
+            name: "Juan".to_string(),
+            last_name: "Perez".to_string(),
+            age: 13,
+        };
+        let pk2: (&str, &str) = ("2", "5628");
+        map.save(&mut store, pk2, &data2).unwrap();
+
+        let data3 = Data {
+            name: "Maria".to_string(),
+            last_name: "Young".to_string(),
+            age: 24,
+        };
+        let pk3: (&str, &str) = ("2", "5629");
+        map.save(&mut store, pk3, &data3).unwrap();
+
+        let data4 = Data {
+            name: "Maria Luisa".to_string(),
+            last_name: "Bemberg".to_string(),
+            age: 43,
+        };
+        let pk4: (&str, &str) = ("3", "5630");
+        map.save(&mut store, pk4, &data4).unwrap();
+
+        // let's prefix and iterate
+        let result: StdResult<Vec<_>> = map
+            .prefix_de("2")
+            .range_de(&store, None, None, Order::Ascending)
+            .collect();
+        let result = result.unwrap();
+        assert_eq!(
+            result,
+            [
+                ("5628".to_string(), data2.clone()),
+                ("5629".to_string(), data3.clone()),
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn prefix_de_triple_key() {
+        let mut store = MockStorage::new();
+
+        let indexes = DataCompositeMultiIndex {
+            name_age: MultiIndex::new(
+                |d, k| index_triple(&d.name, d.age, k),
+                "data",
+                "data__name_age",
+            ),
+        };
+        let map = IndexedMap::new("data", indexes);
+
+        // save data
+        let data1 = Data {
+            name: "Maria".to_string(),
+            last_name: "".to_string(),
+            age: 42,
+        };
+        let pk1: (&str, &str, &str) = ("1", "1", "5627");
+        map.save(&mut store, pk1, &data1).unwrap();
+
+        let data2 = Data {
+            name: "Juan".to_string(),
+            last_name: "Perez".to_string(),
+            age: 13,
+        };
+        let pk2: (&str, &str, &str) = ("1", "2", "5628");
+        map.save(&mut store, pk2, &data2).unwrap();
+
+        let data3 = Data {
+            name: "Maria".to_string(),
+            last_name: "Young".to_string(),
+            age: 24,
+        };
+        let pk3: (&str, &str, &str) = ("2", "1", "5629");
+        map.save(&mut store, pk3, &data3).unwrap();
+
+        let data4 = Data {
+            name: "Maria Luisa".to_string(),
+            last_name: "Bemberg".to_string(),
+            age: 43,
+        };
+        let pk4: (&str, &str, &str) = ("2", "2", "5630");
+        map.save(&mut store, pk4, &data4).unwrap();
+
+        // let's prefix and iterate
+        let result: StdResult<Vec<_>> = map
+            .prefix_de(("1", "2"))
+            .range_de(&store, None, None, Order::Ascending)
+            .collect();
+        let result = result.unwrap();
+        assert_eq!(result, [("5628".to_string(), data2.clone()),]);
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn sub_prefix_de_triple_key() {
+        let mut store = MockStorage::new();
+
+        let indexes = DataCompositeMultiIndex {
+            name_age: MultiIndex::new(
+                |d, k| index_triple(&d.name, d.age, k),
+                "data",
+                "data__name_age",
+            ),
+        };
+        let map = IndexedMap::new("data", indexes);
+
+        // save data
+        let data1 = Data {
+            name: "Maria".to_string(),
+            last_name: "".to_string(),
+            age: 42,
+        };
+        let pk1: (&str, &str, &str) = ("1", "1", "5627");
+        map.save(&mut store, pk1, &data1).unwrap();
+
+        let data2 = Data {
+            name: "Juan".to_string(),
+            last_name: "Perez".to_string(),
+            age: 13,
+        };
+        let pk2: (&str, &str, &str) = ("1", "2", "5628");
+        map.save(&mut store, pk2, &data2).unwrap();
+
+        let data3 = Data {
+            name: "Maria".to_string(),
+            last_name: "Young".to_string(),
+            age: 24,
+        };
+        let pk3: (&str, &str, &str) = ("2", "1", "5629");
+        map.save(&mut store, pk3, &data3).unwrap();
+
+        let data4 = Data {
+            name: "Maria Luisa".to_string(),
+            last_name: "Bemberg".to_string(),
+            age: 43,
+        };
+        let pk4: (&str, &str, &str) = ("2", "2", "5630");
+        map.save(&mut store, pk4, &data4).unwrap();
+
+        // let's sub-prefix and iterate
+        let result: StdResult<Vec<_>> = map
+            .sub_prefix_de("1")
+            .range_de(&store, None, None, Order::Ascending)
+            .collect();
+        let result = result.unwrap();
+        assert_eq!(
+            result,
+            [
+                (("1".to_string(), "5627".to_string()), data1.clone()),
+                (("2".to_string(), "5628".to_string()), data2.clone()),
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
     fn prefix_range_de() {
         let mut store = MockStorage::new();
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1061,7 +1061,7 @@ mod test {
             pks.clone()
                 .into_iter()
                 .map(str::to_string)
-                .zip(datas.clone().into_iter())
+                .zip(datas.into_iter())
                 .collect::<Vec<_>>()
         );
     }
@@ -1121,10 +1121,7 @@ mod test {
         let result = result.unwrap();
         assert_eq!(
             result,
-            [
-                ("5628".to_string(), data2.clone()),
-                ("5629".to_string(), data3.clone()),
-            ]
+            [("5628".to_string(), data2), ("5629".to_string(), data3),]
         );
     }
 
@@ -1181,7 +1178,7 @@ mod test {
             .range_de(&store, None, None, Order::Ascending)
             .collect();
         let result = result.unwrap();
-        assert_eq!(result, [("5628".to_string(), data2.clone()),]);
+        assert_eq!(result, [("5628".to_string(), data2),]);
     }
 
     #[test]
@@ -1240,8 +1237,8 @@ mod test {
         assert_eq!(
             result,
             [
-                (("1".to_string(), "5627".to_string()), data1.clone()),
-                (("2".to_string(), "5628".to_string()), data2.clone()),
+                (("1".to_string(), "5627".to_string()), data1),
+                (("2".to_string(), "5628".to_string()), data2),
             ]
         );
     }

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1266,7 +1266,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: (&[u8], &[u8]) = (b"1", b"5627");
+        let pk1: (&str, &str) = ("1", "5627");
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -1274,7 +1274,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: (&[u8], &[u8]) = (b"2", b"5628");
+        let pk2: (&str, &str) = ("2", "5628");
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -1282,7 +1282,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: (&[u8], &[u8]) = (b"2", b"5629");
+        let pk3: (&str, &str) = ("2", "5629");
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -1290,14 +1290,14 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: (&[u8], &[u8]) = (b"3", b"5630");
+        let pk4: (&str, &str) = ("3", "5630");
         map.save(&mut store, pk4, &data4).unwrap();
 
         // let's try to iterate!
         let result: StdResult<Vec<_>> = map
             .prefix_range_de(
                 &store,
-                Some(PrefixBound::inclusive(&b"2"[..])),
+                Some(PrefixBound::inclusive("2")),
                 None,
                 Order::Ascending,
             )
@@ -1306,9 +1306,9 @@ mod test {
         assert_eq!(
             result,
             [
-                ((b"2".to_vec(), b"5628".to_vec()), data2.clone()),
-                ((b"2".to_vec(), b"5629".to_vec()), data3.clone()),
-                ((b"3".to_vec(), b"5630".to_vec()), data4)
+                (("2".to_string(), "5628".to_string()), data2.clone()),
+                (("2".to_string(), "5629".to_string()), data3.clone()),
+                (("3".to_string(), "5630".to_string()), data4)
             ]
         );
 
@@ -1316,8 +1316,8 @@ mod test {
         let result: StdResult<Vec<_>> = map
             .prefix_range_de(
                 &store,
-                Some(PrefixBound::inclusive(&b"2"[..])),
-                Some(PrefixBound::exclusive(&b"3"[..])),
+                Some(PrefixBound::inclusive("2")),
+                Some(PrefixBound::exclusive("3")),
                 Order::Ascending,
             )
             .collect();
@@ -1325,8 +1325,8 @@ mod test {
         assert_eq!(
             result,
             [
-                ((b"2".to_vec(), b"5628".to_vec()), data2),
-                ((b"2".to_vec(), b"5629".to_vec()), data3),
+                (("2".to_string(), "5628".to_string()), data2),
+                (("2".to_string(), "5629".to_string()), data3),
             ]
         );
     }
@@ -1351,7 +1351,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: (&[u8], &[u8], &[u8]) = (b"1", b"1", b"5627");
+        let pk1: (&str, &str, &str) = ("1", "1", "5627");
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -1359,7 +1359,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: (&[u8], &[u8], &[u8]) = (b"1", b"2", b"5628");
+        let pk2: (&str, &str, &str) = ("1", "2", "5628");
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -1367,7 +1367,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: (&[u8], &[u8], &[u8]) = (b"2", b"1", b"5629");
+        let pk3: (&str, &str, &str) = ("2", "1", "5629");
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -1375,14 +1375,14 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: (&[u8], &[u8], &[u8]) = (b"2", b"2", b"5630");
+        let pk4: (&str, &str, &str) = ("2", "2", "5630");
         map.save(&mut store, pk4, &data4).unwrap();
 
-        // let's try to iterate!
+        // let's prefix-range and iterate
         let result: StdResult<Vec<_>> = map
             .prefix_range_de(
                 &store,
-                Some(PrefixBound::inclusive((&b"1"[..], &b"2"[..]))),
+                Some(PrefixBound::inclusive(("1", "2"))),
                 None,
                 Order::Ascending,
             )
@@ -1392,23 +1392,26 @@ mod test {
             result,
             [
                 (
-                    (b"1".to_vec(), b"2".to_vec(), b"5628".to_vec()),
+                    ("1".to_string(), "2".to_string(), "5628".to_string()),
                     data2.clone()
                 ),
                 (
-                    (b"2".to_vec(), b"1".to_vec(), b"5629".to_vec()),
+                    ("2".to_string(), "1".to_string(), "5629".to_string()),
                     data3.clone()
                 ),
-                ((b"2".to_vec(), b"2".to_vec(), b"5630".to_vec()), data4)
+                (
+                    ("2".to_string(), "2".to_string(), "5630".to_string()),
+                    data4
+                )
             ]
         );
 
-        // let's try to iterate over a range
+        // let's prefix-range over inclusive bounds on both sides
         let result: StdResult<Vec<_>> = map
             .prefix_range_de(
                 &store,
-                Some(PrefixBound::inclusive((&b"1"[..], &b"2"[..]))),
-                Some(PrefixBound::inclusive((&b"2"[..], &b"1"[..]))),
+                Some(PrefixBound::inclusive(("1", "2"))),
+                Some(PrefixBound::inclusive(("2", "1"))),
                 Order::Ascending,
             )
             .collect();
@@ -1416,8 +1419,14 @@ mod test {
         assert_eq!(
             result,
             [
-                ((b"1".to_vec(), b"2".to_vec(), b"5628".to_vec()), data2),
-                ((b"2".to_vec(), b"1".to_vec(), b"5629".to_vec()), data3),
+                (
+                    ("1".to_string(), "2".to_string(), "5628".to_string()),
+                    data2
+                ),
+                (
+                    ("2".to_string(), "1".to_string(), "5629".to_string()),
+                    data3
+                ),
             ]
         );
     }

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -200,6 +200,22 @@ where
 impl<'a, K, T, I> IndexedMap<'a, K, T, I>
 where
     T: Serialize + DeserializeOwned + Clone,
+    K: PrimaryKey<'a>,
+    I: IndexList<T>,
+{
+    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
+
+    pub fn prefix_de(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
+}
+
+#[cfg(feature = "iterator")]
+impl<'a, K, T, I> IndexedMap<'a, K, T, I>
+where
+    T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + KeyDeserialize,
     I: IndexList<T>,
 {
@@ -220,7 +236,7 @@ where
         K: 'c,
         K::Output: 'static,
     {
-        let mapped = namespaced_prefix_range(store, self.primary.namespace(), min, max, order)
+        let mapped = namespaced_prefix_range(store, self.pk_namespace, min, max, order)
             .map(deserialize_kv::<K, T>);
         Box::new(mapped)
     }
@@ -254,7 +270,7 @@ where
     }
 
     fn no_prefix_de(&self) -> Prefix<K, T> {
-        Prefix::new(self.primary.namespace(), &[])
+        Prefix::new(self.pk_namespace, &[])
     }
 }
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -906,7 +906,7 @@ mod test {
     }
 
     #[test]
-    fn unique_index_simple_key_range_de() {
+    fn range_de_simple_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -968,7 +968,7 @@ mod test {
     }
 
     #[test]
-    fn unique_index_composite_key_range_de() {
+    fn range_de_composite_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -1248,7 +1248,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_range_de() {
+    fn prefix_range_de_simple_key() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {


### PR DESCRIPTION
#461 follow-up. Adds `sub_`/`prefix_de` to `IndexedMap` for completeness (Addresses third part of https://github.com/CosmWasm/cw-plus/issues/461#issuecomment-961153138).