### PR TITLE
Update cw2 readme - contract_info key

### DIFF
--- a/packages/cw2/README.md
+++ b/packages/cw2/README.md
@@ -23,7 +23,7 @@ paths.
 
 All CW2-compliant contracts must store the following data:
 
-* key: `\x00\x0dcontract_info` (length prefixed "contract_info" using Singleton pattern)
+* key: `contract_info`
 * data: Json-serialized `ContractVersion`
 
 ```rust


### PR DESCRIPTION
Hi everyone!

Based on my raw queries on terra contracts, all `Item` keys are not length prefixed.
Only `Map` keys add this prefix.

I'm using `cw2 = "0.9.1"`