### PR TITLE
Index keys consistency

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -722,7 +722,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: &str = "5627";
+        let pk1 = "5627";
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -730,7 +730,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: &str = "5628";
+        let pk2 = "5628";
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -738,7 +738,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: &str = "5629";
+        let pk3 = "5629";
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -746,7 +746,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: &str = "5630";
+        let pk4 = "5630";
         map.save(&mut store, pk4, &data4).unwrap();
 
         let marias: Vec<_> = map
@@ -1089,7 +1089,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: (&str, &str) = ("1", "5627");
+        let pk1 = ("1", "5627");
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -1097,7 +1097,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: (&str, &str) = ("2", "5628");
+        let pk2 = ("2", "5628");
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -1105,7 +1105,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: (&str, &str) = ("2", "5629");
+        let pk3 = ("2", "5629");
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -1113,7 +1113,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: (&str, &str) = ("3", "5630");
+        let pk4 = ("3", "5630");
         map.save(&mut store, pk4, &data4).unwrap();
 
         // let's prefix and iterate
@@ -1148,7 +1148,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: (&str, &str, &str) = ("1", "1", "5627");
+        let pk1 = ("1", "1", "5627");
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -1156,7 +1156,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: (&str, &str, &str) = ("1", "2", "5628");
+        let pk2 = ("1", "2", "5628");
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -1164,7 +1164,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: (&str, &str, &str) = ("2", "1", "5629");
+        let pk3 = ("2", "1", "5629");
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -1172,7 +1172,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: (&str, &str, &str) = ("2", "2", "5630");
+        let pk4 = ("2", "2", "5630");
         map.save(&mut store, pk4, &data4).unwrap();
 
         // let's prefix and iterate
@@ -1204,7 +1204,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: (&str, &str, &str) = ("1", "1", "5627");
+        let pk1 = ("1", "1", "5627");
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -1212,7 +1212,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: (&str, &str, &str) = ("1", "2", "5628");
+        let pk2 = ("1", "2", "5628");
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -1220,7 +1220,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: (&str, &str, &str) = ("2", "1", "5629");
+        let pk3 = ("2", "1", "5629");
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -1228,7 +1228,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: (&str, &str, &str) = ("2", "2", "5630");
+        let pk4 = ("2", "2", "5630");
         map.save(&mut store, pk4, &data4).unwrap();
 
         // let's sub-prefix and iterate
@@ -1266,7 +1266,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: (&str, &str) = ("1", "5627");
+        let pk1 = ("1", "5627");
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -1274,7 +1274,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: (&str, &str) = ("2", "5628");
+        let pk2 = ("2", "5628");
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -1282,7 +1282,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: (&str, &str) = ("2", "5629");
+        let pk3 = ("2", "5629");
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -1290,7 +1290,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: (&str, &str) = ("3", "5630");
+        let pk4 = ("3", "5630");
         map.save(&mut store, pk4, &data4).unwrap();
 
         // let's try to iterate!
@@ -1351,7 +1351,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: (&str, &str, &str) = ("1", "1", "5627");
+        let pk1 = ("1", "1", "5627");
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -1359,7 +1359,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: (&str, &str, &str) = ("1", "2", "5628");
+        let pk2 = ("1", "2", "5628");
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -1367,7 +1367,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: (&str, &str, &str) = ("2", "1", "5629");
+        let pk3 = ("2", "1", "5629");
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -1375,7 +1375,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: (&str, &str, &str) = ("2", "2", "5630");
+        let pk4 = ("2", "2", "5630");
         map.save(&mut store, pk4, &data4).unwrap();
 
         // let's prefix-range and iterate

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -894,18 +894,18 @@ mod test {
         assert_eq!(5, count);
 
         // The pks, sorted by age ascending
-        assert_eq!(pks[4], String::from_slice(&ages[4].0).unwrap());
-        assert_eq!(pks[3], String::from_slice(&ages[0].0).unwrap());
-        assert_eq!(pks[1], String::from_slice(&ages[1].0).unwrap());
-        assert_eq!(pks[2], String::from_slice(&ages[2].0).unwrap());
-        assert_eq!(pks[0], String::from_slice(&ages[3].0).unwrap());
+        assert_eq!(pks[3], String::from_slice(&ages[0].0).unwrap()); // 12
+        assert_eq!(pks[1], String::from_slice(&ages[1].0).unwrap()); // 23
+        assert_eq!(pks[2], String::from_slice(&ages[2].0).unwrap()); // 32
+        assert_eq!(pks[0], String::from_slice(&ages[3].0).unwrap()); // 42
+        assert_eq!(pks[4], String::from_slice(&ages[4].0).unwrap()); // 90
 
         // The associated data
-        assert_eq!(datas[4], ages[4].1);
         assert_eq!(datas[3], ages[0].1);
         assert_eq!(datas[1], ages[1].1);
         assert_eq!(datas[2], ages[2].1);
         assert_eq!(datas[0], ages[3].1);
+        assert_eq!(datas[4], ages[4].1);
     }
 
     #[test]
