### PR TITLE
Deprecate IntKey

### DIFF
--- a/packages/storage-plus/src/de.rs
+++ b/packages/storage-plus/src/de.rs
@@ -98,7 +98,7 @@ impl KeyDeserialize for &Addr {
 
 macro_rules! integer_de {
     (for $($t:ty),+) => {
-        $(impl KeyDeserialize for IntKey<$t> {
+        $(impl KeyDeserialize for $t {
             type Output = $t;
 
             #[inline(always)]
@@ -111,6 +111,22 @@ macro_rules! integer_de {
 }
 
 integer_de!(for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+macro_rules! intkey_de {
+    (for $($t:ty),+) => {
+        $(impl KeyDeserialize for IntKey<$t> {
+            type Output = $t;
+
+            #[inline(always)]
+            fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+                Ok(<$t>::from_be_bytes(value.as_slice().try_into()
+                    .map_err(|err: TryFromSliceError| StdError::generic_err(err.to_string()))?))
+            }
+        })*
+    }
+}
+
+intkey_de!(for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 
 impl KeyDeserialize for TimestampKey {
     type Output = u64;

--- a/packages/storage-plus/src/helpers.rs
+++ b/packages/storage-plus/src/helpers.rs
@@ -7,6 +7,8 @@
 use serde::de::DeserializeOwned;
 use std::any::type_name;
 
+use crate::keys::Key;
+
 use cosmwasm_std::{
     from_slice, to_vec, Addr, Binary, ContractResult, Empty, QuerierWrapper, QueryRequest,
     StdError, StdResult, SystemResult, WasmQuery,
@@ -54,15 +56,15 @@ pub(crate) fn namespaces_with_key(namespaces: &[&[u8]], key: &[u8]) -> Vec<u8> {
 /// there are multiple sets we do not want to combine just to call this
 pub(crate) fn nested_namespaces_with_key(
     top_names: &[&[u8]],
-    sub_names: &[&[u8]],
+    sub_names: &[Key],
     key: &[u8],
 ) -> Vec<u8> {
     let mut size = key.len();
     for &namespace in top_names {
         size += namespace.len() + 2;
     }
-    for &namespace in sub_names {
-        size += namespace.len() + 2;
+    for namespace in sub_names {
+        size += namespace.as_ref().len() + 2;
     }
 
     let mut out = Vec::with_capacity(size);
@@ -70,9 +72,9 @@ pub(crate) fn nested_namespaces_with_key(
         out.extend_from_slice(&encode_length(namespace));
         out.extend_from_slice(namespace);
     }
-    for &namespace in sub_names {
-        out.extend_from_slice(&encode_length(namespace));
-        out.extend_from_slice(namespace);
+    for namespace in sub_names {
+        out.extend_from_slice(&encode_length(namespace.as_ref()));
+        out.extend_from_slice(namespace.as_ref());
     }
     out.extend_from_slice(key);
     out

--- a/packages/storage-plus/src/helpers.rs
+++ b/packages/storage-plus/src/helpers.rs
@@ -22,7 +22,7 @@ pub(crate) fn may_deserialize<T: DeserializeOwned>(
     value: &Option<Vec<u8>>,
 ) -> StdResult<Option<T>> {
     match value {
-        Some(vec) => Ok(Some(from_slice(&vec)?)),
+        Some(vec) => Ok(Some(from_slice(vec)?)),
         None => Ok(None),
     }
 }
@@ -30,7 +30,7 @@ pub(crate) fn may_deserialize<T: DeserializeOwned>(
 /// must_deserialize parses json bytes from storage (Option), returning NotFound error if no data present
 pub(crate) fn must_deserialize<T: DeserializeOwned>(value: &Option<Vec<u8>>) -> StdResult<T> {
     match value {
-        Some(vec) => from_slice(&vec),
+        Some(vec) => from_slice(vec),
         None => Err(StdError::not_found(type_name::<T>())),
     }
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -202,7 +202,7 @@ impl<'a> PrimaryKey<'a> for Vec<u8> {
     type SuperSuffix = Self;
 
     fn key(&self) -> Vec<Key> {
-        vec![Key::Ref(&self)]
+        vec![Key::Ref(self)]
     }
 }
 
@@ -572,6 +572,7 @@ mod test {
     #[test]
     fn proper_prefixes() {
         let simple: &str = "hello";
+        assert_eq!(simple.prefix().len(), 1);
         assert_eq!(simple.prefix()[0].as_ref(), b"hello");
 
         let pair: (U32Key, &[u8]) = (12345.into(), b"random");

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -517,7 +517,7 @@ mod test {
     #[test]
     fn proper_prefixes() {
         let simple: &str = "hello";
-        assert_eq!(simple.prefix(), vec![b"hello"]);
+        assert_eq!(simple.prefix()[0].as_ref(), b"hello");
 
         let pair: (U32Key, &[u8]) = (12345.into(), b"random");
         let one: Vec<u8> = vec![0, 0, 48, 57];

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -599,6 +599,45 @@ mod test {
     }
 
     #[test]
+    fn naked_8bit_prefixes() {
+        let pair: (u8, &[u8]) = (123, b"random");
+        let one: Vec<u8> = vec![123];
+        let two: Vec<u8> = b"random".to_vec();
+        assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
+
+        let pair: (i8, &[u8]) = (123, b"random");
+        let one: Vec<u8> = vec![123];
+        let two: Vec<u8> = b"random".to_vec();
+        assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
+    }
+
+    #[test]
+    fn naked_16bit_prefixes() {
+        let pair: (u16, &[u8]) = (12345, b"random");
+        let one: Vec<u8> = vec![48, 57];
+        let two: Vec<u8> = b"random".to_vec();
+        assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
+
+        let pair: (i16, &[u8]) = (12345, b"random");
+        let one: Vec<u8> = vec![48, 57];
+        let two: Vec<u8> = b"random".to_vec();
+        assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
+    }
+
+    #[test]
+    fn naked_64bit_prefixes() {
+        let pair: (u64, &[u8]) = (12345, b"random");
+        let one: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 48, 57];
+        let two: Vec<u8> = b"random".to_vec();
+        assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
+
+        let pair: (i64, &[u8]) = (12345, b"random");
+        let one: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 48, 57];
+        let two: Vec<u8> = b"random".to_vec();
+        assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
+    }
+
+    #[test]
     fn naked_proper_prefixes() {
         let pair: (u32, &[u8]) = (12345, b"random");
         let one: Vec<u8> = vec![0, 0, 48, 57];

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -433,11 +433,55 @@ mod test {
     }
 
     #[test]
-    fn naked_u32key_works() {
+    fn naked_8key_works() {
+        let k: u8 = 42u8;
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(42u8.to_be_bytes(), path[0].as_ref());
+
+        let k: i8 = 42i8;
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(42i8.to_be_bytes(), path[0].as_ref());
+    }
+
+    #[test]
+    fn naked_16key_works() {
+        let k: u16 = 4242u16;
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(4242u16.to_be_bytes(), path[0].as_ref());
+
+        let k: i16 = 4242i16;
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(4242i16.to_be_bytes(), path[0].as_ref());
+    }
+
+    #[test]
+    fn naked_32key_works() {
         let k: u32 = 4242u32;
         let path = k.key();
         assert_eq!(1, path.len());
         assert_eq!(4242u32.to_be_bytes(), path[0].as_ref());
+
+        let k: i32 = 4242i32;
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(4242i32.to_be_bytes(), path[0].as_ref());
+    }
+
+    #[test]
+    fn naked_64key_works() {
+        let k: u64 = 4242u64;
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(4242u64.to_be_bytes(), path[0].as_ref());
+
+        let k: i64 = 4242i64;
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(4242i64.to_be_bytes(), path[0].as_ref());
     }
 
     #[test]

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -63,11 +63,7 @@ pub trait PrimaryKey<'a>: Clone {
         let keys = self.key();
         let l = keys.len();
         namespaces_with_key(
-            keys[0..l - 1]
-                .iter()
-                .map(|e| e.as_ref())
-                .collect::<Vec<_>>()
-                .as_slice(),
+            &keys[0..l - 1].iter().map(Key::as_ref).collect::<Vec<_>>(),
             keys[l - 1].as_ref(),
         )
     }
@@ -469,7 +465,7 @@ mod test {
         let path = k.key();
         assert_eq!(2, path.len());
         assert_eq!(
-            path.iter().map(|e| e.as_ref()).collect::<Vec<_>>(),
+            path.iter().map(Key::as_ref).collect::<Vec<_>>(),
             vec![b"foo", b"bar"]
         );
     }
@@ -496,7 +492,7 @@ mod test {
         let path = k.key();
         assert_eq!(3, path.len());
         assert_eq!(
-            path.iter().map(|e| e.as_ref()).collect::<Vec<_>>(),
+            path.iter().map(Key::as_ref).collect::<Vec<_>>(),
             vec![first, b"bar", b"zoom"]
         );
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -161,7 +161,7 @@ impl<'a> Prefixer<'a> for () {
 
 impl<'a> Prefixer<'a> for &'a [u8] {
     fn prefix(&self) -> Vec<Key> {
-        vec![Key::Ref(self.as_ref())]
+        vec![Key::Ref(self)]
     }
 }
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -259,6 +259,23 @@ impl<'a> Prefixer<'a> for Addr {
     }
 }
 
+impl<'a> PrimaryKey<'a> for u32 {
+    type Prefix = ();
+    type SubPrefix = ();
+    type Suffix = Self;
+    type SuperSuffix = Self;
+
+    fn key(&self) -> Vec<Key> {
+        vec![Key::Val32(self.to_be_bytes())]
+    }
+}
+
+// impl<'a> Prefixer<'a> for u32 {
+//     fn prefix(&self) -> Vec<&[u8]> {
+//         vec![&self.to_be_bytes()]
+//     }
+// }
+
 // this auto-implements PrimaryKey for all the IntKey types
 impl<'a, T: Endian + Clone> PrimaryKey<'a> for IntKey<T>
 where
@@ -390,6 +407,14 @@ mod test {
     #[test]
     fn u32key_works() {
         let k: U32Key = 4242u32.into();
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(4242u32.to_be_bytes().to_vec(), path[0].as_ref().to_vec());
+    }
+
+    #[test]
+    fn u32_works() {
+        let k: u32 = 4242u32;
         let path = k.key();
         assert_eq!(1, path.len());
         assert_eq!(4242u32.to_be_bytes().to_vec(), path[0].as_ref().to_vec());

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -20,6 +20,12 @@ impl<'a> AsRef<[u8]> for Key<'a> {
     }
 }
 
+impl<'a> PartialEq<&[u8]> for Key<'a> {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.as_ref() == *other
+    }
+}
+
 /// `PrimaryKey` needs to be implemented for types that want to be a `Map` (or `Map`-like) key,
 /// or part of a key.
 ///
@@ -147,7 +153,15 @@ pub trait Prefixer<'a> {
 
     fn joined_prefix(&self) -> Vec<u8> {
         let prefixes = self.prefix();
-        namespaces_with_key(&prefixes, &[])
+        let l = prefixes.len();
+        namespaces_with_key(
+            &prefixes[0..l - 1]
+                .iter()
+                .map(|e| e.as_ref())
+                .collect::<Vec<_>>()
+                .as_slice(),
+            &[],
+        )
     }
 }
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -153,15 +153,7 @@ pub trait Prefixer<'a> {
 
     fn joined_prefix(&self) -> Vec<u8> {
         let prefixes = self.prefix();
-        let l = prefixes.len();
-        namespaces_with_key(
-            &prefixes[0..l - 1]
-                .iter()
-                .map(|e| e.as_ref())
-                .collect::<Vec<_>>()
-                .as_slice(),
-            &[],
-        )
+        namespaces_with_key(&prefixes.iter().map(Key::as_ref).collect::<Vec<_>>(), &[])
     }
 }
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -403,7 +403,7 @@ mod test {
         let k: U64Key = 134u64.into();
         let path = k.key();
         assert_eq!(1, path.len());
-        assert_eq!(134u64.to_be_bytes().to_vec(), path[0].as_ref().to_vec());
+        assert_eq!(134u64.to_be_bytes(), path[0].as_ref());
     }
 
     #[test]
@@ -411,7 +411,7 @@ mod test {
         let k: U32Key = 4242u32.into();
         let path = k.key();
         assert_eq!(1, path.len());
-        assert_eq!(4242u32.to_be_bytes().to_vec(), path[0].as_ref().to_vec());
+        assert_eq!(4242u32.to_be_bytes(), path[0].as_ref());
     }
 
     #[test]
@@ -419,7 +419,7 @@ mod test {
         let k: u32 = 4242u32;
         let path = k.key();
         assert_eq!(1, path.len());
-        assert_eq!(4242u32.to_be_bytes().to_vec(), path[0].as_ref().to_vec());
+        assert_eq!(4242u32.to_be_bytes(), path[0].as_ref());
     }
 
     #[test]
@@ -429,7 +429,7 @@ mod test {
         let k: K = "hello";
         let path = k.key();
         assert_eq!(1, path.len());
-        assert_eq!("hello".as_bytes(), path[0].as_ref());
+        assert_eq!(b"hello", path[0].as_ref());
 
         let joined = k.joined_key();
         assert_eq!(joined, b"hello")
@@ -442,7 +442,7 @@ mod test {
         let k: K = "hello".to_string();
         let path = k.key();
         assert_eq!(1, path.len());
-        assert_eq!("hello".as_bytes(), path[0].as_ref());
+        assert_eq!(b"hello", path[0].as_ref());
 
         let joined = k.joined_key();
         assert_eq!(joined, b"hello")
@@ -455,19 +455,16 @@ mod test {
         let k: K = ("hello", b"world");
         let path = k.key();
         assert_eq!(2, path.len());
-        assert_eq!("hello".as_bytes(), path[0].as_ref());
-        assert_eq!("world".as_bytes(), path[1].as_ref());
+        assert_eq!(b"hello", path[0].as_ref());
+        assert_eq!(b"world", path[1].as_ref());
     }
 
     #[test]
     fn composite_byte_key() {
-        let k: (&[u8], &[u8]) = (b"foo", b"bar");
+        let k: (&[u8], &[u8]) = ("foo".as_bytes(), b"bar");
         let path = k.key();
         assert_eq!(2, path.len());
-        assert_eq!(
-            path.iter().map(Key::as_ref).collect::<Vec<_>>(),
-            vec![b"foo", b"bar"]
-        );
+        assert_eq!(path, vec!["foo".as_bytes(), b"bar"],);
     }
 
     #[test]
@@ -479,8 +476,8 @@ mod test {
         assert_eq!(2, path.len());
         assert_eq!(4, path[0].as_ref().len());
         assert_eq!(8, path[1].as_ref().len());
-        assert_eq!(path[0].as_ref().to_vec(), 123u32.to_be_bytes().to_vec());
-        assert_eq!(path[1].as_ref().to_vec(), 87654u64.to_be_bytes().to_vec());
+        assert_eq!(path[0].as_ref(), 123u32.to_be_bytes());
+        assert_eq!(path[1].as_ref(), 87654u64.to_be_bytes());
     }
 
     #[test]
@@ -490,8 +487,8 @@ mod test {
         assert_eq!(2, path.len());
         assert_eq!(4, path[0].as_ref().len());
         assert_eq!(8, path[1].as_ref().len());
-        assert_eq!(path[0].as_ref().to_vec(), 123u32.to_be_bytes().to_vec());
-        assert_eq!(path[1].as_ref().to_vec(), 87654u64.to_be_bytes().to_vec());
+        assert_eq!(path[0].as_ref(), 123u32.to_be_bytes());
+        assert_eq!(path[1].as_ref(), 87654u64.to_be_bytes());
     }
 
     #[test]
@@ -502,10 +499,7 @@ mod test {
         let k: ((&[u8], &[u8]), &[u8]) = ((first, b"bar"), b"zoom");
         let path = k.key();
         assert_eq!(3, path.len());
-        assert_eq!(
-            path.iter().map(Key::as_ref).collect::<Vec<_>>(),
-            vec![first, b"bar", b"zoom"]
-        );
+        assert_eq!(path, vec![first, b"bar", b"zoom"]);
 
         // ensure prefix also works
         let dir = k.0.prefix();

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -415,7 +415,7 @@ mod test {
     }
 
     #[test]
-    fn u32_works() {
+    fn naked_u32key_works() {
         let k: u32 = 4242u32;
         let path = k.key();
         assert_eq!(1, path.len());
@@ -484,6 +484,17 @@ mod test {
     }
 
     #[test]
+    fn naked_composite_int_key() {
+        let k: (u32, U64Key) = (123, 87654.into());
+        let path = k.key();
+        assert_eq!(2, path.len());
+        assert_eq!(4, path[0].as_ref().len());
+        assert_eq!(8, path[1].as_ref().len());
+        assert_eq!(path[0].as_ref().to_vec(), 123u32.to_be_bytes().to_vec());
+        assert_eq!(path[1].as_ref().to_vec(), 87654u64.to_be_bytes().to_vec());
+    }
+
+    #[test]
     fn nested_composite_keys() {
         // use this to ensure proper type-casts below
         let first: &[u8] = b"foo";
@@ -524,6 +535,30 @@ mod test {
         // same works with owned variants (&str -> String, &[u8] -> Vec<u8>)
         let owned_triple: (String, U32Key, Vec<u8>) =
             ("begin".to_string(), 12345.into(), b"end".to_vec());
+        assert_eq!(
+            owned_triple.prefix(),
+            vec![one.as_slice(), two.as_slice(), three.as_slice()]
+        );
+    }
+
+    #[test]
+    fn naked_proper_prefixes() {
+        let pair: (u32, &[u8]) = (12345, b"random");
+        let one: Vec<u8> = vec![0, 0, 48, 57];
+        let two: Vec<u8> = b"random".to_vec();
+        assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
+
+        let triple: (&str, u32, &[u8]) = ("begin", 12345, b"end");
+        let one: Vec<u8> = b"begin".to_vec();
+        let two: Vec<u8> = vec![0, 0, 48, 57];
+        let three: Vec<u8> = b"end".to_vec();
+        assert_eq!(
+            triple.prefix(),
+            vec![one.as_slice(), two.as_slice(), three.as_slice()]
+        );
+
+        // same works with owned variants (&str -> String, &[u8] -> Vec<u8>)
+        let owned_triple: (String, u32, Vec<u8>) = ("begin".to_string(), 12345, b"end".to_vec());
         assert_eq!(
             owned_triple.prefix(),
             vec![one.as_slice(), two.as_slice(), three.as_slice()]

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -9,7 +9,7 @@ use crate::helpers::query_raw;
 use crate::iter_helpers::{deserialize_kv, deserialize_v};
 #[cfg(feature = "iterator")]
 use crate::keys::Prefixer;
-use crate::keys::PrimaryKey;
+use crate::keys::{Key, PrimaryKey};
 use crate::path::Path;
 #[cfg(feature = "iterator")]
 use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
@@ -45,11 +45,7 @@ where
     pub fn key(&self, k: K) -> Path<T> {
         Path::new(
             self.namespace,
-            &k.key()
-                .iter()
-                .map(|e| e.as_ref())
-                .collect::<Vec<_>>()
-                .as_slice(),
+            &k.key().iter().map(Key::as_ref).collect::<Vec<_>>(),
         )
     }
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -43,7 +43,14 @@ where
     }
 
     pub fn key(&self, k: K) -> Path<T> {
-        Path::new(self.namespace, &k.key())
+        Path::new(
+            self.namespace,
+            &k.key()
+                .iter()
+                .map(|e| e.as_ref())
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
     }
 
     #[cfg(feature = "iterator")]

--- a/packages/storage-plus/src/path.rs
+++ b/packages/storage-plus/src/path.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::marker::PhantomData;
 
 use crate::helpers::{may_deserialize, must_deserialize, nested_namespaces_with_key};
+use crate::keys::Key;
 use cosmwasm_std::{to_vec, StdError, StdResult, Storage};
 use std::ops::Deref;
 
@@ -35,7 +36,14 @@ where
     pub fn new(namespace: &[u8], keys: &[&[u8]]) -> Self {
         let l = keys.len();
         // FIXME: make this more efficient
-        let storage_key = nested_namespaces_with_key(&[namespace], &keys[0..l - 1], keys[l - 1]);
+        let storage_key = nested_namespaces_with_key(
+            &[namespace],
+            &keys[0..l - 1]
+                .iter()
+                .map(|k| Key::Ref(k))
+                .collect::<Vec<Key>>(),
+            keys[l - 1],
+        );
         Path {
             storage_key,
             data: PhantomData,

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -9,6 +9,7 @@ use std::ops::Deref;
 use crate::de::KeyDeserialize;
 use crate::helpers::{namespaces_with_key, nested_namespaces_with_key};
 use crate::iter_helpers::{concat, deserialize_kv, deserialize_v, trim};
+use crate::keys::Key;
 use crate::{Endian, Prefixer};
 
 /// Bound is used to defines the two ends of a range, more explicit than Option<u8>
@@ -117,7 +118,7 @@ where
     K: KeyDeserialize,
     T: Serialize + DeserializeOwned,
 {
-    pub fn new(top_name: &[u8], sub_names: &[&[u8]]) -> Self {
+    pub fn new(top_name: &[u8], sub_names: &[Key]) -> Self {
         Prefix::with_deserialization_function(
             top_name,
             sub_names,
@@ -128,7 +129,7 @@ where
 
     pub fn with_deserialization_function(
         top_name: &[u8],
-        sub_names: &[&[u8]],
+        sub_names: &[Key],
         pk_name: &[u8],
         de_fn: DeserializeKvFn<K, T>,
     ) -> Self {


### PR DESCRIPTION
closes #472 
Successor of https://github.com/CosmWasm/cw-plus/pull/503.

Idea is to add very small wrapper, which takes either reference or small value (of limited number of bytes).
References should be used for any slice types, while refs for `int` types.
It's basically same approach as with `IntKey`, but instead of wrapping at beginning we do it at the end (in the result).