### PR TITLE
Align tests to mock_dependencies changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 dependencies = [
  "backtrace",
 ]
@@ -46,9 +46,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
@@ -115,9 +115,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -127,15 +127,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
+checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0-beta"
+version = "1.0.0-beta2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6da9aa7d6d1f5607b184bb207ead134df3ddc99ddb1a2d8d9915b59454d535"
+checksum = "c16b255449b3f5cd7fa4b79acd5225b5185655261087a3d8aaac44f88a0e23e9"
 dependencies = [
  "digest 0.9.0",
  "ed25519-zebra",
@@ -146,18 +146,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0-beta"
+version = "1.0.0-beta2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6c5b99d05fcf047bafc0fc093e8e7b7ecb63b76791f644f5dc3eca5a548de1"
+checksum = "abad1a6ff427a2f66890a4dce6354b4563cd07cee91a942300e011c921c09ed2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0-beta"
+version = "1.0.0-beta2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e4b3f6933f94acdd3ddb931af4870c2002e3331a4a8b247a4ef070dd31ccb0"
+checksum = "fe52b19d45fe3f8359db6cc24df44dbe05e5ae32539afc0f5b7f790a21aa6fd0"
 dependencies = [
  "schemars",
  "serde_json",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0-beta"
+version = "1.0.0-beta2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7214fed59d78adc13b98e68072bf49f5273c8a6713ca98cb7784339f49ef01"
+checksum = "1660ee3d5734672e1eb4f0ceda403e2d83345e15143a48845f340f3252ce99a6"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-beta"
+version = "1.0.0-beta2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "665cf97ad42be46936f6e6739711824a9bf21c440a6c98e185a3404aef0c3b81"
+checksum = "cf3b4efe3b4f86df668520a02e9a29c23eea99b64dfcacb0e59b98346418af7f"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -206,9 +206,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e7ef8604ba15f1ea2cef61e17577e630ee39aef7f94305d138dbf1a216ada3"
+checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
  "generic-array 0.14.4",
  "rand_core 0.6.3",
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adca118c71ecd9ae094d4b68257b3fdfcb711a612b9eec7b5a0d27a5a70a5b4"
+checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
 dependencies = [
  "const-oid",
 ]
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "group"
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "memchr"
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f1028de22e436bb35fce070310ee57d57b5e59ae77b4e3f24ce4773312b813"
+checksum = "353775f96a1f400edcca737f843cb201af3645912e741e64456a257c770173e8"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -989,9 +989,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885c12e31e1e1a44805b867da9176a3a710e0c9965aeff020db13cf82ee9dbe1"
+checksum = "271ac0c667b8229adf70f0f957697c96fafd7486ab7481e15dc5e45e3e6a4368"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -1001,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd851dbc056c0aaae2b164205b502572cf082274a877436f4546e1cf4211aad"
+checksum = "6ebda811090b257411540779860bc09bf321bc587f58d2c5864309d1566214e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1059,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest 0.9.0",
  "rand_core 0.6.3",
@@ -1126,9 +1126,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1137,18 +1137,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1199,6 +1199,6 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"

--- a/contracts/cw1-subkeys/schema/all_allowances_response.json
+++ b/contracts/cw1-subkeys/schema/all_allowances_response.json
@@ -50,7 +50,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw1-subkeys/schema/allowance.json
+++ b/contracts/cw1-subkeys/schema/allowance.json
@@ -32,7 +32,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw1-subkeys/schema/execute_msg.json
+++ b/contracts/cw1-subkeys/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Execute requests the contract to re-dispatch all these messages with the contract's address as sender. Every implementation has it's own logic to determine in",
       "type": "object",
@@ -161,7 +161,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -236,7 +236,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -301,7 +301,7 @@
     },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -354,7 +354,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",
@@ -423,7 +423,7 @@
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -523,7 +523,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/contracts/cw1-subkeys/schema/query_msg.json
+++ b/contracts/cw1-subkeys/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Shows all admins and whether or not it is mutable Returns cw1-whitelist::AdminListResponse",
       "type": "object",
@@ -144,7 +144,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -219,7 +219,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -284,7 +284,7 @@
     },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -337,7 +337,7 @@
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -425,7 +425,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -598,7 +598,7 @@ mod tests {
 
         /// Initialized test case using provided config
         fn init_with_config(config: SuiteConfig) -> Self {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let admins = std::iter::once(OWNER)
                 .chain(config.admins)
                 .map(ToOwned::to_owned)
@@ -2232,7 +2232,7 @@ mod tests {
     // tests permissions and allowances are independent features and does not affect each other
     #[test]
     fn permissions_allowances_independent() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let owner = "admin0001";
         let admins = vec![owner.to_string()];

--- a/contracts/cw1-whitelist-ng/schema/cw1_exec_msg.json
+++ b/contracts/cw1-whitelist-ng/schema/cw1_exec_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw1ExecMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Execute requests the contract to re-dispatch all these messages with the contract's address as sender. Every implementation has it's own logic to determine in",
       "type": "object",
@@ -30,7 +30,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -105,7 +105,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -170,7 +170,7 @@
     },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -223,7 +223,7 @@
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -311,7 +311,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/contracts/cw1-whitelist-ng/schema/cw1_query_msg.json
+++ b/contracts/cw1-whitelist-ng/schema/cw1_query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw1QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Checks permissions of the caller on this proxy. If CanExecute returns true then a call to `Execute` with the same message, before any further state changes, should also succeed.",
       "type": "object",
@@ -31,7 +31,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -106,7 +106,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -171,7 +171,7 @@
     },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -224,7 +224,7 @@
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -312,7 +312,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/contracts/cw1-whitelist-ng/schema/whitelist_exec_msg.json
+++ b/contracts/cw1-whitelist-ng/schema/whitelist_exec_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "WhitelistExecMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Freeze will make a mutable contract immutable, must be called by an admin",
       "type": "object",

--- a/contracts/cw1-whitelist-ng/schema/whitelist_query_msg.json
+++ b/contracts/cw1-whitelist-ng/schema/whitelist_query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "WhitelistQueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Shows all admins and whether or not it is mutable",
       "type": "object",

--- a/contracts/cw1-whitelist-ng/src/contract.rs
+++ b/contracts/cw1-whitelist-ng/src/contract.rs
@@ -213,7 +213,7 @@ mod tests {
     fn instantiate_and_modify_config() {
         let contract = Cw1WhitelistContract::native();
 
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let alice = "alice";
         let bob = "bob";
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn execute_messages_has_proper_permissions() {
         let contract = Cw1WhitelistContract::native();
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let alice = "alice";
         let bob = "bob";
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn execute_custom_messages_works() {
         let contract = Cw1WhitelistContract::<String>::new();
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let alice = "alice";
 
         let admins = vec![alice.to_owned()];
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn can_execute_query_works() {
         let contract = Cw1WhitelistContract::native();
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let alice = "alice";
         let bob = "bob";

--- a/contracts/cw1-whitelist/schema/execute_msg.json
+++ b/contracts/cw1-whitelist/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Execute requests the contract to re-dispatch all these messages with the contract's address as sender. Every implementation has it's own logic to determine in",
       "type": "object",
@@ -67,7 +67,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -142,7 +142,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -207,7 +207,7 @@
     },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -260,7 +260,7 @@
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -348,7 +348,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/contracts/cw1-whitelist/schema/query_msg.json
+++ b/contracts/cw1-whitelist/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Shows all admins and whether or not it is mutable",
       "type": "object",
@@ -44,7 +44,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -119,7 +119,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -184,7 +184,7 @@
     },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -237,7 +237,7 @@
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -325,7 +325,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/contracts/cw1-whitelist/src/contract.rs
+++ b/contracts/cw1-whitelist/src/contract.rs
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn instantiate_and_modify_config() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let alice = "alice";
         let bob = "bob";
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn execute_messages_has_proper_permissions() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let alice = "alice";
         let bob = "bob";
@@ -268,7 +268,7 @@ mod tests {
 
     #[test]
     fn can_execute_query_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let alice = "alice";
         let bob = "bob";

--- a/contracts/cw1155-base/schema/approved_for_all_response.json
+++ b/contracts/cw1155-base/schema/approved_for_all_response.json
@@ -37,7 +37,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw1155-base/schema/cw1155_execute_msg.json
+++ b/contracts/cw1155-base/schema/cw1155_execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw1155ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "SendFrom is a base message to move tokens, if `env.sender` is the owner or has sufficient pre-approval.",
       "type": "object",
@@ -319,7 +319,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw1155-base/schema/cw1155_query_msg.json
+++ b/contracts/cw1155-base/schema/cw1155_query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw1155QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Returns the current balance of the given address, 0 if unset. Return type: BalanceResponse.",
       "type": "object",

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -573,7 +573,7 @@ mod tests {
         let user1 = String::from("user1");
         let user2 = String::from("user2");
 
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             minter: minter.clone(),
         };
@@ -897,7 +897,7 @@ mod tests {
         let token2 = "token2".to_owned();
         let dummy_msg = Binary::default();
 
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             minter: minter.clone(),
         };
@@ -990,7 +990,7 @@ mod tests {
         let users = (0..10).map(|i| format!("user{}", i)).collect::<Vec<_>>();
         let minter = String::from("minter");
 
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let msg = InstantiateMsg {
             minter: minter.clone(),
         };
@@ -1102,7 +1102,7 @@ mod tests {
 
     #[test]
     fn approval_expires() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let token1 = "token1".to_owned();
         let minter = String::from("minter");
         let user1 = String::from("user1");
@@ -1181,7 +1181,7 @@ mod tests {
 
     #[test]
     fn mint_overflow() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let token1 = "token1".to_owned();
         let minter = String::from("minter");
         let user1 = String::from("user1");

--- a/contracts/cw20-atomic-swap/schema/details_response.json
+++ b/contracts/cw20-atomic-swap/schema/details_response.json
@@ -46,7 +46,7 @@
   },
   "definitions": {
     "BalanceHuman": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -108,7 +108,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-atomic-swap/schema/execute_msg.json
+++ b/contracts/cw20-atomic-swap/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -133,7 +133,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-atomic-swap/schema/query_msg.json
+++ b/contracts/cw20-atomic-swap/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Show all open swaps. Return type is ListResponse.",
       "type": "object",

--- a/contracts/cw20-atomic-swap/src/contract.rs
+++ b/contracts/cw20-atomic-swap/src/contract.rs
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_instantiate() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // Instantiate an empty contract
         let instantiate_msg = InstantiateMsg {};
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_create() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let info = mock_info("anyone", &[]);
         instantiate(deps.as_mut(), mock_env(), info, InstantiateMsg {}).unwrap();
@@ -391,7 +391,7 @@ mod tests {
 
     #[test]
     fn test_release() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let info = mock_info("anyone", &[]);
         instantiate(deps.as_mut(), mock_env(), info, InstantiateMsg {}).unwrap();
@@ -478,7 +478,7 @@ mod tests {
 
     #[test]
     fn test_refund() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let info = mock_info("anyone", &[]);
         instantiate(deps.as_mut(), mock_env(), info, InstantiateMsg {}).unwrap();
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn test_query() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let info = mock_info("anyone", &[]);
         instantiate(deps.as_mut(), mock_env(), info, InstantiateMsg {}).unwrap();
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn test_native_cw20_swap() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // Create the contract
         let info = mock_info("anyone", &[]);

--- a/contracts/cw20-base/schema/all_allowances_response.json
+++ b/contracts/cw20-base/schema/all_allowances_response.json
@@ -35,7 +35,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-base/schema/allowance_response.json
+++ b/contracts/cw20-base/schema/allowance_response.json
@@ -17,7 +17,7 @@
   "definitions": {
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-base/schema/cw20_execute_msg.json
+++ b/contracts/cw20-base/schema/cw20_execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Transfer is a base message to move tokens to another account without triggering actions",
       "type": "object",
@@ -316,7 +316,7 @@
     },
     "EmbeddedLogo": {
       "description": "This is used to store the logo on the blockchain in an accepted format. Enforce maximum size of 5KB on all variants.",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Store the Logo as an SVG file. The content must conform to the spec at https://en.wikipedia.org/wiki/Scalable_Vector_Graphics (The contract should do some light-weight sanity-check validation)",
           "type": "object",
@@ -347,7 +347,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",
@@ -393,7 +393,7 @@
     },
     "Logo": {
       "description": "This is used for uploading logo data, or setting it in InstantiateData",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.",
           "type": "object",

--- a/contracts/cw20-base/schema/instantiate_msg.json
+++ b/contracts/cw20-base/schema/instantiate_msg.json
@@ -69,7 +69,7 @@
     },
     "EmbeddedLogo": {
       "description": "This is used to store the logo on the blockchain in an accepted format. Enforce maximum size of 5KB on all variants.",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Store the Logo as an SVG file. The content must conform to the spec at https://en.wikipedia.org/wiki/Scalable_Vector_Graphics (The contract should do some light-weight sanity-check validation)",
           "type": "object",
@@ -133,7 +133,7 @@
     },
     "Logo": {
       "description": "This is used for uploading logo data, or setting it in InstantiateData",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.",
           "type": "object",

--- a/contracts/cw20-base/schema/query_msg.json
+++ b/contracts/cw20-base/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Returns the current balance of the given address, 0 if unset. Return type: BalanceResponse.",
       "type": "object",

--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -243,7 +243,7 @@ pub fn query_allowance(deps: Deps, owner: String, spender: String) -> StdResult<
 mod tests {
     use super::*;
 
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{mock_dependencies_with_balance, mock_env, mock_info};
     use cosmwasm_std::{coins, CosmosMsg, SubMsg, Timestamp, WasmMsg};
     use cw20::{Cw20Coin, TokenInfoResponse};
 
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn increase_decrease_allowances() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
 
         let owner = String::from("addr0001");
         let spender = String::from("addr0002");
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn allowances_independent() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
 
         let owner = String::from("addr0001");
         let spender = String::from("addr0002");
@@ -456,7 +456,7 @@ mod tests {
 
     #[test]
     fn no_self_allowance() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
 
         let owner = String::from("addr0001");
         let info = mock_info(owner.as_ref(), &[]);
@@ -484,7 +484,7 @@ mod tests {
 
     #[test]
     fn transfer_from_respects_limits() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies_with_balance(&[]);
         let owner = String::from("addr0001");
         let spender = String::from("addr0002");
         let rcpt = String::from("addr0003");
@@ -565,7 +565,7 @@ mod tests {
 
     #[test]
     fn burn_from_respects_limits() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies_with_balance(&[]);
         let owner = String::from("addr0001");
         let spender = String::from("addr0002");
 
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     fn send_from_respects_limits() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies_with_balance(&[]);
         let owner = String::from("addr0001");
         let spender = String::from("addr0002");
         let contract = String::from("cool-dex");

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -521,7 +521,9 @@ pub fn query_download_logo(deps: Deps) -> StdResult<DownloadLogoResponse> {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{
+        mock_dependencies, mock_dependencies_with_balance, mock_env, mock_info,
+    };
     use cosmwasm_std::{coins, from_binary, Addr, CosmosMsg, StdError, SubMsg, WasmMsg};
 
     use super::*;
@@ -600,7 +602,7 @@ mod tests {
 
         #[test]
         fn basic() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let amount = Uint128::from(11223344u128);
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
@@ -635,7 +637,7 @@ mod tests {
 
         #[test]
         fn mintable() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let amount = Uint128::new(11223344);
             let minter = String::from("asmodat");
             let limit = Uint128::new(511223344);
@@ -682,7 +684,7 @@ mod tests {
 
         #[test]
         fn mintable_over_cap() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let amount = Uint128::new(11223344);
             let minter = String::from("asmodat");
             let limit = Uint128::new(11223300);
@@ -714,7 +716,7 @@ mod tests {
 
             #[test]
             fn basic() {
-                let mut deps = mock_dependencies(&[]);
+                let mut deps = mock_dependencies();
                 let instantiate_msg = InstantiateMsg {
                     name: "Cash Token".to_string(),
                     symbol: "CASH".to_string(),
@@ -754,7 +756,7 @@ mod tests {
 
             #[test]
             fn invalid_marketing() {
-                let mut deps = mock_dependencies(&[]);
+                let mut deps = mock_dependencies();
                 let instantiate_msg = InstantiateMsg {
                     name: "Cash Token".to_string(),
                     symbol: "CASH".to_string(),
@@ -785,7 +787,7 @@ mod tests {
 
     #[test]
     fn can_mint_by_minter() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let genesis = String::from("genesis");
         let amount = Uint128::new(11223344);
@@ -832,7 +834,7 @@ mod tests {
 
     #[test]
     fn others_cannot_mint() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate_with_minter(
             deps.as_mut(),
             &String::from("genesis"),
@@ -853,7 +855,7 @@ mod tests {
 
     #[test]
     fn no_one_mints_if_minter_unset() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut(), &String::from("genesis"), Uint128::new(1234));
 
         let msg = ExecuteMsg::Mint {
@@ -868,7 +870,7 @@ mod tests {
 
     #[test]
     fn instantiate_multiple_accounts() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let amount1 = Uint128::from(11223344u128);
         let addr1 = String::from("addr0001");
         let amount2 = Uint128::from(7890987u128);
@@ -910,7 +912,7 @@ mod tests {
 
     #[test]
     fn queries_work() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
         let addr1 = String::from("addr0001");
         let amount1 = Uint128::from(12340000u128);
 
@@ -947,7 +949,7 @@ mod tests {
 
     #[test]
     fn transfer() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
         let addr1 = String::from("addr0001");
         let addr2 = String::from("addr0002");
         let amount1 = Uint128::from(12340000u128);
@@ -1007,7 +1009,7 @@ mod tests {
 
     #[test]
     fn burn() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
         let addr1 = String::from("addr0001");
         let amount1 = Uint128::from(12340000u128);
         let burn = Uint128::from(76543u128);
@@ -1056,7 +1058,7 @@ mod tests {
 
     #[test]
     fn send() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
         let addr1 = String::from("addr0001");
         let contract = String::from("addr0002");
         let amount1 = Uint128::from(12340000u128);
@@ -1133,7 +1135,7 @@ mod tests {
 
         #[test]
         fn update_unauthorised() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1187,7 +1189,7 @@ mod tests {
 
         #[test]
         fn update_project() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1240,7 +1242,7 @@ mod tests {
 
         #[test]
         fn clear_project() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1293,7 +1295,7 @@ mod tests {
 
         #[test]
         fn update_description() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1346,7 +1348,7 @@ mod tests {
 
         #[test]
         fn clear_description() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1399,7 +1401,7 @@ mod tests {
 
         #[test]
         fn update_marketing() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1452,7 +1454,7 @@ mod tests {
 
         #[test]
         fn update_marketing_invalid() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1509,7 +1511,7 @@ mod tests {
 
         #[test]
         fn clear_marketing() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1562,7 +1564,7 @@ mod tests {
 
         #[test]
         fn update_logo_url() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1611,7 +1613,7 @@ mod tests {
 
         #[test]
         fn update_logo_png() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1661,7 +1663,7 @@ mod tests {
 
         #[test]
         fn update_logo_svg() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1712,7 +1714,7 @@ mod tests {
 
         #[test]
         fn update_logo_png_oversized() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1762,7 +1764,7 @@ mod tests {
 
         #[test]
         fn update_logo_svg_oversized() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1819,7 +1821,7 @@ mod tests {
 
         #[test]
         fn update_logo_png_invalid() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),
@@ -1869,7 +1871,7 @@ mod tests {
 
         #[test]
         fn update_logo_svg_invalid() {
-            let mut deps = mock_dependencies(&[]);
+            let mut deps = mock_dependencies();
             let instantiate_msg = InstantiateMsg {
                 name: "Cash Token".to_string(),
                 symbol: "CASH".to_string(),

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -59,7 +59,7 @@ pub fn query_all_accounts(
 mod tests {
     use super::*;
 
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::testing::{mock_dependencies_with_balance, mock_env, mock_info};
     use cosmwasm_std::{coins, DepsMut, Uint128};
     use cw20::{Cw20Coin, Expiration, TokenInfoResponse};
 
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     fn query_all_allowances_works() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
 
         let owner = String::from("owner");
         // these are in alphabetical order same than insert order
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn query_all_accounts_works() {
-        let mut deps = mock_dependencies(&coins(2, "token"));
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
 
         // insert order and lexicographical order are different
         let acct1 = String::from("acct01");

--- a/contracts/cw20-bonding/schema/allowance_response.json
+++ b/contracts/cw20-bonding/schema/allowance_response.json
@@ -17,7 +17,7 @@
   "definitions": {
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-bonding/schema/execute_msg.json
+++ b/contracts/cw20-bonding/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Buy will attempt to purchase as many supply tokens as possible. You must send only reserve tokens in that message",
       "type": "object",
@@ -255,7 +255,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-bonding/schema/instantiate_msg.json
+++ b/contracts/cw20-bonding/schema/instantiate_msg.json
@@ -46,7 +46,7 @@
   },
   "definitions": {
     "CurveType": {
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Constant always returns `value * 10^-scale` as spot price",
           "type": "object",

--- a/contracts/cw20-bonding/schema/query_msg.json
+++ b/contracts/cw20-bonding/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Returns the reserve and supply quantities, as well as the spot price to buy 1 token",
       "type": "object",

--- a/contracts/cw20-bonding/src/contract.rs
+++ b/contracts/cw20-bonding/src/contract.rs
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn proper_instantiation() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // this matches `linear_curve` test case from curves.rs
         let creator = String::from("creator");
@@ -393,7 +393,7 @@ mod tests {
 
     #[test]
     fn buy_issues_tokens() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let curve_type = CurveType::Linear {
             slope: Uint128::new(1),
             scale: 1,
@@ -443,7 +443,7 @@ mod tests {
 
     #[test]
     fn bonding_fails_with_wrong_denom() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let curve_type = CurveType::Linear {
             slope: Uint128::new(1),
             scale: 1,
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn burning_sends_reserve() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let curve_type = CurveType::Linear {
             slope: Uint128::new(1),
             scale: 1,
@@ -531,7 +531,7 @@ mod tests {
 
     #[test]
     fn cw20_imports_work() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let curve_type = CurveType::Constant {
             value: Uint128::new(15),
             scale: 1,

--- a/contracts/cw20-escrow/schema/execute_msg.json
+++ b/contracts/cw20-escrow/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/cw20-escrow/schema/query_msg.json
+++ b/contracts/cw20-escrow/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Show all open escrows. Return type is ListResponse.",
       "type": "object",

--- a/contracts/cw20-escrow/schema/receive_msg.json
+++ b/contracts/cw20-escrow/schema/receive_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ReceiveMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/cw20-escrow/src/contract.rs
+++ b/contracts/cw20-escrow/src/contract.rs
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn happy_path_native() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // instantiate an empty contract
         let instantiate_msg = InstantiateMsg {};
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn happy_path_cw20() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // instantiate an empty contract
         let instantiate_msg = InstantiateMsg {};
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn top_up_mixed_tokens() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // instantiate an empty contract
         let instantiate_msg = InstantiateMsg {};

--- a/contracts/cw20-ics20/schema/channel_response.json
+++ b/contracts/cw20-ics20/schema/channel_response.json
@@ -33,7 +33,7 @@
   },
   "definitions": {
     "Amount": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/contracts/cw20-ics20/schema/execute_msg.json
+++ b/contracts/cw20-ics20/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "This accepts a properly-encoded ReceiveMsg from a cw20 contract",
       "type": "object",

--- a/contracts/cw20-ics20/schema/query_msg.json
+++ b/contracts/cw20-ics20/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Return the port ID bound by this contract. Returns PortResponse",
       "type": "object",

--- a/contracts/cw20-ics20/src/test_helpers.rs
+++ b/contracts/cw20-ics20/src/test_helpers.rs
@@ -55,7 +55,7 @@ pub fn add_channel(mut deps: DepsMut, channel_id: &str) {
 }
 
 pub fn setup(channels: &[&str]) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
-    let mut deps = mock_dependencies(&[]);
+    let mut deps = mock_dependencies();
 
     // instantiate an empty contract
     let instantiate_msg = InitMsg {

--- a/contracts/cw20-merkle-airdrop/schema/execute_msg.json
+++ b/contracts/cw20-merkle-airdrop/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/cw20-merkle-airdrop/schema/query_msg.json
+++ b/contracts/cw20-merkle-airdrop/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/cw20-merkle-airdrop/src/contract.rs
+++ b/contracts/cw20-merkle-airdrop/src/contract.rs
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn proper_instantiation() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg {
             owner: Some("owner0000".to_string()),
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn update_config() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg {
             owner: None,
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn register_merkle_root() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg {
             owner: Some("owner0000".to_string()),
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn claim() {
         // Run test 1
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let test_data: Encoded = from_slice(TEST_DATA_1).unwrap();
 
         let msg = InstantiateMsg {
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn owner_freeze() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let msg = InstantiateMsg {
             owner: Some("owner0000".to_string()),

--- a/contracts/cw20-staking/schema/allowance_response.json
+++ b/contracts/cw20-staking/schema/allowance_response.json
@@ -17,7 +17,7 @@
   "definitions": {
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-staking/schema/claims_response.json
+++ b/contracts/cw20-staking/schema/claims_response.json
@@ -31,7 +31,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-staking/schema/execute_msg.json
+++ b/contracts/cw20-staking/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Bond will bond all staking tokens sent with the message and release derivative tokens",
       "type": "object",
@@ -315,7 +315,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw20-staking/schema/instantiate_msg.json
+++ b/contracts/cw20-staking/schema/instantiate_msg.json
@@ -62,7 +62,7 @@
     },
     "Duration": {
       "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/contracts/cw20-staking/schema/query_msg.json
+++ b/contracts/cw20-staking/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Claims shows the number of tokens this address can access when they are done unbonding",
       "type": "object",

--- a/contracts/cw20-staking/src/contract.rs
+++ b/contracts/cw20-staking/src/contract.rs
@@ -512,7 +512,7 @@ mod tests {
 
     #[test]
     fn instantiation_with_missing_validator() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         deps.querier
             .update_staking("ustake", &[sample_validator("john")], &[]);
 
@@ -540,7 +540,7 @@ mod tests {
 
     #[test]
     fn proper_instantiation() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         deps.querier.update_staking(
             "ustake",
             &[
@@ -593,7 +593,7 @@ mod tests {
 
     #[test]
     fn bonding_issues_tokens() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         let creator = String::from("creator");
@@ -637,7 +637,7 @@ mod tests {
 
     #[test]
     fn rebonding_changes_pricing() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         let creator = String::from("creator");
@@ -696,7 +696,7 @@ mod tests {
 
     #[test]
     fn bonding_fails_with_wrong_denom() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         let creator = String::from("creator");
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn unbonding_maintains_price_ratio() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         let creator = String::from("creator");
@@ -818,7 +818,7 @@ mod tests {
 
     #[test]
     fn claims_paid_out_properly() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         // create contract
@@ -885,7 +885,7 @@ mod tests {
 
     #[test]
     fn cw20_imports_work() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         set_validator(&mut deps.querier);
 
         // set the actors... bob stakes, sends coins to carl, and gives allowance to alice

--- a/contracts/cw3-fixed-multisig/schema/execute_msg.json
+++ b/contracts/cw3-fixed-multisig/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -117,7 +117,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -192,7 +192,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -257,7 +257,7 @@
     },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -310,7 +310,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",
@@ -356,7 +356,7 @@
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -465,7 +465,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/contracts/cw3-fixed-multisig/schema/instantiate_msg.json
+++ b/contracts/cw3-fixed-multisig/schema/instantiate_msg.json
@@ -26,7 +26,7 @@
   "definitions": {
     "Duration": {
       "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/contracts/cw3-fixed-multisig/schema/query_msg.json
+++ b/contracts/cw3-fixed-multisig/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Return ThresholdResponse",
       "type": "object",

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -519,7 +519,7 @@ mod tests {
 
     #[test]
     fn test_instantiate_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let info = mock_info(OWNER, &[]);
 
         let max_voting_period = Duration::Time(1234567);
@@ -573,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_propose_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let required_weight = 4;
         let voting_period = Duration::Time(2000000);
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_vote_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let required_weight = 3;
         let voting_period = Duration::Time(2000000);
@@ -753,7 +753,7 @@ mod tests {
 
     #[test]
     fn test_execute_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let required_weight = 3;
         let voting_period = Duration::Time(2000000);
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn test_close_works() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let required_weight = 3;
         let voting_period = Duration::Height(2000000);

--- a/contracts/cw3-flex-multisig/schema/execute_msg.json
+++ b/contracts/cw3-flex-multisig/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -130,7 +130,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -205,7 +205,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -270,7 +270,7 @@
     },
     "DistributionMsg": {
       "description": "The message types of the distribution module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -323,7 +323,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",
@@ -412,7 +412,7 @@
     },
     "StakingMsg": {
       "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -521,7 +521,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/contracts/cw3-flex-multisig/schema/instantiate_msg.json
+++ b/contracts/cw3-flex-multisig/schema/instantiate_msg.json
@@ -25,7 +25,7 @@
     },
     "Duration": {
       "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -59,7 +59,7 @@
     },
     "Threshold": {
       "description": "This defines the different ways tallies can happen.\n\nThe total_weight used for calculating success as well as the weights of each individual voter used in tallying should be snapshotted at the beginning of the block at which the proposal starts (this is likely the responsibility of a correct cw4 implementation). See also `ThresholdResponse` in the cw3 spec.",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Declares that a fixed weight of Yes votes is needed to pass. See `ThresholdResponse.AbsoluteCount` in the cw3 spec for details.",
           "type": "object",

--- a/contracts/cw3-flex-multisig/schema/query_msg.json
+++ b/contracts/cw3-flex-multisig/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Return ThresholdResponse",
       "type": "object",

--- a/contracts/cw4-group/schema/execute_msg.json
+++ b/contracts/cw4-group/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Change the admin",
       "type": "object",

--- a/contracts/cw4-group/schema/query_msg.json
+++ b/contracts/cw4-group/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Return AdminResponse",
       "type": "object",

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn proper_instantiation() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
         // it worked, let's query the state
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn try_member_queries() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
         let member1 = query_member(deps.as_ref(), USER1.into(), None).unwrap();
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn add_new_remove_old_member() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
         // add a new one and remove existing one
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn add_old_remove_new_member() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
         // add a new one and remove existing one
@@ -379,7 +379,7 @@ mod tests {
     #[test]
     fn add_and_remove_same_member() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
         // USER1 is updated and remove in the same call, we should remove this an add member3
@@ -411,7 +411,7 @@ mod tests {
     #[test]
     fn add_remove_hooks() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
         let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn hooks_fire() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
         let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
@@ -537,7 +537,7 @@ mod tests {
     #[test]
     fn raw_queries_work() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
         // get total from raw key

--- a/contracts/cw4-stake/schema/claims_response.json
+++ b/contracts/cw4-stake/schema/claims_response.json
@@ -31,7 +31,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/contracts/cw4-stake/schema/execute_msg.json
+++ b/contracts/cw4-stake/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Bond will bond all staking tokens sent with the message and update membership weight",
       "type": "object",

--- a/contracts/cw4-stake/schema/instantiate_msg.json
+++ b/contracts/cw4-stake/schema/instantiate_msg.json
@@ -39,7 +39,7 @@
       "type": "string"
     },
     "Denom": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -68,7 +68,7 @@
     },
     "Duration": {
       "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/contracts/cw4-stake/schema/query_msg.json
+++ b/contracts/cw4-stake/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Claims shows the tokens in process of unbonding for this address",
       "type": "object",

--- a/contracts/cw4-stake/schema/receive_msg.json
+++ b/contracts/cw4-stake/schema/receive_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ReceiveMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Only valid cw20 message is to bond the tokens",
       "type": "object",

--- a/contracts/cw4-stake/schema/staked_response.json
+++ b/contracts/cw4-stake/schema/staked_response.json
@@ -20,7 +20,7 @@
       "type": "string"
     },
     "Denom": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [

--- a/contracts/cw4-stake/src/contract.rs
+++ b/contracts/cw4-stake/src/contract.rs
@@ -466,7 +466,7 @@ mod tests {
 
     #[test]
     fn proper_instantiation() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         default_instantiate(deps.as_mut());
 
         // it worked, let's query the state
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn bond_stake_adds_membership() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         default_instantiate(deps.as_mut());
         let height = mock_env().block.height;
 
@@ -566,7 +566,7 @@ mod tests {
 
     #[test]
     fn unbond_stake_update_membership() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         default_instantiate(deps.as_mut());
         let height = mock_env().block.height;
 
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn cw20_token_bond() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         cw20_instantiate(deps.as_mut(), Duration::Height(2000));
 
         // Assert original weights
@@ -629,7 +629,7 @@ mod tests {
         let unbonding_period: u64 = 50;
         let unbond_height: u64 = 10;
 
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let unbonding = Duration::Height(unbonding_period);
         cw20_instantiate(deps.as_mut(), unbonding);
 
@@ -686,7 +686,7 @@ mod tests {
     #[test]
     fn raw_queries_work() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         default_instantiate(deps.as_mut());
         // Set values as (11, 6, None)
         bond(deps.as_mut(), 11_000, 6_000, 0, 1);
@@ -712,7 +712,7 @@ mod tests {
 
     #[test]
     fn unbond_claim_workflow() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         default_instantiate(deps.as_mut());
 
         // create some data
@@ -847,7 +847,7 @@ mod tests {
     #[test]
     fn add_remove_hooks() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         default_instantiate(deps.as_mut());
 
         let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
@@ -915,7 +915,7 @@ mod tests {
 
     #[test]
     fn hooks_fire() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         default_instantiate(deps.as_mut());
 
         let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
@@ -969,7 +969,7 @@ mod tests {
 
     #[test]
     fn only_bond_valid_coins() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         default_instantiate(deps.as_mut());
 
         // cannot bond with 0 coins
@@ -996,7 +996,7 @@ mod tests {
     #[test]
     fn ensure_bonding_edge_cases() {
         // use min_bond 0, tokens_per_weight 500
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         do_instantiate(
             deps.as_mut(),
             Uint128::new(100),

--- a/packages/controllers/src/admin.rs
+++ b/packages/controllers/src/admin.rs
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn set_and_get_admin() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let control = Admin::new("foo");
 
         // initialize and check
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn admin_checks() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         let control = Admin::new("foo");
         let owner = Addr::unchecked("big boss");
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_execute_query() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
 
         // initial setup
         let control = Admin::new("foo");

--- a/packages/controllers/src/claim.rs
+++ b/packages/controllers/src/claim.rs
@@ -112,7 +112,7 @@ mod test {
 
     #[test]
     fn can_create_claims() {
-        let deps = mock_dependencies(&[]);
+        let deps = mock_dependencies();
         let claims = Claims::new("claims");
         // Assert that claims creates a map and there are no keys in the map.
         assert_eq!(
@@ -128,7 +128,7 @@ mod test {
 
     #[test]
     fn check_create_claim_updates_map() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -196,7 +196,7 @@ mod test {
 
     #[test]
     fn test_claim_tokens_with_no_claims() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         let amount = claims
@@ -218,7 +218,7 @@ mod test {
 
     #[test]
     fn test_claim_tokens_with_no_released_claims() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -266,7 +266,7 @@ mod test {
 
     #[test]
     fn test_claim_tokens_with_one_released_claim() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -312,7 +312,7 @@ mod test {
 
     #[test]
     fn test_claim_tokens_with_all_released_claims() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -356,7 +356,7 @@ mod test {
 
     #[test]
     fn test_claim_tokens_with_zero_cap() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -404,7 +404,7 @@ mod test {
 
     #[test]
     fn test_claim_tokens_with_cap_greater_than_pending_claims() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -448,7 +448,7 @@ mod test {
 
     #[test]
     fn test_claim_tokens_with_cap_only_one_claim_released() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -493,7 +493,7 @@ mod test {
 
     #[test]
     fn test_claim_tokens_with_cap_too_low_no_claims_released() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -540,7 +540,7 @@ mod test {
 
     #[test]
     fn test_query_claims_returns_correct_claims() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims
@@ -564,7 +564,7 @@ mod test {
 
     #[test]
     fn test_query_claims_returns_empty_for_non_existent_user() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let claims = Claims::new("claims");
 
         claims

--- a/packages/cw0/src/pagination.rs
+++ b/packages/cw0/src/pagination.rs
@@ -55,7 +55,7 @@ mod test {
     #[test]
     fn calc_range_start_works_as_expected() {
         let total_elements_count = 100;
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         for i in 0..total_elements_count {
             let holder = (addr_from_i(i), i);
             HOLDERS
@@ -88,7 +88,7 @@ mod test {
     #[test]
     fn calc_range_end_works_as_expected() {
         let total_elements_count = 100;
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         for i in 0..total_elements_count {
             let holder = (addr_from_i(i), i);
             HOLDERS

--- a/packages/cw1/schema/execute_msg.json
+++ b/packages/cw1/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Execute requests the contract to re-dispatch all these messages with the contract's address as sender. Every implementation has it's own logic to determine in",
       "type": "object",
@@ -30,7 +30,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -105,7 +105,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -154,7 +154,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/packages/cw1/schema/query_msg.json
+++ b/packages/cw1/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Checks permissions of the caller on this proxy. If CanExecute returns true then a call to `Execute` with the same message, from the given sender, before any further state changes, should also succeed.",
       "type": "object",
@@ -31,7 +31,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -106,7 +106,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -155,7 +155,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/packages/cw1155/schema/approved_for_all_response.json
+++ b/packages/cw1155/schema/approved_for_all_response.json
@@ -37,7 +37,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/packages/cw1155/schema/cw1155_execute_msg.json
+++ b/packages/cw1155/schema/cw1155_execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw1155ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "SendFrom is a base message to move tokens, if `env.sender` is the owner or has sufficient pre-approval.",
       "type": "object",
@@ -319,7 +319,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/packages/cw1155/schema/cw1155_query_msg.json
+++ b/packages/cw1155/schema/cw1155_query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw1155QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Returns the current balance of the given address, 0 if unset. Return type: BalanceResponse.",
       "type": "object",

--- a/packages/cw20/schema/all_allowances_response.json
+++ b/packages/cw20/schema/all_allowances_response.json
@@ -35,7 +35,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/packages/cw20/schema/allowance_response.json
+++ b/packages/cw20/schema/allowance_response.json
@@ -17,7 +17,7 @@
   "definitions": {
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",

--- a/packages/cw20/schema/cw20_execute_msg.json
+++ b/packages/cw20/schema/cw20_execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Transfer is a base message to move tokens to another account without triggering actions",
       "type": "object",
@@ -316,7 +316,7 @@
     },
     "EmbeddedLogo": {
       "description": "This is used to store the logo on the blockchain in an accepted format. Enforce maximum size of 5KB on all variants.",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Store the Logo as an SVG file. The content must conform to the spec at https://en.wikipedia.org/wiki/Scalable_Vector_Graphics (The contract should do some light-weight sanity-check validation)",
           "type": "object",
@@ -347,7 +347,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",
@@ -393,7 +393,7 @@
     },
     "Logo": {
       "description": "This is used for uploading logo data, or setting it in InstantiateData",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.",
           "type": "object",

--- a/packages/cw20/schema/cw20_query_msg.json
+++ b/packages/cw20/schema/cw20_query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Returns the current balance of the given address, 0 if unset. Return type: BalanceResponse.",
       "type": "object",

--- a/packages/cw20/schema/marketing_info_response.json
+++ b/packages/cw20/schema/marketing_info_response.json
@@ -47,7 +47,7 @@
     },
     "LogoInfo": {
       "description": "This is used to display logo info, provide a link or inform there is one that can be downloaded from the blockchain itself",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "string",
           "enum": [

--- a/packages/cw3/schema/execute_msg.json
+++ b/packages/cw3/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -127,7 +127,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -202,7 +202,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -247,7 +247,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",
@@ -318,7 +318,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/packages/cw3/schema/proposal_list_response.json
+++ b/packages/cw3/schema/proposal_list_response.json
@@ -16,7 +16,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -91,7 +91,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -140,7 +140,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",
@@ -242,7 +242,7 @@
     },
     "ThresholdResponse": {
       "description": "This defines the different ways tallies can happen. Every contract should support a subset of these, ideally all.\n\nThe total_weight used for calculating success as well as the weights of each individual voter used in tallying should be snapshotted at the beginning of the block at which the proposal starts (this is likely the responsibility of a correct cw4 implementation).",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Declares that a fixed weight of yes votes is needed to pass. It does not matter how many no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.\n\nThis is the simplest format and usually suitable for small multisigs of trusted parties, like 3 of 5. (weight: 3, total_weight: 5)\n\nA proposal of this type can pass early as soon as the needed weight of yes votes has been cast.",
           "type": "object",
@@ -350,7 +350,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/packages/cw3/schema/proposal_response.json
+++ b/packages/cw3/schema/proposal_response.json
@@ -48,7 +48,7 @@
   "definitions": {
     "BankMsg": {
       "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
           "type": "object",
@@ -123,7 +123,7 @@
       }
     },
     "CosmosMsg_for_Empty": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "required": [
@@ -172,7 +172,7 @@
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "AtHeight will expire when `env.block.height` >= height",
           "type": "object",
@@ -228,7 +228,7 @@
     },
     "ThresholdResponse": {
       "description": "This defines the different ways tallies can happen. Every contract should support a subset of these, ideally all.\n\nThe total_weight used for calculating success as well as the weights of each individual voter used in tallying should be snapshotted at the beginning of the block at which the proposal starts (this is likely the responsibility of a correct cw4 implementation).",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Declares that a fixed weight of yes votes is needed to pass. It does not matter how many no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.\n\nThis is the simplest format and usually suitable for small multisigs of trusted parties, like 3 of 5. (weight: 3, total_weight: 5)\n\nA proposal of this type can pass early as soon as the needed weight of yes votes has been cast.",
           "type": "object",
@@ -336,7 +336,7 @@
     },
     "WasmMsg": {
       "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
           "type": "object",

--- a/packages/cw3/schema/query_msg.json
+++ b/packages/cw3/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Returns the threshold rules that would be used for a new proposal that was opened right now. The threshold rules do not change often, but the `total_weight` in the response may easily differ from that used in previously opened proposals. Returns ThresholdResponse.",
       "type": "object",

--- a/packages/cw3/schema/threshold_response.json
+++ b/packages/cw3/schema/threshold_response.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ThresholdResponse",
   "description": "This defines the different ways tallies can happen. Every contract should support a subset of these, ideally all.\n\nThe total_weight used for calculating success as well as the weights of each individual voter used in tallying should be snapshotted at the beginning of the block at which the proposal starts (this is likely the responsibility of a correct cw4 implementation).",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Declares that a fixed weight of yes votes is needed to pass. It does not matter how many no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.\n\nThis is the simplest format and usually suitable for small multisigs of trusted parties, like 3 of 5. (weight: 3, total_weight: 5)\n\nA proposal of this type can pass early as soon as the needed weight of yes votes has been cast.",
       "type": "object",

--- a/packages/cw4/schema/cw4_execute_msg.json
+++ b/packages/cw4/schema/cw4_execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw4ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Change the admin",
       "type": "object",

--- a/packages/cw4/schema/cw4_query_msg.json
+++ b/packages/cw4/schema/cw4_query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw4QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Return AdminResponse",
       "type": "object",


### PR DESCRIPTION
The `mock_dependencies` function was changed in breaking way, but semver-compatible version was set after the change, which made most test not compile after removing `Cargo.lock` (or doing some change which would make update it). This aligns tests to work with those changes.