@@ -927,18 +927,18 @@ mod test {
         assert_eq!(5, count);
 
         // The pks, sorted by age ascending
-        assert_eq!(pks[4], ages[4].0);
         assert_eq!(pks[3], ages[0].0);
         assert_eq!(pks[1], ages[1].0);
         assert_eq!(pks[2], ages[2].0);
         assert_eq!(pks[0], ages[3].0);
+        assert_eq!(pks[4], ages[4].0);
 
         // The associated data
-        assert_eq!(datas[4], ages[4].1);
         assert_eq!(datas[3], ages[0].1);
         assert_eq!(datas[1], ages[1].1);
         assert_eq!(datas[2], ages[2].1);
         assert_eq!(datas[0], ages[3].1);
+        assert_eq!(datas[4], ages[4].1);
     }
 
     #[test]

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -296,7 +296,7 @@ mod test {
 
     struct DataIndexes<'a> {
         // Second arg is for storing pk
-        pub name: MultiIndex<'a, (String, String), Data>,
+        pub name: MultiIndex<'a, (String, String), Data, String>,
         pub age: UniqueIndex<'a, u32, Data, String>,
         pub name_lastname: UniqueIndex<'a, (Vec<u8>, Vec<u8>), Data, String>,
     }
@@ -312,7 +312,7 @@ mod test {
     // For composite multi index tests
     struct DataCompositeMultiIndex<'a> {
         // Third arg needed for storing pk
-        pub name_age: MultiIndex<'a, (Vec<u8>, u32, Vec<u8>), Data>,
+        pub name_age: MultiIndex<'a, (Vec<u8>, u32, Vec<u8>), Data, String>,
     }
 
     // Future Note: this can likely be macro-derived
