### PR TITLE
`MultiIndex` primary key spec removal

### DIFF
--- a/packages/storage-plus/README.md
+++ b/packages/storage-plus/README.md
@@ -205,7 +205,7 @@ That means that byte and string slices, byte vectors, and strings, can be conven
 Moreover, some other types can be used as well, like addresses and address references, pairs and triples, and
 integer types.
 
-If the key represents and address, we suggest using `&Addr` for keys in storage, instead of `String` or string slices.
+If the key represents an address, we suggest using `&Addr` for keys in storage, instead of `String` or string slices.
 This implies doing address validation through `addr_validate` on any address passed in via a message, to ensure it's a
 legitimate address, and not random text which will fail later.
 `pub fn addr_validate(&self, &str) -> Addr` in `deps.api` can be used for address validation, and the returned `Addr`

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -295,7 +295,7 @@ mod test {
     }
 
     struct DataIndexes<'a> {
-        // Last args are for signaling pk deserialization
+        // Last type parameters are for signaling pk deserialization
         pub name: MultiIndex<'a, String, Data, String>,
         pub age: UniqueIndex<'a, u32, Data, String>,
         pub name_lastname: UniqueIndex<'a, (Vec<u8>, Vec<u8>), Data, String>,
@@ -311,7 +311,7 @@ mod test {
 
     // For composite multi index tests
     struct DataCompositeMultiIndex<'a> {
-        // Last arg is for signaling pk deserialization
+        // Last type parameter is for signaling pk deserialization
         pub name_age: MultiIndex<'a, (Vec<u8>, u32), Data, String>,
     }
 

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -311,7 +311,7 @@ mod test {
     }
 
     struct DataIndexes<'a> {
-        // Last args are for signaling pk deserialization
+        // Last type parameters are for signaling pk deserialization
         pub name: MultiIndex<'a, Vec<u8>, Data, String>,
         pub age: UniqueIndex<'a, u32, Data, String>,
         pub name_lastname: UniqueIndex<'a, (Vec<u8>, Vec<u8>), Data, String>,
@@ -327,7 +327,7 @@ mod test {
 
     // For composite multi index tests
     struct DataCompositeMultiIndex<'a> {
-        // Last arg is for signaling pk deserialization
+        // Last type parameter is for signaling pk deserialization
         pub name_age: MultiIndex<'a, (Vec<u8>, u32), Data, String>,
     }
 

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -297,8 +297,8 @@ where
 mod test {
     use super::*;
 
-    use crate::indexes::{index_string_tuple, index_triple};
-    use crate::{Index, MultiIndex, UniqueIndex};
+    use crate::indexes::index_string_tuple;
+    use crate::{index_tuple, Index, MultiIndex, UniqueIndex};
     use cosmwasm_std::testing::MockStorage;
     use cosmwasm_std::{MemoryStorage, Order};
     use serde::{Deserialize, Serialize};
@@ -311,11 +311,9 @@ mod test {
     }
 
     struct DataIndexes<'a> {
-        // Second arg is for storing pk
-        pub name: MultiIndex<'a, (Vec<u8>, String), Data, String>,
-        // Last generic type arg is pk deserialization type
+        // Last args are for signaling pk deserialization
+        pub name: MultiIndex<'a, Vec<u8>, Data, String>,
         pub age: UniqueIndex<'a, u32, Data, String>,
-        // Last generic type arg is pk deserialization type
         pub name_lastname: UniqueIndex<'a, (Vec<u8>, Vec<u8>), Data, String>,
     }
 
@@ -329,8 +327,8 @@ mod test {
 
     // For composite multi index tests
     struct DataCompositeMultiIndex<'a> {
-        // Third arg needed for storing pk
-        pub name_age: MultiIndex<'a, (Vec<u8>, u32, Vec<u8>), Data, String>,
+        // Last arg is for signaling pk deserialization
+        pub name_age: MultiIndex<'a, (Vec<u8>, u32), Data, String>,
     }
 
     // Future Note: this can likely be macro-derived
@@ -344,15 +342,7 @@ mod test {
     // Can we make it easier to define this? (less wordy generic)
     fn build_snapshot_map<'a>() -> IndexedSnapshotMap<'a, &'a str, Data, DataIndexes<'a>> {
         let indexes = DataIndexes {
-            name: MultiIndex::new(
-                |d, k| {
-                    (d.name.as_bytes().to_vec(), unsafe {
-                        String::from_utf8_unchecked(k)
-                    })
-                },
-                "data",
-                "data__name",
-            ),
+            name: MultiIndex::new(|d| d.name.as_bytes().to_vec(), "data", "data__name"),
             age: UniqueIndex::new(|d| d.age, "data__age"),
             name_lastname: UniqueIndex::new(
                 |d| index_string_tuple(&d.name, &d.last_name),
@@ -445,10 +435,7 @@ mod test {
             .count();
         assert_eq!(2, count);
 
-        // TODO: we load by wrong keys - get full storage key!
-
-        // load it by secondary index (we must know how to compute this)
-        // let marias: Vec<_>> = map
+        // load it by secondary index
         let marias: Vec<_> = map
             .idx
             .name
@@ -626,11 +613,7 @@ mod test {
         let mut height = 2;
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(
-                |d, k| index_triple(&d.name, d.age, k),
-                "data",
-                "data__name_age",
-            ),
+            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
         };
         let map =
             IndexedSnapshotMap::new("data", "checks", "changes", Strategy::EveryBlock, indexes);
@@ -696,11 +679,7 @@ mod test {
         let mut height = 2;
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(
-                |d, k| index_triple(&d.name, d.age, k),
-                "data",
-                "data__name_age",
-            ),
+            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
         };
         let map =
             IndexedSnapshotMap::new("data", "checks", "changes", Strategy::EveryBlock, indexes);
@@ -1096,11 +1075,7 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(
-                |d, k| index_triple(&d.name, d.age, k),
-                "data",
-                "data__name_age",
-            ),
+            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
         };
         let map =
             IndexedSnapshotMap::new("data", "checks", "changes", Strategy::EveryBlock, indexes);

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -39,7 +39,7 @@ where
     // TODO: make this a const fn
     /// Create a new MultiIndex
     ///
-    /// idx_fn - lambda creating index key from value (first argument) and primary key (second argument)
+    /// idx_fn - lambda creating index key from value
     /// pk_namespace - prefix for the primary key
     /// idx_namespace - prefix for the index value
     ///

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -76,6 +76,11 @@ pub trait PrimaryKey<'a>: Clone {
             keys[l - 1].as_ref(),
         )
     }
+
+    fn joined_extra_key(&self, key: &[u8]) -> Vec<u8> {
+        let keys = self.key();
+        namespaces_with_key(&keys.iter().map(Key::as_ref).collect::<Vec<_>>(), key)
+    }
 }
 
 // Empty / no primary key


### PR DESCRIPTION
Closes #533.

Builds on top of #568. Makes it simpler to handle `MultiIndex` by removing the pk from the index key specification.

Solved it by collapsing the index key along with an extra element (the raw pk). This makes it possible to keep the old format in the store, as the new (internally generated) index key would be exactly the same as the one corresponding to the previous key spec.

Overall, I'm pretty happy with this implementation. It has some tricks, like shifting the definition of what is a prefix and a sub-prefix. So that prefixes can still be specified over the **full** index key (which doesn't include the primary key in its spec anymore). Despite (or because of) that, I think the end result is both clear and ergonomic.

This PR also renames `K` to `IK` for clarity. So, it also closes (the second part of) #531.

TODO:

- ~~Update related documentation / comments~~. (done)