### PR TITLE
Change contract file prefix to be cw* in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["packages/*", "contracts/*"]
+members = ["packages/*", "contracts/cw*"]
 
 [profile.release.package.cw1-subkeys]
 codegen-units = 1


### PR DESCRIPTION
Resolves https://github.com/CosmWasm/cw-plus/issues/545

When trying to compile all the contracts, we get an error because of the new ```base-helpers.ts```. Since ```Cargo.toml``` has ```contracts/*``` as a workspace, it tries to get inside the helpers file. This is not possible because it's a file. 

Added **cw** prefix to go through only the contract folders.