@@ -722,7 +722,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: &[u8] = b"5627";
+        let pk1: &str = "5627";
         map.save(&mut store, pk1, &data1).unwrap();
 
         let data2 = Data {
@@ -730,7 +730,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: &[u8] = b"5628";
+        let pk2: &str = "5628";
         map.save(&mut store, pk2, &data2).unwrap();
 
         let data3 = Data {
@@ -738,7 +738,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: &[u8] = b"5629";
+        let pk3: &str = "5629";
         map.save(&mut store, pk3, &data3).unwrap();
 
         let data4 = Data {
@@ -746,7 +746,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: &[u8] = b"5630";
+        let pk4: &str = "5630";
         map.save(&mut store, pk4, &data4).unwrap();
 
         let marias: Vec<_> = map
@@ -760,8 +760,8 @@ mod test {
         assert_eq!(2, count);
 
         // Remaining part (age) of the index keys, plus pks (bytes) (sorted by age descending)
-        assert_eq!((42, pk1.to_vec()), marias[0].0);
-        assert_eq!((24, pk3.to_vec()), marias[1].0);
+        assert_eq!(pk1, marias[0].0);
+        assert_eq!(pk3, marias[1].0);
 
         // Data
         assert_eq!(data1, marias[0].1);

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -18,7 +18,7 @@ pub trait IndexList<T> {
 }
 
 // TODO: remove traits here and make this const fn new
-/// IndexedBucket works like a bucket but has a secondary index
+/// `IndexedMap` works like a `Map` but has a secondary index
 pub struct IndexedMap<'a, K, T, I>
 where
     K: PrimaryKey<'a>,
@@ -574,7 +574,7 @@ mod test {
         let count = marias.len();
         assert_eq!(2, count);
 
-        // Sorted by (descending) pk
+        // Pks, sorted by (descending) pk
         assert_eq!(marias[0].0, b"5629");
         assert_eq!(marias[1].0, b"5627");
         // Data is correct
@@ -630,7 +630,7 @@ mod test {
         let count = marias.len();
         assert_eq!(2, count);
 
-        // Sorted by (descending) pk
+        // Pks, sorted by (descending) pk
         assert_eq!(marias[0].0, "5629");
         assert_eq!(marias[1].0, "5627");
         // Data is correct
@@ -694,7 +694,7 @@ mod test {
         let count = marias.len();
         assert_eq!(2, count);
 
-        // Pks (sorted by age descending)
+        // Pks, sorted by (descending) age
         assert_eq!(pk1, marias[0].0);
         assert_eq!(pk3, marias[1].0);
 
@@ -759,7 +759,7 @@ mod test {
         let count = marias.len();
         assert_eq!(2, count);
 
-        // Remaining part (age) of the index keys, plus pks (bytes) (sorted by age descending)
+        // Pks, sorted by (descending) age
         assert_eq!(pk1, marias[0].0);
         assert_eq!(pk3, marias[1].0);
 

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -312,7 +312,7 @@ mod test {
 
     struct DataIndexes<'a> {
         // Second arg is for storing pk
-        pub name: MultiIndex<'a, (Vec<u8>, String), Data>,
+        pub name: MultiIndex<'a, (Vec<u8>, String), Data, String>,
         // Last generic type arg is pk deserialization type
         pub age: UniqueIndex<'a, u32, Data, String>,
         // Last generic type arg is pk deserialization type
@@ -330,7 +330,7 @@ mod test {
     // For composite multi index tests
     struct DataCompositeMultiIndex<'a> {
         // Third arg needed for storing pk
-        pub name_age: MultiIndex<'a, (Vec<u8>, u32, Vec<u8>), Data>,
+        pub name_age: MultiIndex<'a, (Vec<u8>, u32, Vec<u8>), Data, String>,
     }
 
     // Future Note: this can likely be macro-derived
@@ -752,8 +752,8 @@ mod test {
         assert_eq!(2, count);
 
         // Pks (sorted by age descending)
-        assert_eq!((42, pk1.as_bytes().to_owned()), marias[0].0);
-        assert_eq!((24, pk3.as_bytes().to_owned()), marias[1].0);
+        assert_eq!(pk1.to_string(), marias[0].0);
+        assert_eq!(pk3.to_string(), marias[1].0);
 
         // Data
         assert_eq!(data1, marias[0].1);

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -380,7 +380,7 @@ mod test {
             last_name: "Doe".to_string(),
             age: 42,
         };
-        let pk: &str = "1";
+        let pk = "1";
         map.save(store, pk, &data, height).unwrap();
         height += 1;
         pks.push(pk);
@@ -392,7 +392,7 @@ mod test {
             last_name: "Williams".to_string(),
             age: 23,
         };
-        let pk: &str = "2";
+        let pk = "2";
         map.save(store, pk, &data, height).unwrap();
         height += 1;
         pks.push(pk);
@@ -404,7 +404,7 @@ mod test {
             last_name: "Wayne".to_string(),
             age: 32,
         };
-        let pk: &str = "3";
+        let pk = "3";
         map.save(store, pk, &data, height).unwrap();
         height += 1;
         pks.push(pk);
@@ -415,7 +415,7 @@ mod test {
             last_name: "Rodriguez".to_string(),
             age: 12,
         };
-        let pk: &str = "4";
+        let pk = "4";
         map.save(store, pk, &data, height).unwrap();
         pks.push(pk);
         datas.push(data);
@@ -512,7 +512,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk: &str = "5627";
+        let pk = "5627";
         map.save(&mut store, pk, &data1, height).unwrap();
         height += 1;
 
@@ -521,7 +521,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk: &str = "5628";
+        let pk = "5628";
         map.save(&mut store, pk, &data2, height).unwrap();
         height += 1;
 
@@ -530,7 +530,7 @@ mod test {
             last_name: "Williams".to_string(),
             age: 24,
         };
-        let pk: &str = "5629";
+        let pk = "5629";
         map.save(&mut store, pk, &data3, height).unwrap();
         height += 1;
 
@@ -539,7 +539,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 12,
         };
-        let pk: &str = "5630";
+        let pk = "5630";
         map.save(&mut store, pk, &data4, height).unwrap();
 
         let marias: Vec<_> = map
@@ -572,7 +572,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk: &str = "5627";
+        let pk = "5627";
         map.save(&mut store, pk, &data1, height).unwrap();
         height += 1;
 
@@ -581,7 +581,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk: &str = "5628";
+        let pk = "5628";
         map.save(&mut store, pk, &data2, height).unwrap();
         height += 1;
 
@@ -590,7 +590,7 @@ mod test {
             last_name: "Williams".to_string(),
             age: 24,
         };
-        let pk: &str = "5629";
+        let pk = "5629";
         map.save(&mut store, pk, &data3, height).unwrap();
         height += 1;
 
@@ -599,7 +599,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 12,
         };
-        let pk: &str = "5630";
+        let pk = "5630";
         map.save(&mut store, pk, &data4, height).unwrap();
 
         let marias: Vec<_> = map
@@ -641,7 +641,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: &str = "5627";
+        let pk1 = "5627";
         map.save(&mut store, pk1, &data1, height).unwrap();
         height += 1;
 
@@ -650,7 +650,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: &str = "5628";
+        let pk2 = "5628";
         map.save(&mut store, pk2, &data2, height).unwrap();
         height += 1;
 
@@ -659,7 +659,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: &str = "5629";
+        let pk3 = "5629";
         map.save(&mut store, pk3, &data3, height).unwrap();
         height += 1;
 
@@ -668,7 +668,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: &str = "5630";
+        let pk4 = "5630";
         map.save(&mut store, pk4, &data4, height).unwrap();
 
         let marias: Vec<_> = map
@@ -711,7 +711,7 @@ mod test {
             last_name: "".to_string(),
             age: 42,
         };
-        let pk1: &str = "5627";
+        let pk1 = "5627";
         map.save(&mut store, pk1, &data1, height).unwrap();
         height += 1;
 
@@ -720,7 +720,7 @@ mod test {
             last_name: "Perez".to_string(),
             age: 13,
         };
-        let pk2: &str = "5628";
+        let pk2 = "5628";
         map.save(&mut store, pk2, &data2, height).unwrap();
         height += 1;
 
@@ -729,7 +729,7 @@ mod test {
             last_name: "Young".to_string(),
             age: 24,
         };
-        let pk3: &str = "5629";
+        let pk3 = "5629";
         map.save(&mut store, pk3, &data3, height).unwrap();
         height += 1;
 
@@ -738,7 +738,7 @@ mod test {
             last_name: "Bemberg".to_string(),
             age: 43,
         };
-        let pk4: &str = "5630";
+        let pk4 = "5630";
         map.save(&mut store, pk4, &data4, height).unwrap();
 
         let marias: Vec<_> = map
@@ -775,7 +775,7 @@ mod test {
             last_name: "Laurens".to_string(),
             age: 42,
         };
-        let pk5: &str = "4";
+        let pk5 = "4";
 
         // enforce this returns some error
         map.save(&mut store, pk5, &data5, height).unwrap_err();
@@ -822,7 +822,7 @@ mod test {
             last_name: "Doe".to_string(),
             age: 24,
         };
-        let pk5: &str = "5";
+        let pk5 = "5";
         // enforce this returns some error
         map.save(&mut store, pk5, &data5, height).unwrap_err();
     }

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -12,7 +12,7 @@ use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
 use crate::snapshot::SnapshotMap;
 use crate::{IndexList, Path, Strategy};
 
-/// IndexedSnapshotMap works like a SnapshotMap but has a secondary index
+/// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
 pub struct IndexedSnapshotMap<'a, K, T, I> {
     pk_namespace: &'a [u8],
     primary: SnapshotMap<'a, K, T>,

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -95,7 +95,6 @@ fn deserialize_multi_v<T: DeserializeOwned>(
         .ok_or_else(|| StdError::generic_err("pk not found"))?;
     let v = from_slice::<T>(&v)?;
 
-    // FIXME: Return `key` here instead of `pk` (be consistent with `deserialize_multi_kv` and `Map` behaviour)
     Ok((pk.to_vec(), v))
 }
 
@@ -120,6 +119,7 @@ fn deserialize_multi_kv<K: KeyDeserialize, T: DeserializeOwned>(
         .ok_or_else(|| StdError::generic_err("pk not found"))?;
     let v = from_slice::<T>(&v)?;
 
+    // FIXME: Return `pk` here instead of `key` for consistency
     Ok((K::from_vec(key)?, v))
 }
 

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -31,7 +31,7 @@ pub struct MultiIndex<'a, K, T, PK = ()> {
     idx_namespace: &'a [u8],
     idx_map: Map<'a, K, u32>,
     pk_namespace: &'a [u8],
-    _phantom: PhantomData<PK>,
+    phantom: PhantomData<PK>,
 }
 
 impl<'a, K, T, PK> MultiIndex<'a, K, T, PK>
@@ -73,7 +73,7 @@ where
             idx_namespace: idx_namespace.as_bytes(),
             idx_map: Map::new(idx_namespace),
             pk_namespace: pk_namespace.as_bytes(),
-            _phantom: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -188,8 +188,8 @@ where
     pub fn prefix_range_de<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<PrefixBound<'a, PK::Prefix>>,
-        max: Option<PrefixBound<'a, PK::Prefix>>,
+        min: Option<PrefixBound<'a, K::Prefix>>,
+        max: Option<PrefixBound<'a, K::Prefix>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(PK::Output, T)>> + 'c>
     where

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -29,7 +29,7 @@ pub struct UniqueIndex<'a, K, T, PK = ()> {
     index: fn(&T) -> K,
     idx_map: Map<'a, K, UniqueRef<T>>,
     idx_namespace: &'a [u8],
-    _phantom: PhantomData<PK>,
+    phantom: PhantomData<PK>,
 }
 
 impl<'a, K, T, PK> UniqueIndex<'a, K, T, PK> {
@@ -56,7 +56,7 @@ impl<'a, K, T, PK> UniqueIndex<'a, K, T, PK> {
             index: idx_fn,
             idx_map: Map::new(idx_namespace),
             idx_namespace: idx_namespace.as_bytes(),
-            _phantom: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -92,8 +92,7 @@ where
 fn deserialize_unique_v<T: DeserializeOwned>(kv: Record) -> StdResult<Record<T>> {
     let (_, v) = kv;
     let t = from_slice::<UniqueRef<T>>(&v)?;
-    // FIXME: Return `k` here instead of `t.pk` (be consistent with `Map` behaviour)
-    Ok((t.pk.to_vec(), t.value))
+    Ok((t.pk.0, t.value))
 }
 
 fn deserialize_unique_kv<K: KeyDeserialize, T: DeserializeOwned>(
@@ -101,8 +100,7 @@ fn deserialize_unique_kv<K: KeyDeserialize, T: DeserializeOwned>(
 ) -> StdResult<(K::Output, T)> {
     let (_, v) = kv;
     let t = from_slice::<UniqueRef<T>>(&v)?;
-    // FIXME: Return `k` deserialization here instead of `t.pk` (be consistent with `deserialize_multi_kv` and `Map` behaviour)
-    Ok((K::from_vec(t.pk.to_vec())?, t.value))
+    Ok((K::from_vec(t.pk.0)?, t.value))
 }
 
 impl<'a, K, T, PK> UniqueIndex<'a, K, T, PK>


### PR DESCRIPTION
Closes #532.

This simplifies the key returned by `MultiIndex`, so that it is consistent with the `UniqueIndex` key.

In principle the other approach is also possible: making `UniqueIndex` return the same than `MultiIndex`; see https://github.com/CosmWasm/cw-plus/tree/532-index-keys-consistency.

But this approach is simpler: we just return a tuple with the associated primary key, and the value. Given that the index key is a combination of the data fields present in the value, this makes sense, both to avoid returning redundant data and for simplicity.

This PR also introduces a generic type for signaling the type for primary key deserialization, like in `UniqueIndex`. So, it also closes (the first part of) #531.

Overall, the end result is that both indices are now behaving more similarly. Both in their returned values and also in their specification.