### PR TITLE
Migrate from `IntKey` to new naked int key

### DIFF
--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -80,8 +80,8 @@ fn verify_png_logo(logo: &[u8]) -> Result<(), ContractError> {
 /// Checks if passed logo is correct, and if not, returns an error
 fn verify_logo(logo: &Logo) -> Result<(), ContractError> {
     match logo {
-        Logo::Embedded(EmbeddedLogo::Svg(logo)) => verify_xml_logo(&logo),
-        Logo::Embedded(EmbeddedLogo::Png(logo)) => verify_png_logo(&logo),
+        Logo::Embedded(EmbeddedLogo::Svg(logo)) => verify_xml_logo(logo),
+        Logo::Embedded(EmbeddedLogo::Png(logo)) => verify_png_logo(logo),
         Logo::Url(_) => Ok(()), // Any reasonable url validation would be regex based, probably not worth it
     }
 }

--- a/contracts/cw20-merkle-airdrop/src/state.rs
+++ b/contracts/cw20-merkle-airdrop/src/state.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::Addr;
-use cw_storage_plus::{Item, Map, U8Key};
+use cw_storage_plus::{Item, Map};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -18,7 +18,7 @@ pub const LATEST_STAGE_KEY: &str = "stage";
 pub const LATEST_STAGE: Item<u8> = Item::new(LATEST_STAGE_KEY);
 
 pub const MERKLE_ROOT_PREFIX: &str = "merkle_root";
-pub const MERKLE_ROOT: Map<U8Key, String> = Map::new(MERKLE_ROOT_PREFIX);
+pub const MERKLE_ROOT: Map<u8, String> = Map::new(MERKLE_ROOT_PREFIX);
 
 pub const CLAIM_PREFIX: &str = "claim";
-pub const CLAIM: Map<(&Addr, U8Key), bool> = Map::new(CLAIM_PREFIX);
+pub const CLAIM: Map<(&Addr, u8), bool> = Map::new(CLAIM_PREFIX);

--- a/contracts/cw3-fixed-multisig/src/state.rs
+++ b/contracts/cw3-fixed-multisig/src/state.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{Addr, BlockInfo, CosmosMsg, Empty, StdError, StdResult, Stora
 
 use cw0::{Duration, Expiration};
 use cw3::{Status, Vote};
-use cw_storage_plus::{Item, Map, U64Key};
+use cw_storage_plus::{Item, Map};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Config {
@@ -58,8 +58,8 @@ pub const PROPOSAL_COUNT: Item<u64> = Item::new("proposal_count");
 
 // multiple-item maps
 pub const VOTERS: Map<&Addr, u64> = Map::new("voters");
-pub const PROPOSALS: Map<U64Key, Proposal> = Map::new("proposals");
-pub const BALLOTS: Map<(U64Key, &Addr), Ballot> = Map::new("ballots");
+pub const PROPOSALS: Map<u64, Proposal> = Map::new("proposals");
+pub const BALLOTS: Map<(u64, &Addr), Ballot> = Map::new("ballots");
 
 pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -123,14 +123,14 @@ pub fn execute_propose(
     };
     prop.update_status(&env.block);
     let id = next_id(deps.storage)?;
-    PROPOSALS.save(deps.storage, id.into(), &prop)?;
+    PROPOSALS.save(deps.storage, id, &prop)?;
 
     // add the first yes vote from voter
     let ballot = Ballot {
         weight: vote_power,
         vote: Vote::Yes,
     };
-    BALLOTS.save(deps.storage, (id.into(), &info.sender), &ballot)?;
+    BALLOTS.save(deps.storage, (id, &info.sender), &ballot)?;
 
     Ok(Response::new()
         .add_attribute("action", "propose")
@@ -150,7 +150,7 @@ pub fn execute_vote(
     let cfg = CONFIG.load(deps.storage)?;
 
     // ensure proposal exists and can be voted on
-    let mut prop = PROPOSALS.load(deps.storage, proposal_id.into())?;
+    let mut prop = PROPOSALS.load(deps.storage, proposal_id)?;
     if prop.status != Status::Open {
         return Err(ContractError::NotOpen {});
     }
@@ -167,22 +167,18 @@ pub fn execute_vote(
         .ok_or(ContractError::Unauthorized {})?;
 
     // cast vote if no vote previously cast
-    BALLOTS.update(
-        deps.storage,
-        (proposal_id.into(), &info.sender),
-        |bal| match bal {
-            Some(_) => Err(ContractError::AlreadyVoted {}),
-            None => Ok(Ballot {
-                weight: vote_power,
-                vote,
-            }),
-        },
-    )?;
+    BALLOTS.update(deps.storage, (proposal_id, &info.sender), |bal| match bal {
+        Some(_) => Err(ContractError::AlreadyVoted {}),
+        None => Ok(Ballot {
+            weight: vote_power,
+            vote,
+        }),
+    })?;
 
     // update vote tally
     prop.votes.add_vote(vote, vote_power);
     prop.update_status(&env.block);
-    PROPOSALS.save(deps.storage, proposal_id.into(), &prop)?;
+    PROPOSALS.save(deps.storage, proposal_id, &prop)?;
 
     Ok(Response::new()
         .add_attribute("action", "vote")
@@ -199,7 +195,7 @@ pub fn execute_execute(
 ) -> Result<Response, ContractError> {
     // anyone can trigger this if the vote passed
 
-    let mut prop = PROPOSALS.load(deps.storage, proposal_id.into())?;
+    let mut prop = PROPOSALS.load(deps.storage, proposal_id)?;
     // we allow execution even after the proposal "expiration" as long as all vote come in before
     // that point. If it was approved on time, it can be executed any time.
     if prop.status != Status::Passed {
@@ -208,7 +204,7 @@ pub fn execute_execute(
 
     // set it to executed
     prop.status = Status::Executed;
-    PROPOSALS.save(deps.storage, proposal_id.into(), &prop)?;
+    PROPOSALS.save(deps.storage, proposal_id, &prop)?;
 
     // dispatch all proposed messages
     Ok(Response::new()
@@ -226,7 +222,7 @@ pub fn execute_close(
 ) -> Result<Response<Empty>, ContractError> {
     // anyone can trigger this if the vote passed
 
-    let mut prop = PROPOSALS.load(deps.storage, proposal_id.into())?;
+    let mut prop = PROPOSALS.load(deps.storage, proposal_id)?;
     if [Status::Executed, Status::Rejected, Status::Passed]
         .iter()
         .any(|x| *x == prop.status)
@@ -239,7 +235,7 @@ pub fn execute_close(
 
     // set it to failed
     prop.status = Status::Rejected;
-    PROPOSALS.save(deps.storage, proposal_id.into(), &prop)?;
+    PROPOSALS.save(deps.storage, proposal_id, &prop)?;
 
     Ok(Response::new()
         .add_attribute("action", "close")
@@ -295,7 +291,7 @@ fn query_threshold(deps: Deps) -> StdResult<ThresholdResponse> {
 }
 
 fn query_proposal(deps: Deps, env: Env, id: u64) -> StdResult<ProposalResponse> {
-    let prop = PROPOSALS.load(deps.storage, id.into())?;
+    let prop = PROPOSALS.load(deps.storage, id)?;
     let status = prop.current_status(&env.block);
     let threshold = prop.threshold.to_response(prop.total_weight);
     Ok(ProposalResponse {
@@ -367,7 +363,7 @@ fn map_proposal(
 
 fn query_vote(deps: Deps, proposal_id: u64, voter: String) -> StdResult<VoteResponse> {
     let voter_addr = deps.api.addr_validate(&voter)?;
-    let prop = BALLOTS.may_load(deps.storage, (proposal_id.into(), &voter_addr))?;
+    let prop = BALLOTS.may_load(deps.storage, (proposal_id, &voter_addr))?;
     let vote = prop.map(|b| VoteInfo {
         voter,
         vote: b.vote,
@@ -387,7 +383,7 @@ fn list_votes(
     let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
 
     let votes: StdResult<Vec<_>> = BALLOTS
-        .prefix(proposal_id.into())
+        .prefix(proposal_id)
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
 use cw0::{Duration, Expiration};
 use cw3::{Status, Vote};
 use cw4::Cw4Contract;
-use cw_storage_plus::{Item, Map, U64Key};
+use cw_storage_plus::{Item, Map};
 
 use crate::msg::Threshold;
 
@@ -153,8 +153,8 @@ pub const CONFIG: Item<Config> = Item::new("config");
 pub const PROPOSAL_COUNT: Item<u64> = Item::new("proposal_count");
 
 // multiple-item map
-pub const BALLOTS: Map<(U64Key, &Addr), Ballot> = Map::new("votes");
-pub const PROPOSALS: Map<U64Key, Proposal> = Map::new("proposals");
+pub const BALLOTS: Map<(u64, &Addr), Ballot> = Map::new("votes");
+pub const PROPOSALS: Map<u64, Proposal> = Map::new("proposals");
 
 pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;

--- a/packages/multi-test/src/test_helpers/contracts/reflect.rs
+++ b/packages/multi-test/src/test_helpers/contracts/reflect.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
     to_binary, Binary, Deps, DepsMut, Env, Event, MessageInfo, Reply, Response, StdError, SubMsg,
 };
-use cw_storage_plus::{Map, U64Key};
+use cw_storage_plus::Map;
 
 use crate::contracts::{Contract, ContractWrapper};
 use crate::test_helpers::contracts::payout;
@@ -20,7 +20,7 @@ pub enum QueryMsg {
     Reply { id: u64 },
 }
 
-const REFLECT: Map<U64Key, Reply> = Map::new("reflect");
+const REFLECT: Map<u64, Reply> = Map::new("reflect");
 
 fn instantiate(
     deps: DepsMut,
@@ -51,14 +51,14 @@ fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, StdError> {
             to_binary(&res)
         }
         QueryMsg::Reply { id } => {
-            let reply = REFLECT.load(deps.storage, id.into())?;
+            let reply = REFLECT.load(deps.storage, id)?;
             to_binary(&reply)
         }
     }
 }
 
 fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response<CustomMsg>, StdError> {
-    REFLECT.save(deps.storage, msg.id.into(), &msg)?;
+    REFLECT.save(deps.storage, msg.id, &msg)?;
     // add custom event here to test
     let event = Event::new("custom")
         .add_attribute("from", "reply")

--- a/packages/storage-plus/src/de.rs
+++ b/packages/storage-plus/src/de.rs
@@ -1,3 +1,6 @@
+// TODO: Remove along with IntKey
+#![allow(deprecated)]
+
 use std::array::TryFromSliceError;
 use std::convert::TryInto;
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1433,10 +1433,9 @@ mod test {
 
     mod inclusive_bound {
         use super::*;
-        use crate::U64Key;
 
         struct Indexes<'a> {
-            secondary: MultiIndex<'a, (U64Key, Vec<u8>), u64>,
+            secondary: MultiIndex<'a, (u64, Vec<u8>), u64>,
         }
 
         impl<'a> IndexList<u64> for Indexes<'a> {
@@ -1451,7 +1450,7 @@ mod test {
         fn composite_key_query() {
             let indexes = Indexes {
                 secondary: MultiIndex::new(
-                    |secondary, k| (U64Key::new(*secondary), k),
+                    |secondary, k| (*secondary, k),
                     "test_map",
                     "test_map__secondary",
                 ),
@@ -1468,7 +1467,7 @@ mod test {
                 .prefix_range(
                     &store,
                     None,
-                    Some(PrefixBound::inclusive(1)),
+                    Some(PrefixBound::inclusive(1u64)),
                     Order::Ascending,
                 )
                 .collect::<Result<_, _>>()

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -282,7 +282,7 @@ mod test {
     use super::*;
 
     use crate::indexes::{index_string_tuple, index_triple};
-    use crate::{MultiIndex, U32Key, UniqueIndex};
+    use crate::{MultiIndex, UniqueIndex};
     use cosmwasm_std::testing::MockStorage;
     use cosmwasm_std::{MemoryStorage, Order};
     use serde::{Deserialize, Serialize};
@@ -297,7 +297,7 @@ mod test {
     struct DataIndexes<'a> {
         // Second arg is for storing pk
         pub name: MultiIndex<'a, (String, String), Data>,
-        pub age: UniqueIndex<'a, U32Key, Data, String>,
+        pub age: UniqueIndex<'a, u32, Data, String>,
         pub name_lastname: UniqueIndex<'a, (Vec<u8>, Vec<u8>), Data, String>,
     }
 
@@ -312,7 +312,7 @@ mod test {
     // For composite multi index tests
     struct DataCompositeMultiIndex<'a> {
         // Third arg needed for storing pk
-        pub name_age: MultiIndex<'a, (Vec<u8>, U32Key, Vec<u8>), Data>,
+        pub name_age: MultiIndex<'a, (Vec<u8>, u32, Vec<u8>), Data>,
     }
 
     // Future Note: this can likely be macro-derived
@@ -331,7 +331,7 @@ mod test {
                 "data",
                 "data__name",
             ),
-            age: UniqueIndex::new(|d| U32Key::new(d.age), "data__age"),
+            age: UniqueIndex::new(|d| d.age, "data__age"),
             name_lastname: UniqueIndex::new(
                 |d| index_string_tuple(&d.name, &d.last_name),
                 "data__name_lastname",
@@ -497,7 +497,7 @@ mod test {
         assert_eq!(3, count);
 
         // index_key() over UniqueIndex works.
-        let age_key = U32Key::from(23);
+        let age_key = 23u32;
         // Use the index_key() helper to build the (raw) index key
         let age_key = map.idx.age.index_key(age_key);
         // Iterate using a (inclusive) bound over the raw key.
@@ -515,13 +515,13 @@ mod test {
         assert_eq!(4, count);
 
         // match on proper age
-        let proper = U32Key::new(42);
+        let proper = 42u32;
         let aged = map.idx.age.item(&store, proper).unwrap().unwrap();
         assert_eq!(pk, String::from_vec(aged.0).unwrap());
         assert_eq!(*data, aged.1);
 
         // no match on wrong age
-        let too_old = U32Key::new(43);
+        let too_old = 43u32;
         let aged = map.idx.age.item(&store, too_old).unwrap();
         assert_eq!(None, aged);
     }
@@ -789,14 +789,14 @@ mod test {
 
         // query by unique key
         // match on proper age
-        let age42 = U32Key::new(42);
-        let (k, v) = map.idx.age.item(&store, age42.clone()).unwrap().unwrap();
+        let age42 = 42u32;
+        let (k, v) = map.idx.age.item(&store, age42).unwrap().unwrap();
         assert_eq!(String::from_vec(k).unwrap(), pks[0]);
         assert_eq!(v.name, datas[0].name);
         assert_eq!(v.age, datas[0].age);
 
         // match on other age
-        let age23 = U32Key::new(23);
+        let age23 = 23u32;
         let (k, v) = map.idx.age.item(&store, age23).unwrap().unwrap();
         assert_eq!(String::from_vec(k).unwrap(), pks[1]);
         assert_eq!(v.name, datas[1].name);

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -298,7 +298,7 @@ mod test {
     use super::*;
 
     use crate::indexes::{index_string_tuple, index_triple};
-    use crate::{Index, MultiIndex, U32Key, UniqueIndex};
+    use crate::{Index, MultiIndex, UniqueIndex};
     use cosmwasm_std::testing::MockStorage;
     use cosmwasm_std::{MemoryStorage, Order};
     use serde::{Deserialize, Serialize};
@@ -314,7 +314,7 @@ mod test {
         // Second arg is for storing pk
         pub name: MultiIndex<'a, (Vec<u8>, String), Data>,
         // Last generic type arg is pk deserialization type
-        pub age: UniqueIndex<'a, U32Key, Data, String>,
+        pub age: UniqueIndex<'a, u32, Data, String>,
         // Last generic type arg is pk deserialization type
         pub name_lastname: UniqueIndex<'a, (Vec<u8>, Vec<u8>), Data, String>,
     }
@@ -330,7 +330,7 @@ mod test {
     // For composite multi index tests
     struct DataCompositeMultiIndex<'a> {
         // Third arg needed for storing pk
-        pub name_age: MultiIndex<'a, (Vec<u8>, U32Key, Vec<u8>), Data>,
+        pub name_age: MultiIndex<'a, (Vec<u8>, u32, Vec<u8>), Data>,
     }
 
     // Future Note: this can likely be macro-derived
@@ -353,7 +353,7 @@ mod test {
                 "data",
                 "data__name",
             ),
-            age: UniqueIndex::new(|d| U32Key::new(d.age), "data__age"),
+            age: UniqueIndex::new(|d| d.age, "data__age"),
             name_lastname: UniqueIndex::new(
                 |d| index_string_tuple(&d.name, &d.last_name),
                 "data__name_lastname",
@@ -489,13 +489,13 @@ mod test {
         assert_eq!(0, count);
 
         // match on proper age
-        let proper = U32Key::new(42);
+        let proper = 42u32;
         let aged = map.idx.age.item(&store, proper).unwrap().unwrap();
         assert_eq!(pk.as_bytes(), aged.0);
         assert_eq!(*data, aged.1);
 
         // no match on wrong age
-        let too_old = U32Key::new(43);
+        let too_old = 43u32;
         let aged = map.idx.age.item(&store, too_old).unwrap();
         assert_eq!(None, aged);
     }
@@ -783,14 +783,14 @@ mod test {
 
         // query by unique key
         // match on proper age
-        let age42 = U32Key::new(42);
-        let (k, v) = map.idx.age.item(&store, age42.clone()).unwrap().unwrap();
+        let age42 = 42u32;
+        let (k, v) = map.idx.age.item(&store, age42).unwrap().unwrap();
         assert_eq!(k, pks[0].as_bytes());
         assert_eq!(v.name, datas[0].name);
         assert_eq!(v.age, datas[0].age);
 
         // match on other age
-        let age23 = U32Key::new(23);
+        let age23 = 23u32;
         let (k, v) = map.idx.age.item(&store, age23).unwrap().unwrap();
         assert_eq!(k, pks[1].as_bytes());
         assert_eq!(v.name, datas[1].name);

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -25,7 +25,7 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
     /// Examples:
     ///
     /// ```rust
-    /// use cw_storage_plus::{IndexedSnapshotMap, Strategy, U32Key, UniqueIndex};
+    /// use cw_storage_plus::{IndexedSnapshotMap, Strategy, UniqueIndex};
     ///
     /// #[derive(PartialEq, Debug, Clone)]
     /// struct Data {
@@ -33,9 +33,9 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
     ///     pub age: u32,
     /// }
     ///
-    /// let indexes = UniqueIndex::new(|d: &Data| U32Key::new(d.age), "data__age");
+    /// let indexes = UniqueIndex::new(|d: &Data| d.age, "data__age");
     ///
-    /// IndexedSnapshotMap::<&[u8], Data, UniqueIndex<U32Key, Data>>::new(
+    /// IndexedSnapshotMap::<&[u8], Data, UniqueIndex<u32, Data>>::new(
     ///     "data",
     ///     "checkpoints",
     ///     "changelog",

--- a/packages/storage-plus/src/indexes/mod.rs
+++ b/packages/storage-plus/src/indexes/mod.rs
@@ -11,18 +11,16 @@ use serde::Serialize;
 
 use cosmwasm_std::{StdResult, Storage};
 
-use crate::U32Key;
-
 pub fn index_string(data: &str) -> Vec<u8> {
     data.as_bytes().to_vec()
 }
 
-pub fn index_tuple(name: &str, age: u32) -> (Vec<u8>, U32Key) {
-    (index_string(name), U32Key::new(age))
+pub fn index_tuple(name: &str, age: u32) -> (Vec<u8>, u32) {
+    (index_string(name), age)
 }
 
-pub fn index_triple(name: &str, age: u32, pk: Vec<u8>) -> (Vec<u8>, U32Key, Vec<u8>) {
-    (index_string(name), U32Key::new(age), pk)
+pub fn index_triple(name: &str, age: u32, pk: Vec<u8>) -> (Vec<u8>, u32, Vec<u8>) {
+    (index_string(name), age, pk)
 }
 
 pub fn index_string_tuple(data1: &str, data2: &str) -> (Vec<u8>, Vec<u8>) {

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -42,14 +42,14 @@ impl<'a, K, T, PK> UniqueIndex<'a, K, T, PK> {
     /// ## Example:
     ///
     /// ```rust
-    /// use cw_storage_plus::{U32Key, UniqueIndex};
+    /// use cw_storage_plus::UniqueIndex;
     ///
     /// struct Data {
     ///     pub name: String,
     ///     pub age: u32,
     /// }
     ///
-    /// UniqueIndex::<_, _, ()>::new(|d: &Data| U32Key::new(d.age), "data__age");
+    /// UniqueIndex::<_, _, ()>::new(|d: &Data| d.age, "data__age");
     /// ```
     pub fn new(idx_fn: fn(&T) -> K, idx_namespace: &'a str) -> Self {
         UniqueIndex {

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -1,3 +1,6 @@
+// TODO: Remove along with IntKey
+#![allow(deprecated)]
+
 use cosmwasm_std::{Addr, Timestamp};
 use std::marker::PhantomData;
 
@@ -336,6 +339,7 @@ pub type I128Key = IntKey<i128>;
 ///   let k = U64Key::new(12345);
 ///   let k = U32Key::from(12345);
 ///   let k: U16Key = 12345.into();
+#[deprecated(note = "It is suggested to use naked int types instead of IntKey wrapper")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IntKey<T: Endian> {
     pub wrapped: Vec<u8>,

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -555,7 +555,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE_ID
             .range_de(
                 &store,
-                Some(Bound::Inclusive(56u32.to_be_bytes().to_vec())),
+                Some(Bound::inclusive_int(56u32)),
                 None,
                 Order::Ascending,
             )
@@ -568,7 +568,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE_ID
             .range_de(
                 &store,
-                Some(Bound::Inclusive(57u32.to_be_bytes().to_vec())),
+                Some(Bound::inclusive_int(57u32)),
                 None,
                 Order::Ascending,
             )

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -1014,18 +1014,12 @@ mod test {
         const AGES: Map<(u32, Vec<u8>), u64> = Map::new("ages");
 
         let mut store = MockStorage::new();
-        AGES.save(&mut store, (2, vec![1, 2, 3]), &123)
-            .unwrap();
-        AGES.save(&mut store, (3, vec![4, 5, 6]), &456)
-            .unwrap();
-        AGES.save(&mut store, (5, vec![7, 8, 9]), &789)
-            .unwrap();
-        AGES.save(&mut store, (5, vec![9, 8, 7]), &987)
-            .unwrap();
-        AGES.save(&mut store, (7, vec![20, 21, 22]), &2002)
-            .unwrap();
-        AGES.save(&mut store, (8, vec![23, 24, 25]), &2332)
-            .unwrap();
+        AGES.save(&mut store, (2, vec![1, 2, 3]), &123).unwrap();
+        AGES.save(&mut store, (3, vec![4, 5, 6]), &456).unwrap();
+        AGES.save(&mut store, (5, vec![7, 8, 9]), &789).unwrap();
+        AGES.save(&mut store, (5, vec![9, 8, 7]), &987).unwrap();
+        AGES.save(&mut store, (7, vec![20, 21, 22]), &2002).unwrap();
+        AGES.save(&mut store, (8, vec![23, 24, 25]), &2332).unwrap();
 
         // typical range under one prefix as a control
         let fives = AGES

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -298,7 +298,7 @@ mod test {
         assert_eq!(b"john".to_vec().as_slice(), &key[9..13]);
         assert_eq!(b"maria".to_vec().as_slice(), &key[13..]);
 
-        let path = TRIPLE.key((b"john", 8u8.into(), "pedro"));
+        let path = TRIPLE.key((b"john", 8u8, "pedro"));
         let key = path.deref();
         // this should be prefixed(allow) || prefixed(john) || maria
         assert_eq!(
@@ -387,21 +387,19 @@ mod test {
         let mut store = MockStorage::new();
 
         // save and load on a triple composite key
-        let triple = TRIPLE.key((b"owner", 10u8.into(), "recipient"));
+        let triple = TRIPLE.key((b"owner", 10u8, "recipient"));
         assert_eq!(None, triple.may_load(&store).unwrap());
         triple.save(&mut store, &1234).unwrap();
         assert_eq!(1234, triple.load(&store).unwrap());
 
         // not under other key
         let different = TRIPLE
-            .may_load(&store, (b"owners", 10u8.into(), "ecipient"))
+            .may_load(&store, (b"owners", 10u8, "ecipient"))
             .unwrap();
         assert_eq!(None, different);
 
         // matches under a proper copy
-        let same = TRIPLE
-            .load(&store, (b"owner", 10u8.into(), "recipient"))
-            .unwrap();
+        let same = TRIPLE.load(&store, (b"owner", 10u8, "recipient")).unwrap();
         assert_eq!(1234, same);
     }
 

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -143,7 +143,7 @@ where
 
         // this will look for the first snapshot of height >= given height
         // If None, there is no snapshot since that time.
-        let start = Bound::inclusive(height.to_be_bytes().to_vec());
+        let start = Bound::inclusive_int(height);
         let first = self
             .changelog
             .prefix(key)

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -6,22 +6,22 @@ pub use item::SnapshotItem;
 pub use map::SnapshotMap;
 
 use crate::de::KeyDeserialize;
-use crate::{Bound, Map, Prefixer, PrimaryKey, U64Key};
+use crate::{Bound, Map, Prefixer, PrimaryKey};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 /// Structure holding a map of checkpoints composited from
-/// height (as U64Key) and counter of how many times it has
+/// height (as u64) and counter of how many times it has
 /// been checkpointed (as u32).
 /// Stores all changes in changelog.
 #[derive(Debug, Clone)]
 pub(crate) struct Snapshot<'a, K, T> {
-    checkpoints: Map<'a, U64Key, u32>,
+    checkpoints: Map<'a, u64, u32>,
 
     // this stores all changes (key, height). Must differentiate between no data written,
     // and explicit None (just inserted)
-    pub changelog: Map<'a, (K, U64Key), ChangeSet<T>>,
+    pub changelog: Map<'a, (K, u64), ChangeSet<T>>,
 
     // How aggressive we are about checkpointing all data
     strategy: Strategy,
@@ -42,22 +42,20 @@ impl<'a, K, T> Snapshot<'a, K, T> {
 
     pub fn add_checkpoint(&self, store: &mut dyn Storage, height: u64) -> StdResult<()> {
         self.checkpoints
-            .update::<_, StdError>(store, height.into(), |count| {
-                Ok(count.unwrap_or_default() + 1)
-            })?;
+            .update::<_, StdError>(store, height, |count| Ok(count.unwrap_or_default() + 1))?;
         Ok(())
     }
 
     pub fn remove_checkpoint(&self, store: &mut dyn Storage, height: u64) -> StdResult<()> {
         let count = self
             .checkpoints
-            .may_load(store, height.into())?
+            .may_load(store, height)?
             .unwrap_or_default();
         if count <= 1 {
-            self.checkpoints.remove(store, height.into());
+            self.checkpoints.remove(store, height);
             Ok(())
         } else {
-            self.checkpoints.save(store, height.into(), &(count - 1))
+            self.checkpoints.save(store, height, &(count - 1))
         }
     }
 }
@@ -86,7 +84,7 @@ where
             .transpose()?;
         if let Some((height, _)) = checkpoint {
             // any changelog for the given key since then?
-            let start = Bound::inclusive(U64Key::from(height));
+            let start = Bound::inclusive(height);
             let first = self
                 .changelog
                 .prefix(k.clone())
@@ -107,7 +105,7 @@ where
         let has = match self.strategy {
             Strategy::EveryBlock => true,
             Strategy::Never => false,
-            Strategy::Selected => self.checkpoints.may_load(store, height.into())?.is_some(),
+            Strategy::Selected => self.checkpoints.may_load(store, height)?.is_some(),
         };
         match has {
             true => Ok(()),
@@ -116,10 +114,7 @@ where
     }
 
     pub fn has_changelog(&self, store: &mut dyn Storage, key: K, height: u64) -> StdResult<bool> {
-        Ok(self
-            .changelog
-            .may_load(store, (key, U64Key::from(height)))?
-            .is_some())
+        Ok(self.changelog.may_load(store, (key, height))?.is_some())
     }
 
     pub fn write_changelog(
@@ -130,7 +125,7 @@ where
         old: Option<T>,
     ) -> StdResult<()> {
         self.changelog
-            .save(store, (key, U64Key::from(height)), &ChangeSet { old })
+            .save(store, (key, height), &ChangeSet { old })
     }
 
     // may_load_at_height reads historical data from given checkpoints.
@@ -148,7 +143,7 @@ where
 
         // this will look for the first snapshot of height >= given height
         // If None, there is no snapshot since that time.
-        let start = Bound::inclusive(U64Key::new(height));
+        let start = Bound::inclusive(height.to_be_bytes().to_vec());
         let first = self
             .changelog
             .prefix(key)


### PR DESCRIPTION
closes https://github.com/CosmWasm/cw-plus/issues/549

I succesfully replaced every `IntKey` usage both in contracts and packages (other then implementation itself + tests + de).

Looking at overall progress, I could actually remove whole `IntKey` implementation along with deserialization.
I wonder if it wouldn't be too drastic? This seems to be major change, although from end user POV nothing changes - it's all internal.