### PR TITLE
Add `range_de` to `IndexedSnapshotMap`

### DIFF
--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -217,6 +217,22 @@ where
 impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I>
 where
     T: Serialize + DeserializeOwned + Clone,
+    K: PrimaryKey<'a>,
+    I: IndexList<T>,
+{
+    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
+
+    pub fn prefix_de(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+        Prefix::new(self.pk_namespace, &p.prefix())
+    }
+}
+
+#[cfg(feature = "iterator")]
+impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I>
+where
+    T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + KeyDeserialize,
     I: IndexList<T>,
 {

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -870,7 +870,7 @@ mod test {
     }
 
     #[test]
-    fn unique_index_simple_key_range() {
+    fn range_simple_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 
@@ -901,7 +901,7 @@ mod test {
     }
 
     #[test]
-    fn unique_index_composite_key_range() {
+    fn range_composite_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 


### PR DESCRIPTION
#461 follow-up. Adds `keys_de ` / `range_de` to `IndexedSnapshotMap`. Also adds `sub_`/`prefix_de` for completeness.
(Addresses fourth part of https://github.com/CosmWasm/cw-plus/issues/461#issuecomment-961153138).