### PR TITLE
`range` to `range raw`

### DIFF
--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -410,7 +410,7 @@ pub fn query_all_allowances(
     let start = start_after.map(Bound::exclusive);
 
     let res: StdResult<Vec<AllowanceInfo>> = ALLOWANCES
-        .range(deps.storage, start, None, Order::Ascending)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .filter(|item| {
             if let Ok((_, allow)) = item {
                 !allow.expires.is_expired(&env.block)
@@ -442,7 +442,7 @@ pub fn query_all_permissions(
     let start = start_after.map(Bound::exclusive);
 
     let res: StdResult<Vec<PermissionsInfo>> = PERMISSIONS
-        .range(deps.storage, start, None, Order::Ascending)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
             item.and_then(|(k, perm)| {

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -497,8 +497,8 @@ fn query_all_approvals(
     let start = start_after.map(|addr| Bound::exclusive(addr.as_ref()));
 
     let operators = APPROVES
-        .prefix(&owner)
-        .range(deps.storage, start, None, Order::Ascending)
+        .prefix_de(&owner)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .filter(|r| include_expired || r.is_err() || !r.as_ref().unwrap().1.is_expired(&env.block))
         .take(limit)
         .map(parse_approval)
@@ -516,8 +516,8 @@ fn query_tokens(
     let start = start_after.map(Bound::exclusive);
 
     let tokens = BALANCES
-        .prefix(&owner)
-        .range(deps.storage, start, None, Order::Ascending)
+        .prefix_de(&owner)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| item.map(|(k, _)| String::from_utf8(k).unwrap()))
         .collect::<StdResult<_>>()?;

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -497,7 +497,7 @@ fn query_all_approvals(
     let start = start_after.map(|addr| Bound::exclusive(addr.as_ref()));
 
     let operators = APPROVES
-        .prefix_de(&owner)
+        .prefix(&owner)
         .range_raw(deps.storage, start, None, Order::Ascending)
         .filter(|r| include_expired || r.is_err() || !r.as_ref().unwrap().1.is_expired(&env.block))
         .take(limit)
@@ -516,7 +516,7 @@ fn query_tokens(
     let start = start_after.map(Bound::exclusive);
 
     let tokens = BALANCES
-        .prefix_de(&owner)
+        .prefix(&owner)
         .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| item.map(|(k, _)| String::from_utf8(k).unwrap()))

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -517,9 +517,8 @@ fn query_tokens(
 
     let tokens = BALANCES
         .prefix(&owner)
-        .range_raw(deps.storage, start, None, Order::Ascending)
+        .keys(deps.storage, start, None, Order::Ascending)
         .take(limit)
-        .map(|item| item.map(|(k, _)| String::from_utf8(k).unwrap()))
         .collect::<StdResult<_>>()?;
     Ok(TokensResponse { tokens })
 }
@@ -532,9 +531,8 @@ fn query_all_tokens(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start = start_after.map(Bound::exclusive);
     let tokens = TOKENS
-        .range_raw(deps.storage, start, None, Order::Ascending)
+        .keys(deps.storage, start, None, Order::Ascending)
         .take(limit)
-        .map(|item| item.map(|(k, _)| String::from_utf8(k).unwrap()))
         .collect::<StdResult<_>>()?;
     Ok(TokensResponse { tokens })
 }

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -532,7 +532,7 @@ fn query_all_tokens(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start = start_after.map(Bound::exclusive);
     let tokens = TOKENS
-        .range(deps.storage, start, None, Order::Ascending)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| item.map(|(k, _)| String::from_utf8(k).unwrap()))
         .collect::<StdResult<_>>()?;

--- a/contracts/cw20-atomic-swap/src/state.rs
+++ b/contracts/cw20-atomic-swap/src/state.rs
@@ -32,7 +32,7 @@ pub fn all_swap_ids(
     limit: usize,
 ) -> StdResult<Vec<String>> {
     SWAPS
-        .keys(storage, start, None, Order::Ascending)
+        .keys_raw(storage, start, None, Order::Ascending)
         .take(limit)
         .map(|k| String::from_utf8(k).map_err(|_| StdError::invalid_utf8("Parsing swap id")))
         .collect()

--- a/contracts/cw20-atomic-swap/src/state.rs
+++ b/contracts/cw20-atomic-swap/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Binary, BlockInfo, Order, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, Binary, BlockInfo, Order, StdResult, Storage};
 use cw_storage_plus::{Bound, Map};
 
 use cw20::{Balance, Expiration};
@@ -32,9 +32,8 @@ pub fn all_swap_ids(
     limit: usize,
 ) -> StdResult<Vec<String>> {
     SWAPS
-        .keys_raw(storage, start, None, Order::Ascending)
+        .keys(storage, start, None, Order::Ascending)
         .take(limit)
-        .map(|k| String::from_utf8(k).map_err(|_| StdError::invalid_utf8("Parsing swap id")))
         .collect()
 }
 

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -19,8 +19,8 @@ pub fn query_all_allowances(
     let start = start_after.map(Bound::exclusive);
 
     let allowances: StdResult<Vec<AllowanceInfo>> = ALLOWANCES
-        .prefix(&owner_addr)
-        .range(deps.storage, start, None, Order::Ascending)
+        .prefix_de(&owner_addr)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
             let (k, v) = item?;

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -19,7 +19,7 @@ pub fn query_all_allowances(
     let start = start_after.map(Bound::exclusive);
 
     let allowances: StdResult<Vec<AllowanceInfo>> = ALLOWANCES
-        .prefix_de(&owner_addr)
+        .prefix(&owner_addr)
         .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -41,15 +41,13 @@ pub fn query_all_accounts(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start = start_after.map(Bound::exclusive);
 
-    let accounts: Result<Vec<_>, _> = BALANCES
-        .keys_raw(deps.storage, start, None, Order::Ascending)
-        .map(String::from_utf8)
+    let accounts = BALANCES
+        .keys(deps.storage, start, None, Order::Ascending)
         .take(limit)
-        .collect();
+        .map(|item| item.map(Into::into))
+        .collect::<StdResult<_>>()?;
 
-    Ok(AllAccountsResponse {
-        accounts: accounts?,
-    })
+    Ok(AllAccountsResponse { accounts })
 }
 
 #[cfg(test)]

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -45,7 +45,7 @@ pub fn query_all_accounts(
     let start = start_after.map(Bound::exclusive);
 
     let accounts: Result<Vec<_>, _> = BALANCES
-        .keys(deps.storage, start, None, Order::Ascending)
+        .keys_raw(deps.storage, start, None, Order::Ascending)
         .map(String::from_utf8)
         .take(limit)
         .collect();

--- a/contracts/cw20-escrow/src/state.rs
+++ b/contracts/cw20-escrow/src/state.rs
@@ -95,7 +95,7 @@ pub const ESCROWS: Map<&str, Escrow> = Map::new("escrow");
 /// This returns the list of ids for all registered escrows
 pub fn all_escrow_ids(storage: &dyn Storage) -> StdResult<Vec<String>> {
     ESCROWS
-        .keys(storage, None, None, Order::Ascending)
+        .keys_raw(storage, None, None, Order::Ascending)
         .map(|k| String::from_utf8(k).map_err(|_| StdError::invalid_utf8("parsing escrow key")))
         .collect()
 }

--- a/contracts/cw20-escrow/src/state.rs
+++ b/contracts/cw20-escrow/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Coin, Env, Order, StdError, StdResult, Storage, Timestamp};
+use cosmwasm_std::{Addr, Coin, Env, Order, StdResult, Storage, Timestamp};
 use cw_storage_plus::Map;
 
 use cw20::{Balance, Cw20CoinVerified};
@@ -95,8 +95,7 @@ pub const ESCROWS: Map<&str, Escrow> = Map::new("escrow");
 /// This returns the list of ids for all registered escrows
 pub fn all_escrow_ids(storage: &dyn Storage) -> StdResult<Vec<String>> {
     ESCROWS
-        .keys_raw(storage, None, None, Order::Ascending)
-        .map(|k| String::from_utf8(k).map_err(|_| StdError::invalid_utf8("parsing escrow key")))
+        .keys(storage, None, None, Order::Ascending)
         .collect()
 }
 

--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -165,8 +165,8 @@ pub fn query_channel(deps: Deps, id: String) -> StdResult<ChannelResponse> {
     let info = CHANNEL_INFO.load(deps.storage, &id)?;
     // this returns Vec<(outstanding, total)>
     let state: StdResult<Vec<_>> = CHANNEL_STATE
-        .prefix(&id)
-        .range(deps.storage, None, None, Order::Ascending)
+        .prefix_de(&id)
+        .range_raw(deps.storage, None, None, Order::Ascending)
         .map(|r| {
             let (k, v) = r?;
             let denom = String::from_utf8(k)?;

--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -151,32 +151,30 @@ fn query_port(deps: Deps) -> StdResult<PortResponse> {
 }
 
 fn query_list(deps: Deps) -> StdResult<ListChannelsResponse> {
-    let channels: StdResult<Vec<_>> = CHANNEL_INFO
+    let channels = CHANNEL_INFO
         .range_raw(deps.storage, None, None, Order::Ascending)
         .map(|r| r.map(|(_, v)| v))
-        .collect();
-    Ok(ListChannelsResponse {
-        channels: channels?,
-    })
+        .collect::<StdResult<_>>()?;
+    Ok(ListChannelsResponse { channels })
 }
 
 // make public for ibc tests
 pub fn query_channel(deps: Deps, id: String) -> StdResult<ChannelResponse> {
     let info = CHANNEL_INFO.load(deps.storage, &id)?;
     // this returns Vec<(outstanding, total)>
-    let state: StdResult<Vec<_>> = CHANNEL_STATE
+    let state = CHANNEL_STATE
         .prefix(&id)
-        .range_raw(deps.storage, None, None, Order::Ascending)
+        .range(deps.storage, None, None, Order::Ascending)
         .map(|r| {
-            let (k, v) = r?;
-            let denom = String::from_utf8(k)?;
-            let outstanding = Amount::from_parts(denom.clone(), v.outstanding);
-            let total = Amount::from_parts(denom, v.total_sent);
-            Ok((outstanding, total))
+            r.map(|(denom, v)| {
+                let outstanding = Amount::from_parts(denom.clone(), v.outstanding);
+                let total = Amount::from_parts(denom, v.total_sent);
+                (outstanding, total)
+            })
         })
-        .collect();
+        .collect::<StdResult<Vec<_>>>()?;
     // we want (Vec<outstanding>, Vec<total>)
-    let (balances, total_sent) = state?.into_iter().unzip();
+    let (balances, total_sent) = state.into_iter().unzip();
 
     Ok(ChannelResponse {
         info,

--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -165,7 +165,7 @@ pub fn query_channel(deps: Deps, id: String) -> StdResult<ChannelResponse> {
     let info = CHANNEL_INFO.load(deps.storage, &id)?;
     // this returns Vec<(outstanding, total)>
     let state: StdResult<Vec<_>> = CHANNEL_STATE
-        .prefix_de(&id)
+        .prefix(&id)
         .range_raw(deps.storage, None, None, Order::Ascending)
         .map(|r| {
             let (k, v) = r?;

--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -152,7 +152,7 @@ fn query_port(deps: Deps) -> StdResult<PortResponse> {
 
 fn query_list(deps: Deps) -> StdResult<ListChannelsResponse> {
     let channels: StdResult<Vec<_>> = CHANNEL_INFO
-        .range(deps.storage, None, None, Order::Ascending)
+        .range_raw(deps.storage, None, None, Order::Ascending)
         .map(|r| r.map(|(_, v)| v))
         .collect();
     Ok(ListChannelsResponse {

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -386,8 +386,8 @@ fn list_votes(
     let start = start_after.map(Bound::exclusive);
 
     let votes: StdResult<Vec<_>> = BALLOTS
-        .prefix(proposal_id)
-        .range(deps.storage, start, None, Order::Ascending)
+        .prefix_de(proposal_id)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
             let (key, ballot) = item?;

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -386,7 +386,7 @@ fn list_votes(
     let start = start_after.map(Bound::exclusive);
 
     let votes: StdResult<Vec<_>> = BALLOTS
-        .prefix_de(proposal_id)
+        .prefix(proposal_id)
         .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -17,9 +17,7 @@ use utils::Expiration;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{
-    next_id, parse_id, Ballot, Config, Proposal, BALLOTS, CONFIG, PROPOSALS, VOTERS,
-};
+use crate::state::{next_id, Ballot, Config, Proposal, BALLOTS, CONFIG, PROPOSALS, VOTERS};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw3-fixed-multisig";
@@ -315,13 +313,13 @@ fn list_proposals(
 
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start = start_after.map(Bound::exclusive_int);
-    let props: StdResult<Vec<_>> = PROPOSALS
-        .range_raw(deps.storage, start, None, Order::Ascending)
+    let proposals = PROPOSALS
+        .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|p| map_proposal(&env.block, &threshold, p))
-        .collect();
+        .collect::<StdResult<_>>()?;
 
-    Ok(ProposalListResponse { proposals: props? })
+    Ok(ProposalListResponse { proposals })
 }
 
 fn reverse_proposals(
@@ -338,30 +336,31 @@ fn reverse_proposals(
 
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let end = start_before.map(Bound::exclusive_int);
-    let props: StdResult<Vec<_>> = PROPOSALS
-        .range_raw(deps.storage, None, end, Order::Descending)
+    let proposals = PROPOSALS
+        .range(deps.storage, None, end, Order::Descending)
         .take(limit)
         .map(|p| map_proposal(&env.block, &threshold, p))
-        .collect();
+        .collect::<StdResult<_>>()?;
 
-    Ok(ProposalListResponse { proposals: props? })
+    Ok(ProposalListResponse { proposals })
 }
 
 fn map_proposal(
     block: &BlockInfo,
     threshold: &ThresholdResponse,
-    item: StdResult<(Vec<u8>, Proposal)>,
+    item: StdResult<(u64, Proposal)>,
 ) -> StdResult<ProposalResponse> {
-    let (key, prop) = item?;
-    let status = prop.current_status(block);
-    Ok(ProposalResponse {
-        id: parse_id(&key)?,
-        title: prop.title,
-        description: prop.description,
-        msgs: prop.msgs,
-        status,
-        expires: prop.expires,
-        threshold: threshold.clone(),
+    item.map(|(id, prop)| {
+        let status = prop.current_status(block);
+        ProposalResponse {
+            id,
+            title: prop.title,
+            description: prop.description,
+            msgs: prop.msgs,
+            status,
+            expires: prop.expires,
+            threshold: threshold.clone(),
+        }
     })
 }
 
@@ -385,21 +384,20 @@ fn list_votes(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start = start_after.map(Bound::exclusive);
 
-    let votes: StdResult<Vec<_>> = BALLOTS
+    let votes = BALLOTS
         .prefix(proposal_id)
-        .range_raw(deps.storage, start, None, Order::Ascending)
+        .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
-            let (key, ballot) = item?;
-            Ok(VoteInfo {
-                voter: String::from_utf8(key)?,
+            item.map(|(addr, ballot)| VoteInfo {
+                voter: addr.into(),
                 vote: ballot.vote,
                 weight: ballot.weight,
             })
         })
-        .collect();
+        .collect::<StdResult<_>>()?;
 
-    Ok(VoteListResponse { votes: votes? })
+    Ok(VoteListResponse { votes })
 }
 
 fn query_voter(deps: Deps, voter: String) -> StdResult<VoterResponse> {
@@ -416,19 +414,18 @@ fn list_voters(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start = start_after.map(Bound::exclusive);
 
-    let voters: StdResult<Vec<_>> = VOTERS
-        .range_raw(deps.storage, start, None, Order::Ascending)
+    let voters = VOTERS
+        .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
-            let (key, weight) = item?;
-            Ok(VoterDetail {
-                addr: String::from_utf8(key)?,
+            item.map(|(addr, weight)| VoterDetail {
+                addr: addr.into(),
                 weight,
             })
         })
-        .collect();
+        .collect::<StdResult<_>>()?;
 
-    Ok(VoterListResponse { voters: voters? })
+    Ok(VoterListResponse { voters })
 }
 
 #[cfg(test)]

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -316,7 +316,7 @@ fn list_proposals(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start = start_after.map(Bound::exclusive_int);
     let props: StdResult<Vec<_>> = PROPOSALS
-        .range(deps.storage, start, None, Order::Ascending)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|p| map_proposal(&env.block, &threshold, p))
         .collect();
@@ -339,7 +339,7 @@ fn reverse_proposals(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let end = start_before.map(Bound::exclusive_int);
     let props: StdResult<Vec<_>> = PROPOSALS
-        .range(deps.storage, None, end, Order::Descending)
+        .range_raw(deps.storage, None, end, Order::Descending)
         .take(limit)
         .map(|p| map_proposal(&env.block, &threshold, p))
         .collect();
@@ -417,7 +417,7 @@ fn list_voters(
     let start = start_after.map(Bound::exclusive);
 
     let voters: StdResult<Vec<_>> = VOTERS
-        .range(deps.storage, start, None, Order::Ascending)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
             let (key, weight) = item?;

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -318,7 +318,7 @@ fn list_proposals(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start = start_after.map(Bound::exclusive_int);
     let props: StdResult<Vec<_>> = PROPOSALS
-        .range(deps.storage, start, None, Order::Ascending)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|p| map_proposal(&env.block, p))
         .collect();
@@ -335,7 +335,7 @@ fn reverse_proposals(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let end = start_before.map(Bound::exclusive_int);
     let props: StdResult<Vec<_>> = PROPOSALS
-        .range(deps.storage, None, end, Order::Descending)
+        .range_raw(deps.storage, None, end, Order::Descending)
         .take(limit)
         .map(|p| map_proposal(&env.block, p))
         .collect();

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -383,8 +383,8 @@ fn list_votes(
     let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
 
     let votes: StdResult<Vec<_>> = BALLOTS
-        .prefix(proposal_id)
-        .range(deps.storage, start, None, Order::Ascending)
+        .prefix_de(proposal_id)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
             let (voter, ballot) = item?;

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -383,7 +383,7 @@ fn list_votes(
     let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
 
     let votes: StdResult<Vec<_>> = BALLOTS
-        .prefix_de(proposal_id)
+        .prefix(proposal_id)
         .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -192,19 +192,18 @@ fn list_members(
     let addr = maybe_addr(deps.api, start_after)?;
     let start = addr.map(|addr| Bound::exclusive(addr.to_string()));
 
-    let members: StdResult<Vec<_>> = MEMBERS
-        .range_raw(deps.storage, start, None, Order::Ascending)
+    let members = MEMBERS
+        .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
-            let (key, weight) = item?;
-            Ok(Member {
-                addr: String::from_utf8(key)?,
+            item.map(|(addr, weight)| Member {
+                addr: addr.into(),
                 weight,
             })
         })
-        .collect();
+        .collect::<StdResult<_>>()?;
 
-    Ok(MemberListResponse { members: members? })
+    Ok(MemberListResponse { members })
 }
 
 #[cfg(test)]

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -193,7 +193,7 @@ fn list_members(
     let start = addr.map(|addr| Bound::exclusive(addr.to_string()));
 
     let members: StdResult<Vec<_>> = MEMBERS
-        .range(deps.storage, start, None, Order::Ascending)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
             let (key, weight) = item?;

--- a/contracts/cw4-stake/src/contract.rs
+++ b/contracts/cw4-stake/src/contract.rs
@@ -342,7 +342,7 @@ fn list_members(
     let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
 
     let members: StdResult<Vec<_>> = MEMBERS
-        .range(deps.storage, start, None, Order::Ascending)
+        .range_raw(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
             let (key, weight) = item?;

--- a/contracts/cw4-stake/src/contract.rs
+++ b/contracts/cw4-stake/src/contract.rs
@@ -341,19 +341,18 @@ fn list_members(
     let addr = maybe_addr(deps.api, start_after)?;
     let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
 
-    let members: StdResult<Vec<_>> = MEMBERS
-        .range_raw(deps.storage, start, None, Order::Ascending)
+    let members = MEMBERS
+        .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
-            let (key, weight) = item?;
-            Ok(Member {
-                addr: String::from_utf8(key)?,
+            item.map(|(addr, weight)| Member {
+                addr: addr.into(),
                 weight,
             })
         })
-        .collect();
+        .collect::<StdResult<_>>()?;
 
-    Ok(MemberListResponse { members: members? })
+    Ok(MemberListResponse { members })
 }
 
 #[cfg(test)]

--- a/packages/controllers/src/claim.rs
+++ b/packages/controllers/src/claim.rs
@@ -118,7 +118,7 @@ mod test {
         assert_eq!(
             claims
                 .0
-                .range(&deps.storage, None, None, Order::Ascending)
+                .range_raw(&deps.storage, None, None, Order::Ascending)
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap()
                 .len(),

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -791,7 +791,7 @@ where
     fn next_address(&self, storage: &dyn Storage) -> Addr {
         // FIXME: quite inefficient if we actually had 100s of contracts
         let count = CONTRACTS
-            .range(storage, None, None, Order::Ascending)
+            .range_raw(storage, None, None, Order::Ascending)
             .count();
         // we make this longer so it is not rejected by tests
         Addr::unchecked(format!("Contract #{}", count.to_string()))

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -676,8 +676,8 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name_age
-            .sub_prefix(b"Maria".to_vec())
-            .range(&store, None, None, Order::Descending)
+            .sub_prefix_de(b"Maria".to_vec())
+            .range_raw(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
         let count = marias.len();

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -154,7 +154,7 @@ where
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
-    pub fn range<'c>(
+    pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -165,6 +165,16 @@ where
         T: 'c,
     {
         self.no_prefix().range_raw(store, min, max, order)
+    }
+
+    pub fn keys_raw<'c>(
+        &self,
+        store: &'c dyn Storage,
+        min: Option<Bound>,
+        max: Option<Bound>,
+        order: cosmwasm_std::Order,
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
+        self.no_prefix().keys_raw(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -130,7 +130,7 @@ where
     }
 
     // use no_prefix to scan -> range
-    fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
+    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &[])
     }
 }
@@ -154,7 +154,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range_raw(store, min, max, order)
+        self.no_prefix_raw().range_raw(store, min, max, order)
     }
 
     pub fn keys_raw<'c>(
@@ -164,7 +164,7 @@ where
         max: Option<Bound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
-        self.no_prefix().keys_raw(store, min, max, order)
+        self.no_prefix_raw().keys_raw(store, min, max, order)
     }
 }
 
@@ -255,7 +255,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -269,10 +269,10 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 
-    fn no_prefix_de(&self) -> Prefix<K, T> {
+    fn no_prefix(&self) -> Prefix<K, T> {
         Prefix::new(self.pk_namespace, &[])
     }
 }

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -414,8 +414,8 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix("Maria".to_string())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de("Maria".to_string())
+            .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(2, count);
 
@@ -423,8 +423,8 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix("Maria".to_string())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de("Maria".to_string())
+            .range_raw(&store, None, None, Order::Ascending)
             .collect::<StdResult<_>>()
             .unwrap();
         assert_eq!(2, marias.len());
@@ -436,8 +436,8 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix("Marib".to_string())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de("Marib".to_string())
+            .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
 
@@ -445,8 +445,8 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix("Mari`".to_string())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de("Mari`".to_string())
+            .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
 
@@ -454,8 +454,8 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix("Maria5".to_string())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de("Maria5".to_string())
+            .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
 
@@ -560,8 +560,8 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix("Maria".to_string())
-            .range(&store, None, None, Order::Descending)
+            .prefix_de("Maria".to_string())
+            .range_raw(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
         let count = marias.len();
@@ -827,7 +827,7 @@ mod test {
          -> usize {
             map.idx
                 .name
-                .prefix(name.to_string())
+                .prefix_de(name.to_string())
                 .keys_raw(store, None, None, Order::Ascending)
                 .count()
         };

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -204,11 +204,11 @@ where
     K: PrimaryKey<'a>,
     I: IndexList<T>,
 {
-    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 
-    pub fn prefix_de(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 }
@@ -220,13 +220,13 @@ where
     K: PrimaryKey<'a> + KeyDeserialize,
     I: IndexList<T>,
 {
-    /// While `range_de` over a `prefix_de` fixes the prefix to one element and iterates over the
-    /// remaining, `prefix_range_de` accepts bounds for the lowest and highest elements of the
+    /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
+    /// remaining, `prefix_range` accepts bounds for the lowest and highest elements of the
     /// `Prefix` itself, and iterates over those (inclusively or exclusively, depending on
     /// `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
-    pub fn prefix_range_de<'c>(
+    pub fn prefix_range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, K::Prefix>>,
@@ -244,7 +244,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn range_de<'c>(
+    pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -258,7 +258,7 @@ where
         self.no_prefix_de().range(store, min, max, order)
     }
 
-    pub fn keys_de<'c>(
+    pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -994,7 +994,7 @@ mod test {
         let (pks, datas) = save_data(&mut store, &map);
 
         // let's try to iterate!
-        let all: StdResult<Vec<_>> = map.range_de(&store, None, None, Order::Ascending).collect();
+        let all: StdResult<Vec<_>> = map.range(&store, None, None, Order::Ascending).collect();
         let all = all.unwrap();
         assert_eq!(
             all,
@@ -1007,7 +1007,7 @@ mod test {
 
         // let's try to iterate over a range
         let all: StdResult<Vec<_>> = map
-            .range_de(
+            .range(
                 &store,
                 Some(Bound::Inclusive(b"3".to_vec())),
                 None,
@@ -1040,7 +1040,7 @@ mod test {
         // This is similar to calling range() directly, but added here for completeness / prefix_de
         // type checks
         let all: StdResult<Vec<_>> = map
-            .prefix_de(())
+            .prefix(())
             .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -1099,7 +1099,7 @@ mod test {
 
         // let's prefix and iterate
         let result: StdResult<Vec<_>> = map
-            .prefix_de("2")
+            .prefix("2")
             .range(&store, None, None, Order::Ascending)
             .collect();
         let result = result.unwrap();
@@ -1154,7 +1154,7 @@ mod test {
 
         // let's prefix and iterate
         let result: StdResult<Vec<_>> = map
-            .prefix_de(("1", "2"))
+            .prefix(("1", "2"))
             .range(&store, None, None, Order::Ascending)
             .collect();
         let result = result.unwrap();
@@ -1206,7 +1206,7 @@ mod test {
 
         // let's sub-prefix and iterate
         let result: StdResult<Vec<_>> = map
-            .sub_prefix_de("1")
+            .sub_prefix("1")
             .range(&store, None, None, Order::Ascending)
             .collect();
         let result = result.unwrap();
@@ -1264,7 +1264,7 @@ mod test {
 
         // let's try to iterate!
         let result: StdResult<Vec<_>> = map
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::inclusive("2")),
                 None,
@@ -1283,7 +1283,7 @@ mod test {
 
         // let's try to iterate over a range
         let result: StdResult<Vec<_>> = map
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::inclusive("2")),
                 Some(PrefixBound::exclusive("3")),
@@ -1345,7 +1345,7 @@ mod test {
 
         // let's prefix-range and iterate
         let result: StdResult<Vec<_>> = map
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::inclusive(("1", "2"))),
                 None,
@@ -1373,7 +1373,7 @@ mod test {
 
         // let's prefix-range over inclusive bounds on both sides
         let result: StdResult<Vec<_>> = map
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::inclusive(("1", "2"))),
                 Some(PrefixBound::inclusive(("2", "1"))),

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -414,7 +414,7 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix_de("Maria".to_string())
+            .prefix("Maria".to_string())
             .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(2, count);
@@ -423,7 +423,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix_de("Maria".to_string())
+            .prefix("Maria".to_string())
             .range_raw(&store, None, None, Order::Ascending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -436,7 +436,7 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix_de("Marib".to_string())
+            .prefix("Marib".to_string())
             .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
@@ -445,7 +445,7 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix_de("Mari`".to_string())
+            .prefix("Mari`".to_string())
             .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
@@ -454,7 +454,7 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix_de("Maria5".to_string())
+            .prefix("Maria5".to_string())
             .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
@@ -560,7 +560,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix_de("Maria".to_string())
+            .prefix("Maria".to_string())
             .range_raw(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -616,7 +616,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix_de("Maria".to_string())
+            .prefix("Maria".to_string())
             .range(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -676,7 +676,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name_age
-            .sub_prefix_de(b"Maria".to_vec())
+            .sub_prefix(b"Maria".to_vec())
             .range_raw(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -737,7 +737,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name_age
-            .sub_prefix_de(b"Maria".to_vec())
+            .sub_prefix(b"Maria".to_vec())
             .range(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -827,7 +827,7 @@ mod test {
          -> usize {
             map.idx
                 .name
-                .prefix_de(name.to_string())
+                .prefix(name.to_string())
                 .keys_raw(store, None, None, Order::Ascending)
                 .count()
         };

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -164,7 +164,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range(store, min, max, order)
+        self.no_prefix().range_raw(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -828,7 +828,7 @@ mod test {
             map.idx
                 .name
                 .prefix(name.to_string())
-                .keys(store, None, None, Order::Ascending)
+                .keys_raw(store, None, None, Order::Ascending)
                 .count()
         };
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -255,7 +255,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().range_de(store, min, max, order)
+        self.no_prefix_de().range(store, min, max, order)
     }
 
     pub fn keys_de<'c>(
@@ -269,7 +269,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().keys_de(store, min, max, order)
+        self.no_prefix_de().keys(store, min, max, order)
     }
 
     fn no_prefix_de(&self) -> Prefix<K, T> {
@@ -617,7 +617,7 @@ mod test {
             .idx
             .name
             .prefix_de("Maria".to_string())
-            .range_de(&store, None, None, Order::Descending)
+            .range(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
         let count = marias.len();
@@ -738,7 +738,7 @@ mod test {
             .idx
             .name_age
             .sub_prefix_de(b"Maria".to_vec())
-            .range_de(&store, None, None, Order::Descending)
+            .range(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
         let count = marias.len();
@@ -967,7 +967,7 @@ mod test {
             .idx
             .name_lastname
             .prefix_de(b"Maria".to_vec())
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let marias = res.unwrap();
 
@@ -1041,7 +1041,7 @@ mod test {
         // type checks
         let all: StdResult<Vec<_>> = map
             .prefix_de(())
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(
@@ -1100,7 +1100,7 @@ mod test {
         // let's prefix and iterate
         let result: StdResult<Vec<_>> = map
             .prefix_de("2")
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let result = result.unwrap();
         assert_eq!(
@@ -1155,7 +1155,7 @@ mod test {
         // let's prefix and iterate
         let result: StdResult<Vec<_>> = map
             .prefix_de(("1", "2"))
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let result = result.unwrap();
         assert_eq!(result, [("5628".to_string(), data2),]);
@@ -1207,7 +1207,7 @@ mod test {
         // let's sub-prefix and iterate
         let result: StdResult<Vec<_>> = map
             .sub_prefix_de("1")
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let result = result.unwrap();
         assert_eq!(

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -469,7 +469,7 @@ mod test {
         let count = map
             .idx
             .name
-            .range(&store, Some(Bound::inclusive(key)), None, Order::Ascending)
+            .range_raw(&store, Some(Bound::inclusive(key)), None, Order::Ascending)
             .count();
         // gets from the first "Maria" until the end
         assert_eq!(4, count);
@@ -484,7 +484,7 @@ mod test {
         let count = map
             .idx
             .name
-            .range(&store, Some(Bound::exclusive(key)), None, Order::Ascending)
+            .range_raw(&store, Some(Bound::exclusive(key)), None, Order::Ascending)
             .count();
         // gets from the 2nd "Maria" until the end
         assert_eq!(3, count);
@@ -497,7 +497,7 @@ mod test {
         let count = map
             .idx
             .age
-            .range(
+            .range_raw(
                 &store,
                 Some(Bound::inclusive(age_key)),
                 None,
@@ -871,7 +871,7 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .age
-            .range(&store, None, None, Order::Ascending)
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let ages = res.unwrap();
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -937,8 +937,8 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .name_lastname
-            .prefix(b"Maria".to_vec())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"Maria".to_vec())
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let marias = res.unwrap();
 

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -904,7 +904,7 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .age
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let ages = res.unwrap();
 
@@ -937,7 +937,7 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .name_lastname
-            .prefix_de(b"Maria".to_vec())
+            .prefix(b"Maria".to_vec())
             .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let marias = res.unwrap();
@@ -966,7 +966,7 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .name_lastname
-            .prefix_de(b"Maria".to_vec())
+            .prefix(b"Maria".to_vec())
             .range(&store, None, None, Order::Ascending)
             .collect();
         let marias = res.unwrap();

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -129,16 +129,6 @@ where
         self.primary.may_load(store, key)
     }
 
-    // use prefix to scan -> range
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
-        Prefix::new(self.pk_namespace, &p.prefix())
-    }
-
-    // use sub_prefix to scan -> range
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
-        Prefix::new(self.pk_namespace, &p.prefix())
-    }
-
     // use no_prefix to scan -> range
     fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &[])

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -180,7 +180,7 @@ where
     /// itself, and iterates over those (inclusively or exclusively, depending on `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
-    pub fn prefix_range<'c>(
+    pub fn prefix_range_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, K::Prefix>>,
@@ -1429,7 +1429,7 @@ mod test {
             let items: Vec<_> = map
                 .idx
                 .secondary
-                .prefix_range(
+                .prefix_range_raw(
                     &store,
                     None,
                     Some(PrefixBound::inclusive(1u64)),

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -135,7 +135,7 @@ where
     }
 }
 
-// short-cut for simple keys, rather than .prefix(()).range(...)
+// short-cut for simple keys, rather than .prefix(()).range_raw(...)
 impl<'a, K, T, I> IndexedMap<'a, K, T, I>
 where
     K: PrimaryKey<'a>,
@@ -175,8 +175,8 @@ where
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
 {
-    /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
-    /// remaining, `prefix_range` accepts bounds for the lowest and highest elements of the `Prefix`
+    /// While `range_raw` over a `prefix` fixes the prefix to one element and iterates over the
+    /// remaining, `prefix_range_raw` accepts bounds for the lowest and highest elements of the `Prefix`
     /// itself, and iterates over those (inclusively or exclusively, depending on `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
@@ -520,7 +520,7 @@ mod test {
     }
 
     #[test]
-    fn range_simple_key_by_multi_index() {
+    fn range_raw_simple_key_by_multi_index() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -576,7 +576,7 @@ mod test {
     }
 
     #[test]
-    fn range_de_simple_key_by_multi_index() {
+    fn range_simple_key_by_multi_index() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -632,7 +632,7 @@ mod test {
     }
 
     #[test]
-    fn range_composite_key_by_multi_index() {
+    fn range_raw_composite_key_by_multi_index() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
@@ -693,7 +693,7 @@ mod test {
     }
 
     #[test]
-    fn range_de_composite_key_by_multi_index() {
+    fn range_composite_key_by_multi_index() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
@@ -861,7 +861,7 @@ mod test {
     }
 
     #[test]
-    fn range_simple_key_by_unique_index() {
+    fn range_raw_simple_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -894,7 +894,7 @@ mod test {
     }
 
     #[test]
-    fn range_de_simple_key_by_unique_index() {
+    fn range_simple_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -927,7 +927,7 @@ mod test {
     }
 
     #[test]
-    fn range_composite_key_by_unique_index() {
+    fn range_raw_composite_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -956,7 +956,7 @@ mod test {
     }
 
     #[test]
-    fn range_de_composite_key_by_unique_index() {
+    fn range_composite_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -986,7 +986,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_de_simple_string_key() {
+    fn range_simple_string_key() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -1029,7 +1029,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_de_simple_string_key() {
+    fn prefix_simple_string_key() {
         let mut store = MockStorage::new();
         let map = build_map();
 
@@ -1037,7 +1037,7 @@ mod test {
         let (pks, datas) = save_data(&mut store, &map);
 
         // Let's prefix and iterate.
-        // This is similar to calling range() directly, but added here for completeness / prefix_de
+        // This is similar to calling range() directly, but added here for completeness / prefix
         // type checks
         let all: StdResult<Vec<_>> = map
             .prefix(())
@@ -1056,7 +1056,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_de_composite_key() {
+    fn prefix_composite_key() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
@@ -1111,7 +1111,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_de_triple_key() {
+    fn prefix_triple_key() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
@@ -1163,7 +1163,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn sub_prefix_de_triple_key() {
+    fn sub_prefix_triple_key() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
@@ -1221,7 +1221,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_range_de_simple_key() {
+    fn prefix_range_simple_key() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
@@ -1262,7 +1262,7 @@ mod test {
         let pk4 = ("3", "5630");
         map.save(&mut store, pk4, &data4).unwrap();
 
-        // let's try to iterate!
+        // let's prefix-range and iterate
         let result: StdResult<Vec<_>> = map
             .prefix_range(
                 &store,
@@ -1281,7 +1281,7 @@ mod test {
             ]
         );
 
-        // let's try to iterate over a range
+        // let's try to iterate over a more restrictive prefix-range!
         let result: StdResult<Vec<_>> = map
             .prefix_range(
                 &store,
@@ -1302,7 +1302,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_range_de_triple_key() {
+    fn prefix_range_triple_key() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -209,7 +209,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range(store, min, max, order)
+        self.no_prefix().range_raw(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -894,7 +894,7 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .age
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let ages = res.unwrap();
 
@@ -925,7 +925,7 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .name_lastname
-            .prefix_de(b"Maria".to_vec())
+            .prefix(b"Maria".to_vec())
             .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let marias = res.unwrap();
@@ -954,7 +954,7 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .name_lastname
-            .prefix_de(b"Maria".to_vec())
+            .prefix(b"Maria".to_vec())
             .range(&store, None, None, Order::Ascending)
             .collect();
         let marias = res.unwrap();

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -430,8 +430,8 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix(b"Maria".to_vec())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"Maria".to_vec())
+            .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(2, count);
 
@@ -439,8 +439,8 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix(b"Maria".to_vec())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"Maria".to_vec())
+            .range_raw(&store, None, None, Order::Ascending)
             .collect::<StdResult<_>>()
             .unwrap();
         assert_eq!(2, marias.len());
@@ -452,8 +452,8 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix(b"Marib".to_vec())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"Marib".to_vec())
+            .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
 
@@ -461,8 +461,8 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix(b"Mari`".to_vec())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"Mari`".to_vec())
+            .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
 
@@ -470,8 +470,8 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix(b"Maria5".to_vec())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"Maria5".to_vec())
+            .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
 
@@ -532,8 +532,8 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix(b"Maria".to_vec())
-            .range(&store, None, None, Order::Descending)
+            .prefix_de(b"Maria".to_vec())
+            .range_raw(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
         let count = marias.len();
@@ -818,7 +818,7 @@ mod test {
          -> usize {
             map.idx
                 .name
-                .prefix(name.as_bytes().to_vec())
+                .prefix_de(name.as_bytes().to_vec())
                 .keys_raw(store, None, None, Order::Ascending)
                 .count()
         };

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -174,16 +174,6 @@ where
         self.primary.may_load(store, key)
     }
 
-    // use prefix to scan -> range
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
-        Prefix::new(self.pk_namespace, &p.prefix())
-    }
-
-    // use sub_prefix to scan -> range
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
-        Prefix::new(self.pk_namespace, &p.prefix())
-    }
-
     // use no_prefix to scan -> range
     pub fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &[])

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -430,7 +430,7 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix_de(b"Maria".to_vec())
+            .prefix(b"Maria".to_vec())
             .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(2, count);
@@ -439,7 +439,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix_de(b"Maria".to_vec())
+            .prefix(b"Maria".to_vec())
             .range_raw(&store, None, None, Order::Ascending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -452,7 +452,7 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix_de(b"Marib".to_vec())
+            .prefix(b"Marib".to_vec())
             .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
@@ -461,7 +461,7 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix_de(b"Mari`".to_vec())
+            .prefix(b"Mari`".to_vec())
             .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
@@ -470,7 +470,7 @@ mod test {
         let count = map
             .idx
             .name
-            .prefix_de(b"Maria5".to_vec())
+            .prefix(b"Maria5".to_vec())
             .range_raw(&store, None, None, Order::Ascending)
             .count();
         assert_eq!(0, count);
@@ -532,7 +532,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix_de(b"Maria".to_vec())
+            .prefix(b"Maria".to_vec())
             .range_raw(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -592,7 +592,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name
-            .prefix_de(b"Maria".to_vec())
+            .prefix(b"Maria".to_vec())
             .range(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -657,7 +657,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name_age
-            .sub_prefix_de(b"Maria".to_vec())
+            .sub_prefix(b"Maria".to_vec())
             .range_raw(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -723,7 +723,7 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name_age
-            .sub_prefix_de(b"Maria".to_vec())
+            .sub_prefix(b"Maria".to_vec())
             .range(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
@@ -818,7 +818,7 @@ mod test {
          -> usize {
             map.idx
                 .name
-                .prefix_de(name.as_bytes().to_vec())
+                .prefix(name.as_bytes().to_vec())
                 .keys_raw(store, None, None, Order::Ascending)
                 .count()
         };

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -819,7 +819,7 @@ mod test {
             map.idx
                 .name
                 .prefix(name.as_bytes().to_vec())
-                .keys(store, None, None, Order::Ascending)
+                .keys_raw(store, None, None, Order::Ascending)
                 .count()
         };
 

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -271,7 +271,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().range_de(store, min, max, order)
+        self.no_prefix_de().range(store, min, max, order)
     }
 
     pub fn keys_de<'c>(
@@ -285,7 +285,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().keys_de(store, min, max, order)
+        self.no_prefix_de().keys(store, min, max, order)
     }
 
     fn no_prefix_de(&self) -> Prefix<K, T> {
@@ -593,7 +593,7 @@ mod test {
             .idx
             .name
             .prefix_de(b"Maria".to_vec())
-            .range_de(&store, None, None, Order::Descending)
+            .range(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
         let count = marias.len();
@@ -724,7 +724,7 @@ mod test {
             .idx
             .name_age
             .sub_prefix_de(b"Maria".to_vec())
-            .range_de(&store, None, None, Order::Descending)
+            .range(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
         let count = marias.len();
@@ -955,7 +955,7 @@ mod test {
             .idx
             .name_lastname
             .prefix_de(b"Maria".to_vec())
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let marias = res.unwrap();
 
@@ -1029,7 +1029,7 @@ mod test {
         // type checks
         let all: StdResult<Vec<_>> = map
             .prefix_de(())
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(
@@ -1056,7 +1056,7 @@ mod test {
         // type checks
         let all: StdResult<Vec<_>> = map
             .sub_prefix_de(())
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -180,7 +180,7 @@ where
     }
 }
 
-// short-cut for simple keys, rather than .prefix(()).range(...)
+// short-cut for simple keys, rather than .prefix(()).range_raw(...)
 impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I>
 where
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
@@ -488,7 +488,7 @@ mod test {
     }
 
     #[test]
-    fn range_simple_key_by_multi_index() {
+    fn range_raw_simple_key_by_multi_index() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
         let mut height = 1;
@@ -548,7 +548,7 @@ mod test {
     }
 
     #[test]
-    fn range_de_simple_key_by_multi_index() {
+    fn range_simple_key_by_multi_index() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
         let mut height = 1;
@@ -608,7 +608,7 @@ mod test {
     }
 
     #[test]
-    fn range_composite_key_by_multi_index() {
+    fn range_raw_composite_key_by_multi_index() {
         let mut store = MockStorage::new();
         let mut height = 2;
 
@@ -674,7 +674,7 @@ mod test {
     }
 
     #[test]
-    fn range_de_composite_key_by_multi_index() {
+    fn range_composite_key_by_multi_index() {
         let mut store = MockStorage::new();
         let mut height = 2;
 
@@ -853,7 +853,7 @@ mod test {
     }
 
     #[test]
-    fn range_simple_key_by_unique_index() {
+    fn range_raw_simple_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 
@@ -884,7 +884,7 @@ mod test {
     }
 
     #[test]
-    fn range_de_simple_key_by_unique_index() {
+    fn range_simple_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 
@@ -915,7 +915,7 @@ mod test {
     }
 
     #[test]
-    fn range_composite_key_by_unique_index() {
+    fn range_raw_composite_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 
@@ -944,7 +944,7 @@ mod test {
     }
 
     #[test]
-    fn range_de_composite_key_by_unique_index() {
+    fn range_composite_key_by_unique_index() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 
@@ -974,7 +974,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_de_simple_string_key() {
+    fn range_simple_string_key() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 
@@ -1017,7 +1017,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_de_simple_string_key() {
+    fn prefix_simple_string_key() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 
@@ -1025,7 +1025,7 @@ mod test {
         let (pks, datas) = save_data(&mut store, &map);
 
         // Let's prefix and iterate.
-        // This is similar to calling range() directly, but added here for completeness / prefix_de
+        // This is similar to calling range() directly, but added here for completeness / prefix
         // type checks
         let all: StdResult<Vec<_>> = map
             .prefix(())
@@ -1044,15 +1044,15 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn sub_prefix_de_simple_string_key() {
+    fn sub_prefix_simple_string_key() {
         let mut store = MockStorage::new();
         let map = build_snapshot_map();
 
         // save data
         let (pks, datas) = save_data(&mut store, &map);
 
-        // Let's prefix and iterate.
-        // This is similar to calling range() directly, but added here for completeness / sub_prefix_de
+        // Let's sub-prefix and iterate.
+        // This is similar to calling range() directly, but added here for completeness / sub_prefix
         // type checks
         let all: StdResult<Vec<_>> = map
             .sub_prefix(())
@@ -1071,7 +1071,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_range_de_simple_key() {
+    fn prefix_range_simple_key() {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
@@ -1113,7 +1113,7 @@ mod test {
         let pk4: (&str, &str) = ("3", "5630");
         map.save(&mut store, pk4, &data4, 1).unwrap();
 
-        // let's try to iterate!
+        // let's prefix-range and iterate
         let result: StdResult<Vec<_>> = map
             .prefix_range(
                 &store,
@@ -1132,7 +1132,7 @@ mod test {
             ]
         );
 
-        // let's try to iterate over a range
+        // let's try to iterate over a more restrictive prefix-range!
         let result: StdResult<Vec<_>> = map
             .prefix_range(
                 &store,

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -925,8 +925,8 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .name_lastname
-            .prefix(b"Maria".to_vec())
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"Maria".to_vec())
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let marias = res.unwrap();
 

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -199,7 +199,7 @@ where
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
-    pub fn range<'c>(
+    pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -210,6 +210,16 @@ where
         T: 'c,
     {
         self.no_prefix().range_raw(store, min, max, order)
+    }
+
+    pub fn keys_raw<'c>(
+        &self,
+        store: &'c dyn Storage,
+        min: Option<Bound>,
+        max: Option<Bound>,
+        order: cosmwasm_std::Order,
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
+        self.no_prefix().keys_raw(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -175,7 +175,7 @@ where
     }
 
     // use no_prefix to scan -> range
-    pub fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
+    pub fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.pk_namespace, &[])
     }
 }
@@ -199,7 +199,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range_raw(store, min, max, order)
+        self.no_prefix_raw().range_raw(store, min, max, order)
     }
 
     pub fn keys_raw<'c>(
@@ -209,7 +209,7 @@ where
         max: Option<Bound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
-        self.no_prefix().keys_raw(store, min, max, order)
+        self.no_prefix_raw().keys_raw(store, min, max, order)
     }
 }
 
@@ -271,7 +271,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -285,10 +285,10 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 
-    fn no_prefix_de(&self) -> Prefix<K, T> {
+    fn no_prefix(&self) -> Prefix<K, T> {
         Prefix::new(self.pk_namespace, &[])
     }
 }

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -863,7 +863,7 @@ mod test {
         let res: StdResult<Vec<_>> = map
             .idx
             .age
-            .range(&store, None, None, Order::Ascending)
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let ages = res.unwrap();
 

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -657,8 +657,8 @@ mod test {
         let marias: Vec<_> = map
             .idx
             .name_age
-            .sub_prefix(b"Maria".to_vec())
-            .range(&store, None, None, Order::Descending)
+            .sub_prefix_de(b"Maria".to_vec())
+            .range_raw(&store, None, None, Order::Descending)
             .collect::<StdResult<_>>()
             .unwrap();
         let count = marias.len();

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -220,11 +220,11 @@ where
     K: PrimaryKey<'a>,
     I: IndexList<T>,
 {
-    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 
-    pub fn prefix_de(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 }
@@ -236,13 +236,13 @@ where
     K: PrimaryKey<'a> + KeyDeserialize,
     I: IndexList<T>,
 {
-    /// While `range_de` over a `prefix_de` fixes the prefix to one element and iterates over the
-    /// remaining, `prefix_range_de` accepts bounds for the lowest and highest elements of the
+    /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
+    /// remaining, `prefix_range` accepts bounds for the lowest and highest elements of the
     /// `Prefix` itself, and iterates over those (inclusively or exclusively, depending on
     /// `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
-    pub fn prefix_range_de<'c>(
+    pub fn prefix_range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, K::Prefix>>,
@@ -260,7 +260,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn range_de<'c>(
+    pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -274,7 +274,7 @@ where
         self.no_prefix_de().range(store, min, max, order)
     }
 
-    pub fn keys_de<'c>(
+    pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -982,7 +982,7 @@ mod test {
         let (pks, datas) = save_data(&mut store, &map);
 
         // let's try to iterate!
-        let all: StdResult<Vec<_>> = map.range_de(&store, None, None, Order::Ascending).collect();
+        let all: StdResult<Vec<_>> = map.range(&store, None, None, Order::Ascending).collect();
         let all = all.unwrap();
         assert_eq!(
             all,
@@ -995,7 +995,7 @@ mod test {
 
         // let's try to iterate over a range
         let all: StdResult<Vec<_>> = map
-            .range_de(
+            .range(
                 &store,
                 Some(Bound::Inclusive(b"3".to_vec())),
                 None,
@@ -1028,7 +1028,7 @@ mod test {
         // This is similar to calling range() directly, but added here for completeness / prefix_de
         // type checks
         let all: StdResult<Vec<_>> = map
-            .prefix_de(())
+            .prefix(())
             .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -1055,7 +1055,7 @@ mod test {
         // This is similar to calling range() directly, but added here for completeness / sub_prefix_de
         // type checks
         let all: StdResult<Vec<_>> = map
-            .sub_prefix_de(())
+            .sub_prefix(())
             .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -1115,7 +1115,7 @@ mod test {
 
         // let's try to iterate!
         let result: StdResult<Vec<_>> = map
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::inclusive("2")),
                 None,
@@ -1134,7 +1134,7 @@ mod test {
 
         // let's try to iterate over a range
         let result: StdResult<Vec<_>> = map
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::inclusive("2")),
                 Some(PrefixBound::exclusive("3")),

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -224,7 +224,7 @@ where
     /// `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
-    pub fn prefix_range<'c>(
+    pub fn prefix_range_raw<'c>(
         &'c self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, IK>>,

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -144,28 +144,31 @@ where
     IK: PrimaryKey<'a> + Prefixer<'a>,
 {
     pub fn prefix(&self, p: IK) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_function(
+        Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
             self.pk_namespace,
+            deserialize_multi_v,
             deserialize_multi_v,
         )
     }
 
     pub fn sub_prefix(&self, p: IK::Prefix) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_function(
+        Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
             self.pk_namespace,
+            deserialize_multi_v,
             deserialize_multi_v,
         )
     }
 
     fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_function(
+        Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],
             self.pk_namespace,
+            deserialize_multi_v,
             deserialize_multi_v,
         )
     }
@@ -257,20 +260,22 @@ where
     IK: PrimaryKey<'a> + Prefixer<'a>,
 {
     pub fn prefix_de(&self, p: IK) -> Prefix<PK, T> {
-        Prefix::with_deserialization_function(
+        Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
             self.pk_namespace,
             deserialize_multi_kv::<PK, T>,
+            deserialize_multi_v,
         )
     }
 
     pub fn sub_prefix_de(&self, p: IK::Prefix) -> Prefix<PK, T> {
-        Prefix::with_deserialization_function(
+        Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
             self.pk_namespace,
             deserialize_multi_kv::<PK, T>,
+            deserialize_multi_v,
         )
     }
 }
@@ -336,11 +341,12 @@ where
     }
 
     fn no_prefix_de(&self) -> Prefix<PK, T> {
-        Prefix::with_deserialization_function(
+        Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],
             self.pk_namespace,
             deserialize_multi_kv::<PK, T>,
+            deserialize_multi_v,
         )
     }
 }

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -312,7 +312,7 @@ where
         T: 'c,
         PK::Output: 'static,
     {
-        self.no_prefix_de().range_de(store, min, max, order)
+        self.no_prefix_de().range(store, min, max, order)
     }
 
     pub fn keys_de<'c>(
@@ -326,7 +326,7 @@ where
         T: 'c,
         PK::Output: 'static,
     {
-        self.no_prefix_de().keys_de(store, min, max, order)
+        self.no_prefix_de().keys(store, min, max, order)
     }
 
     fn no_prefix_de(&self) -> Prefix<PK, T> {

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -216,7 +216,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range(store, min, max, order)
+        self.no_prefix().range_raw(store, min, max, order)
     }
 
     pub fn keys<'c>(

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -160,16 +160,6 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a> + Prefixer<'a>,
 {
-    pub fn sub_prefix(&self, p: IK::Prefix) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_functions(
-            self.idx_namespace,
-            &p.prefix(),
-            self.pk_namespace,
-            deserialize_multi_v,
-            deserialize_multi_v,
-        )
-    }
-
     pub fn index_key(&self, k: IK) -> Vec<u8> {
         k.joined_extra_key(b"")
     }

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -180,14 +180,14 @@ where
     #[cfg(test)]
     pub fn count(&self, store: &dyn Storage, p: IK) -> usize {
         let prefix = self.prefix(p);
-        prefix.keys(store, None, None, Order::Ascending).count()
+        prefix.keys_raw(store, None, None, Order::Ascending).count()
     }
 
     #[cfg(test)]
     pub fn all_pks(&self, store: &dyn Storage, p: IK) -> Vec<Vec<u8>> {
         let prefix = self.prefix(p);
         prefix
-            .keys(store, None, None, Order::Ascending)
+            .keys_raw(store, None, None, Order::Ascending)
             .collect::<Vec<Vec<u8>>>()
     }
 
@@ -226,7 +226,7 @@ where
         max: Option<Bound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
-        self.no_prefix().keys(store, min, max, order)
+        self.no_prefix().keys_raw(store, min, max, order)
     }
 
     /// While `range` over a `prefix` fixes the prefix to one element and iterates over the

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -187,7 +187,7 @@ where
     }
 }
 
-// short-cut for simple keys, rather than .prefix(()).range(...)
+// short-cut for simple keys, rather than .prefix(()).range_raw(...)
 impl<'a, IK, T, PK> MultiIndex<'a, IK, T, PK>
 where
     T: Serialize + DeserializeOwned + Clone,
@@ -218,8 +218,8 @@ where
         self.no_prefix_raw().keys_raw(store, min, max, order)
     }
 
-    /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
-    /// remaining, `prefix_range` accepts bounds for the lowest and highest elements of the
+    /// While `range_raw` over a `prefix` fixes the prefix to one element and iterates over the
+    /// remaining, `prefix_range_raw` accepts bounds for the lowest and highest elements of the
     /// `Prefix` itself, and iterates over those (inclusively or exclusively, depending on
     /// `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -166,13 +166,13 @@ where
 
     #[cfg(test)]
     pub fn count(&self, store: &dyn Storage, p: IK) -> usize {
-        let prefix = self.prefix_de(p);
+        let prefix = self.prefix(p);
         prefix.keys_raw(store, None, None, Order::Ascending).count()
     }
 
     #[cfg(test)]
     pub fn all_pks(&self, store: &dyn Storage, p: IK) -> Vec<Vec<u8>> {
-        let prefix = self.prefix_de(p);
+        let prefix = self.prefix(p);
         prefix
             .keys_raw(store, None, None, Order::Ascending)
             .collect::<Vec<Vec<u8>>>()
@@ -180,7 +180,7 @@ where
 
     #[cfg(test)]
     pub fn all_items(&self, store: &dyn Storage, p: IK) -> StdResult<Vec<Record<T>>> {
-        let prefix = self.prefix_de(p);
+        let prefix = self.prefix(p);
         prefix
             .range_raw(store, None, None, Order::Ascending)
             .collect()
@@ -248,7 +248,7 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a> + Prefixer<'a>,
 {
-    pub fn prefix_de(&self, p: IK) -> Prefix<PK, T> {
+    pub fn prefix(&self, p: IK) -> Prefix<PK, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
@@ -258,7 +258,7 @@ where
         )
     }
 
-    pub fn sub_prefix_de(&self, p: IK::Prefix) -> Prefix<PK, T> {
+    pub fn sub_prefix(&self, p: IK::Prefix) -> Prefix<PK, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
@@ -276,13 +276,13 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a> + KeyDeserialize + Prefixer<'a>,
 {
-    /// While `range_de` over a `prefix_de` fixes the prefix to one element and iterates over the
-    /// remaining, `prefix_range_de` accepts bounds for the lowest and highest elements of the
+    /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
+    /// remaining, `prefix_range` accepts bounds for the lowest and highest elements of the
     /// `Prefix` itself, and iterates over those (inclusively or exclusively, depending on
     /// `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
-    pub fn prefix_range_de<'c>(
+    pub fn prefix_range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, IK>>,
@@ -301,7 +301,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn range_de<'c>(
+    pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -315,7 +315,7 @@ where
         self.no_prefix_de().range(store, min, max, order)
     }
 
-    pub fn keys_de<'c>(
+    pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -195,7 +195,7 @@ where
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
-    pub fn range<'c>(
+    pub fn range_raw<'c>(
         &'c self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -208,7 +208,7 @@ where
         self.no_prefix().range_raw(store, min, max, order)
     }
 
-    pub fn keys<'c>(
+    pub fn keys_raw<'c>(
         &'c self,
         store: &'c dyn Storage,
         min: Option<Bound>,

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -143,7 +143,7 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a> + Prefixer<'a>,
 {
-    fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
+    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],
@@ -205,7 +205,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range_raw(store, min, max, order)
+        self.no_prefix_raw().range_raw(store, min, max, order)
     }
 
     pub fn keys_raw<'c>(
@@ -215,7 +215,7 @@ where
         max: Option<Bound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
-        self.no_prefix().keys_raw(store, min, max, order)
+        self.no_prefix_raw().keys_raw(store, min, max, order)
     }
 
     /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
@@ -312,7 +312,7 @@ where
         T: 'c,
         PK::Output: 'static,
     {
-        self.no_prefix_de().range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -326,10 +326,10 @@ where
         T: 'c,
         PK::Output: 'static,
     {
-        self.no_prefix_de().keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 
-    fn no_prefix_de(&self) -> Prefix<PK, T> {
+    fn no_prefix(&self) -> Prefix<PK, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -207,7 +207,7 @@ where
         T: 'c,
         PK::Output: 'static,
     {
-        self.no_prefix_de().range_de(store, min, max, order)
+        self.no_prefix_de().range(store, min, max, order)
     }
 
     pub fn keys_de<'c>(
@@ -221,7 +221,7 @@ where
         T: 'c,
         PK::Output: 'static,
     {
-        self.no_prefix_de().keys_de(store, min, max, order)
+        self.no_prefix_de().keys(store, min, max, order)
     }
 
     pub fn prefix_de(&self, p: IK::Prefix) -> Prefix<PK, T> {

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -112,16 +112,6 @@ where
         k.joined_key()
     }
 
-    pub fn sub_prefix(&self, p: IK::SubPrefix) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_functions(
-            self.idx_namespace,
-            &p.prefix(),
-            &[],
-            |_, _, kv| deserialize_unique_v(kv),
-            |_, _, kv| deserialize_unique_v(kv),
-        )
-    }
-
     fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -132,7 +132,7 @@ where
     }
 }
 
-// short-cut for simple keys, rather than .prefix(()).range(...)
+// short-cut for simple keys, rather than .prefix(()).range_raw(...)
 impl<'a, IK, T, PK> UniqueIndex<'a, IK, T, PK>
 where
     T: Serialize + DeserializeOwned + Clone,

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -112,16 +112,6 @@ where
         k.joined_key()
     }
 
-    pub fn prefix(&self, p: IK::Prefix) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_functions(
-            self.idx_namespace,
-            &p.prefix(),
-            &[],
-            |_, _, kv| deserialize_unique_v(kv),
-            |_, _, kv| deserialize_unique_v(kv),
-        )
-    }
-
     pub fn sub_prefix(&self, p: IK::SubPrefix) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -112,7 +112,7 @@ where
         k.joined_key()
     }
 
-    fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
+    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],
@@ -150,7 +150,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range_raw(store, min, max, order)
+        self.no_prefix_raw().range_raw(store, min, max, order)
     }
 
     pub fn keys_raw<'c>(
@@ -160,7 +160,7 @@ where
         max: Option<Bound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
-        self.no_prefix().keys_raw(store, min, max, order)
+        self.no_prefix_raw().keys_raw(store, min, max, order)
     }
 }
 
@@ -207,7 +207,7 @@ where
         T: 'c,
         PK::Output: 'static,
     {
-        self.no_prefix_de().range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -221,7 +221,7 @@ where
         T: 'c,
         PK::Output: 'static,
     {
-        self.no_prefix_de().keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 
     pub fn prefix(&self, p: IK::Prefix) -> Prefix<PK, T> {
@@ -244,7 +244,7 @@ where
         )
     }
 
-    fn no_prefix_de(&self) -> Prefix<PK, T> {
+    fn no_prefix(&self) -> Prefix<PK, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -113,21 +113,33 @@ where
     }
 
     pub fn prefix(&self, p: IK::Prefix) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_function(self.idx_namespace, &p.prefix(), &[], |_, _, kv| {
-            deserialize_unique_v(kv)
-        })
+        Prefix::with_deserialization_functions(
+            self.idx_namespace,
+            &p.prefix(),
+            &[],
+            |_, _, kv| deserialize_unique_v(kv),
+            |_, _, kv| deserialize_unique_v(kv),
+        )
     }
 
     pub fn sub_prefix(&self, p: IK::SubPrefix) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_function(self.idx_namespace, &p.prefix(), &[], |_, _, kv| {
-            deserialize_unique_v(kv)
-        })
+        Prefix::with_deserialization_functions(
+            self.idx_namespace,
+            &p.prefix(),
+            &[],
+            |_, _, kv| deserialize_unique_v(kv),
+            |_, _, kv| deserialize_unique_v(kv),
+        )
     }
 
     fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
-        Prefix::with_deserialization_function(self.idx_namespace, &[], &[], |_, _, kv| {
-            deserialize_unique_v(kv)
-        })
+        Prefix::with_deserialization_functions(
+            self.idx_namespace,
+            &[],
+            &[],
+            |_, _, kv| deserialize_unique_v(kv),
+            |_, _, kv| deserialize_unique_v(kv),
+        )
     }
 
     /// returns all items that match this secondary index, always by pk Ascending
@@ -233,20 +245,32 @@ where
     }
 
     pub fn prefix_de(&self, p: IK::Prefix) -> Prefix<PK, T> {
-        Prefix::with_deserialization_function(self.idx_namespace, &p.prefix(), &[], |_, _, kv| {
-            deserialize_unique_kv::<PK, _>(kv)
-        })
+        Prefix::with_deserialization_functions(
+            self.idx_namespace,
+            &p.prefix(),
+            &[],
+            |_, _, kv| deserialize_unique_kv::<PK, _>(kv),
+            |_, _, kv| deserialize_unique_v(kv),
+        )
     }
 
     pub fn sub_prefix_de(&self, p: IK::SubPrefix) -> Prefix<PK, T> {
-        Prefix::with_deserialization_function(self.idx_namespace, &p.prefix(), &[], |_, _, kv| {
-            deserialize_unique_kv::<PK, _>(kv)
-        })
+        Prefix::with_deserialization_functions(
+            self.idx_namespace,
+            &p.prefix(),
+            &[],
+            |_, _, kv| deserialize_unique_kv::<PK, _>(kv),
+            |_, _, kv| deserialize_unique_v(kv),
+        )
     }
 
     fn no_prefix_de(&self) -> Prefix<PK, T> {
-        Prefix::with_deserialization_function(self.idx_namespace, &[], &[], |_, _, kv| {
-            deserialize_unique_kv::<PK, _>(kv)
-        })
+        Prefix::with_deserialization_functions(
+            self.idx_namespace,
+            &[],
+            &[],
+            |_, _, kv| deserialize_unique_kv::<PK, _>(kv),
+            |_, _, kv| deserialize_unique_v(kv),
+        )
     }
 }

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -140,7 +140,7 @@ where
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
-    pub fn range<'c>(
+    pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -153,7 +153,7 @@ where
         self.no_prefix().range_raw(store, min, max, order)
     }
 
-    pub fn keys<'c>(
+    pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -170,7 +170,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range(store, min, max, order)
+        self.no_prefix().range_raw(store, min, max, order)
     }
 
     pub fn keys<'c>(

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -180,7 +180,7 @@ where
         max: Option<Bound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
-        self.no_prefix().keys(store, min, max, order)
+        self.no_prefix().keys_raw(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -171,13 +171,13 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a>,
 {
-    /// While `range_de` over a `prefix_de` fixes the prefix to one element and iterates over the
-    /// remaining, `prefix_range_de` accepts bounds for the lowest and highest elements of the
+    /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
+    /// remaining, `prefix_range` accepts bounds for the lowest and highest elements of the
     /// `Prefix` itself, and iterates over those (inclusively or exclusively, depending on
     /// `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
-    pub fn prefix_range_de<'c>(
+    pub fn prefix_range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, IK::Prefix>>,
@@ -196,7 +196,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn range_de<'c>(
+    pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -210,7 +210,7 @@ where
         self.no_prefix_de().range(store, min, max, order)
     }
 
-    pub fn keys_de<'c>(
+    pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -224,7 +224,7 @@ where
         self.no_prefix_de().keys(store, min, max, order)
     }
 
-    pub fn prefix_de(&self, p: IK::Prefix) -> Prefix<PK, T> {
+    pub fn prefix(&self, p: IK::Prefix) -> Prefix<PK, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
@@ -234,7 +234,7 @@ where
         )
     }
 
-    pub fn sub_prefix_de(&self, p: IK::SubPrefix) -> Prefix<PK, T> {
+    pub fn sub_prefix(&self, p: IK::SubPrefix) -> Prefix<PK, T> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -115,11 +115,11 @@ where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
 {
-    pub fn sub_prefix_de(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
         Prefix::new(self.namespace, &p.prefix())
     }
 
-    pub fn prefix_de(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
         Prefix::new(self.namespace, &p.prefix())
     }
 }
@@ -187,13 +187,13 @@ where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a> + KeyDeserialize,
 {
-    /// While `range_de` over a `prefix_de` fixes the prefix to one element and iterates over the
-    /// remaining, `prefix_range_de` accepts bounds for the lowest and highest elements of the
+    /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
+    /// remaining, `prefix_range` accepts bounds for the lowest and highest elements of the
     /// `Prefix` itself, and iterates over those (inclusively or exclusively, depending on
     /// `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
-    pub fn prefix_range_de<'c>(
+    pub fn prefix_range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, K::Prefix>>,
@@ -211,7 +211,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn range_de<'c>(
+    pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -225,7 +225,7 @@ where
         self.no_prefix_de().range(store, min, max, order)
     }
 
-    pub fn keys_de<'c>(
+    pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -474,9 +474,7 @@ mod test {
         PEOPLE.save(&mut store, b"jim", &data2).unwrap();
 
         // let's try to iterate!
-        let all: StdResult<Vec<_>> = PEOPLE
-            .range_de(&store, None, None, Order::Ascending)
-            .collect();
+        let all: StdResult<Vec<_>> = PEOPLE.range(&store, None, None, Order::Ascending).collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
         assert_eq!(
@@ -489,7 +487,7 @@ mod test {
 
         // let's try to iterate over a range
         let all: StdResult<Vec<_>> = PEOPLE
-            .range_de(
+            .range(
                 &store,
                 Some(Bound::Inclusive(b"j".to_vec())),
                 None,
@@ -505,7 +503,7 @@ mod test {
 
         // let's try to iterate over a more restrictive range
         let all: StdResult<Vec<_>> = PEOPLE
-            .range_de(
+            .range(
                 &store,
                 Some(Bound::Inclusive(b"jo".to_vec())),
                 None,
@@ -537,7 +535,7 @@ mod test {
 
         // let's try to iterate!
         let all: StdResult<Vec<_>> = PEOPLE_ID
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
@@ -545,7 +543,7 @@ mod test {
 
         // let's try to iterate over a range
         let all: StdResult<Vec<_>> = PEOPLE_ID
-            .range_de(
+            .range(
                 &store,
                 Some(Bound::inclusive_int(56u32)),
                 None,
@@ -558,7 +556,7 @@ mod test {
 
         // let's try to iterate over a more restrictive range
         let all: StdResult<Vec<_>> = PEOPLE_ID
-            .range_de(
+            .range(
                 &store,
                 Some(Bound::inclusive_int(57u32)),
                 None,
@@ -603,7 +601,7 @@ mod test {
 
         // let's try to iterate over a prefix
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .prefix_de(b"owner")
+            .prefix(b"owner")
             .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -632,7 +630,7 @@ mod test {
 
         // let's try to iterate!
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(3, all.len());
@@ -647,7 +645,7 @@ mod test {
 
         // let's try to iterate over a prefix_de
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .prefix_de(b"owner")
+            .prefix(b"owner")
             .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -707,7 +705,7 @@ mod test {
 
         // let's iterate over a prefix
         let all: StdResult<Vec<_>> = TRIPLE
-            .prefix_de((b"owner", 9))
+            .prefix((b"owner", 9))
             .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -722,7 +720,7 @@ mod test {
 
         // let's iterate over a sub prefix
         let all: StdResult<Vec<_>> = TRIPLE
-            .sub_prefix_de(b"owner")
+            .sub_prefix(b"owner")
             .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -758,9 +756,7 @@ mod test {
             .unwrap();
 
         // let's try to iterate!
-        let all: StdResult<Vec<_>> = TRIPLE
-            .range_de(&store, None, None, Order::Ascending)
-            .collect();
+        let all: StdResult<Vec<_>> = TRIPLE.range(&store, None, None, Order::Ascending).collect();
         let all = all.unwrap();
         assert_eq!(4, all.len());
         assert_eq!(
@@ -775,7 +771,7 @@ mod test {
 
         // let's iterate over a sub_prefix_de
         let all: StdResult<Vec<_>> = TRIPLE
-            .sub_prefix_de(b"owner")
+            .sub_prefix(b"owner")
             .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -791,7 +787,7 @@ mod test {
 
         // let's iterate over a prefix_de
         let all: StdResult<Vec<_>> = TRIPLE
-            .prefix_de((b"owner", 9))
+            .prefix((b"owner", 9))
             .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
@@ -977,7 +973,7 @@ mod test {
 
         // get all under one key
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .prefix_de(b"owner")
+            .prefix(b"owner")
             .range_raw(&store, None, None, Order::Ascending)
             .collect();
         assert_eq!(
@@ -987,7 +983,7 @@ mod test {
 
         // Or ranges between two items (even reverse)
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .prefix_de(b"owner")
+            .prefix(b"owner")
             .range_raw(
                 &store,
                 Some(Bound::Exclusive(b"spender1".to_vec())),
@@ -1017,7 +1013,7 @@ mod test {
 
         // typical range under one prefix as a control
         let fives = AGES
-            .prefix_de(5)
+            .prefix(5)
             .range_raw(&store, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
@@ -1103,7 +1099,7 @@ mod test {
 
         // typical range under one prefix as a control
         let fives = AGES
-            .prefix_de(5)
+            .prefix(5)
             .range(&store, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
@@ -1113,15 +1109,12 @@ mod test {
             vec![("789".to_string(), 789), ("987".to_string(), 987)]
         );
 
-        let keys: Vec<_> = AGES
-            .no_prefix_de()
-            .keys(&store, None, None, Order::Ascending)
-            .collect();
+        let keys: Vec<_> = AGES.keys(&store, None, None, Order::Ascending).collect();
         println!("keys: {:?}", keys);
 
         // using inclusive bounds both sides
         let include = AGES
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::inclusive(3u32)),
                 Some(PrefixBound::inclusive(7u32)),
@@ -1135,7 +1128,7 @@ mod test {
 
         // using exclusive bounds both sides
         let exclude = AGES
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::exclusive(3u32)),
                 Some(PrefixBound::exclusive(7u32)),
@@ -1149,7 +1142,7 @@ mod test {
 
         // using inclusive in descending
         let include = AGES
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::inclusive(3u32)),
                 Some(PrefixBound::inclusive(5u32)),
@@ -1163,7 +1156,7 @@ mod test {
 
         // using exclusive in descending
         let include = AGES
-            .prefix_range_de(
+            .prefix_range(
                 &store,
                 Some(PrefixBound::exclusive(2u32)),
                 Some(PrefixBound::exclusive(5u32)),

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -50,11 +50,6 @@ where
     }
 
     #[cfg(feature = "iterator")]
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
-        Prefix::new(self.namespace, &p.prefix())
-    }
-
-    #[cfg(feature = "iterator")]
     pub(crate) fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.namespace, &[])
     }
@@ -723,8 +718,8 @@ mod test {
 
         // let's iterate over a sub prefix
         let all: StdResult<Vec<_>> = TRIPLE
-            .sub_prefix(b"owner")
-            .range(&store, None, None, Order::Ascending)
+            .sub_prefix_de(b"owner")
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(3, all.len());

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -167,7 +167,7 @@ where
         self.no_prefix().range_raw(store, min, max, order)
     }
 
-    pub fn keys<'c>(
+    pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -177,7 +177,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().keys(store, min, max, order)
+        self.no_prefix().keys_raw(store, min, max, order)
     }
 }
 
@@ -1019,8 +1019,7 @@ mod test {
         assert_eq!(fives, vec![(vec![7, 8, 9], 789), (vec![9, 8, 7], 987)]);
 
         let keys: Vec<_> = AGES
-            .no_prefix()
-            .keys(&store, None, None, Order::Ascending)
+            .keys_raw(&store, None, None, Order::Ascending)
             .collect();
         println!("keys: {:?}", keys);
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -50,11 +50,6 @@ where
     }
 
     #[cfg(feature = "iterator")]
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
-        Prefix::new(self.namespace, &p.prefix())
-    }
-
-    #[cfg(feature = "iterator")]
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.namespace, &p.prefix())
     }
@@ -611,8 +606,8 @@ mod test {
 
         // let's try to iterate over a prefix
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .prefix(b"owner")
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"owner")
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
@@ -713,8 +708,8 @@ mod test {
 
         // let's iterate over a prefix
         let all: StdResult<Vec<_>> = TRIPLE
-            .prefix((b"owner", 9))
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de((b"owner", 9))
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
@@ -981,8 +976,8 @@ mod test {
 
         // get all under one key
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .prefix(b"owner")
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(b"owner")
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         assert_eq!(
             all?,
@@ -991,8 +986,8 @@ mod test {
 
         // Or ranges between two items (even reverse)
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .prefix(b"owner")
-            .range(
+            .prefix_de(b"owner")
+            .range_raw(
                 &store,
                 Some(Bound::Exclusive(b"spender1".to_vec())),
                 Some(Bound::Inclusive(b"spender2".to_vec())),
@@ -1021,8 +1016,8 @@ mod test {
 
         // typical range under one prefix as a control
         let fives = AGES
-            .prefix(5)
-            .range(&store, None, None, Order::Ascending)
+            .prefix_de(5)
+            .range_raw(&store, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
         assert_eq!(fives.len(), 2);
@@ -1119,7 +1114,7 @@ mod test {
         );
 
         let keys: Vec<_> = AGES
-            .no_prefix()
+            .no_prefix_de()
             .keys_de(&store, None, None, Order::Ascending)
             .collect();
         println!("keys: {:?}", keys);

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -164,7 +164,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range(store, min, max, order)
+        self.no_prefix().range_raw(store, min, max, order)
     }
 
     pub fn keys<'c>(

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -50,7 +50,7 @@ where
     }
 
     #[cfg(feature = "iterator")]
-    pub(crate) fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
+    pub(crate) fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
         Prefix::new(self.namespace, &[])
     }
 
@@ -164,7 +164,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range_raw(store, min, max, order)
+        self.no_prefix_raw().range_raw(store, min, max, order)
     }
 
     pub fn keys_raw<'c>(
@@ -177,7 +177,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().keys_raw(store, min, max, order)
+        self.no_prefix_raw().keys_raw(store, min, max, order)
     }
 }
 
@@ -222,7 +222,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -236,10 +236,10 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 
-    fn no_prefix_de(&self) -> Prefix<K, T> {
+    fn no_prefix(&self) -> Prefix<K, T> {
         Prefix::new(self.namespace, &[])
     }
 }

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -154,7 +154,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn range<'c>(
+    pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -412,7 +412,9 @@ mod test {
         PEOPLE.save(&mut store, b"jim", &data2).unwrap();
 
         // let's try to iterate!
-        let all: StdResult<Vec<_>> = PEOPLE.range(&store, None, None, Order::Ascending).collect();
+        let all: StdResult<Vec<_>> = PEOPLE
+            .range_raw(&store, None, None, Order::Ascending)
+            .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
         assert_eq!(
@@ -425,7 +427,7 @@ mod test {
 
         // let's try to iterate over a range
         let all: StdResult<Vec<_>> = PEOPLE
-            .range(
+            .range_raw(
                 &store,
                 Some(Bound::Inclusive(b"j".to_vec())),
                 None,
@@ -441,7 +443,7 @@ mod test {
 
         // let's try to iterate over a more restrictive range
         let all: StdResult<Vec<_>> = PEOPLE
-            .range(
+            .range_raw(
                 &store,
                 Some(Bound::Inclusive(b"jo".to_vec())),
                 None,
@@ -586,7 +588,7 @@ mod test {
 
         // let's try to iterate!
         let all: StdResult<Vec<_>> = ALLOWANCE
-            .range(&store, None, None, Order::Ascending)
+            .range_raw(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(3, all.len());
@@ -676,7 +678,9 @@ mod test {
             .unwrap();
 
         // let's try to iterate!
-        let all: StdResult<Vec<_>> = TRIPLE.range(&store, None, None, Order::Ascending).collect();
+        let all: StdResult<Vec<_>> = TRIPLE
+            .range_raw(&store, None, None, Order::Ascending)
+            .collect();
         let all = all.unwrap();
         assert_eq!(4, all.len());
         assert_eq!(
@@ -947,7 +951,9 @@ mod test {
         PEOPLE.save(&mut store, b"jim", &data2)?;
 
         // iterate over them all
-        let all: StdResult<Vec<_>> = PEOPLE.range(&store, None, None, Order::Ascending).collect();
+        let all: StdResult<Vec<_>> = PEOPLE
+            .range_raw(&store, None, None, Order::Ascending)
+            .collect();
         assert_eq!(
             all?,
             vec![(b"jim".to_vec(), data2), (b"john".to_vec(), data.clone())]
@@ -955,7 +961,7 @@ mod test {
 
         // or just show what is after jim
         let all: StdResult<Vec<_>> = PEOPLE
-            .range(
+            .range_raw(
                 &store,
                 Some(Bound::Exclusive(b"jim".to_vec())),
                 None,

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -222,7 +222,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().range_de(store, min, max, order)
+        self.no_prefix_de().range(store, min, max, order)
     }
 
     pub fn keys_de<'c>(
@@ -236,7 +236,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().keys_de(store, min, max, order)
+        self.no_prefix_de().keys(store, min, max, order)
     }
 
     fn no_prefix_de(&self) -> Prefix<K, T> {
@@ -648,7 +648,7 @@ mod test {
         // let's try to iterate over a prefix_de
         let all: StdResult<Vec<_>> = ALLOWANCE
             .prefix_de(b"owner")
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
@@ -776,7 +776,7 @@ mod test {
         // let's iterate over a sub_prefix_de
         let all: StdResult<Vec<_>> = TRIPLE
             .sub_prefix_de(b"owner")
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(3, all.len());
@@ -792,7 +792,7 @@ mod test {
         // let's iterate over a prefix_de
         let all: StdResult<Vec<_>> = TRIPLE
             .prefix_de((b"owner", 9))
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
@@ -1104,7 +1104,7 @@ mod test {
         // typical range under one prefix as a control
         let fives = AGES
             .prefix_de(5)
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
         assert_eq!(fives.len(), 2);
@@ -1115,7 +1115,7 @@ mod test {
 
         let keys: Vec<_> = AGES
             .no_prefix_de()
-            .keys_de(&store, None, None, Order::Ascending)
+            .keys(&store, None, None, Order::Ascending)
             .collect();
         println!("keys: {:?}", keys);
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -138,7 +138,7 @@ where
     /// itself, and iterates over those (inclusively or exclusively, depending on `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
-    pub fn prefix_range<'c>(
+    pub fn prefix_range_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, K::Prefix>>,
@@ -1031,7 +1031,7 @@ mod test {
 
         // using inclusive bounds both sides
         let include = AGES
-            .prefix_range(
+            .prefix_range_raw(
                 &store,
                 Some(PrefixBound::inclusive(3u32)),
                 Some(PrefixBound::inclusive(7u32)),
@@ -1045,7 +1045,7 @@ mod test {
 
         // using exclusive bounds both sides
         let exclude = AGES
-            .prefix_range(
+            .prefix_range_raw(
                 &store,
                 Some(PrefixBound::exclusive(3u32)),
                 Some(PrefixBound::exclusive(7u32)),
@@ -1059,7 +1059,7 @@ mod test {
 
         // using inclusive in descending
         let include = AGES
-            .prefix_range(
+            .prefix_range_raw(
                 &store,
                 Some(PrefixBound::inclusive(3u32)),
                 Some(PrefixBound::inclusive(5u32)),
@@ -1073,7 +1073,7 @@ mod test {
 
         // using exclusive in descending
         let include = AGES
-            .prefix_range(
+            .prefix_range_raw(
                 &store,
                 Some(PrefixBound::exclusive(2u32)),
                 Some(PrefixBound::exclusive(5u32)),

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -124,7 +124,7 @@ where
     }
 }
 
-// short-cut for simple keys, rather than .prefix(()).range(...)
+// short-cut for simple keys, rather than .prefix(()).range_raw(...)
 #[cfg(feature = "iterator")]
 impl<'a, K, T> Map<'a, K, T>
 where
@@ -133,8 +133,8 @@ where
     // Other cases need to call prefix() first
     K: PrimaryKey<'a>,
 {
-    /// While `range` over a `prefix` fixes the prefix to one element and iterates over the
-    /// remaining, `prefix_range` accepts bounds for the lowest and highest elements of the `Prefix`
+    /// While `range_raw` over a `prefix` fixes the prefix to one element and iterates over the
+    /// remaining, `prefix_range_raw` accepts bounds for the lowest and highest elements of the `Prefix`
     /// itself, and iterates over those (inclusively or exclusively, depending on `PrefixBound`).
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
@@ -395,7 +395,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_simple_key() {
+    fn range_raw_simple_key() {
         let mut store = MockStorage::new();
 
         // save and load on two keys
@@ -457,7 +457,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_de_simple_string_key() {
+    fn range_simple_string_key() {
         let mut store = MockStorage::new();
 
         // save and load on two keys
@@ -517,7 +517,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_de_simple_integer_key() {
+    fn range_simple_integer_key() {
         let mut store = MockStorage::new();
 
         // save and load on two keys
@@ -570,7 +570,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_composite_key() {
+    fn range_raw_composite_key() {
         let mut store = MockStorage::new();
 
         // save and load on three keys, one under different owner
@@ -614,7 +614,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_de_composite_key() {
+    fn range_composite_key() {
         let mut store = MockStorage::new();
 
         // save and load on three keys, one under different owner
@@ -643,7 +643,7 @@ mod test {
             ]
         );
 
-        // let's try to iterate over a prefix_de
+        // let's try to iterate over a prefix
         let all: StdResult<Vec<_>> = ALLOWANCE
             .prefix(b"owner")
             .range(&store, None, None, Order::Ascending)
@@ -658,7 +658,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_triple_key() {
+    fn range_raw_triple_key() {
         let mut store = MockStorage::new();
 
         // save and load on three keys, one under different owner
@@ -725,7 +725,7 @@ mod test {
             .collect();
         let all = all.unwrap();
         assert_eq!(3, all.len());
-        // Use range_de() if you want key deserialization
+        // Use range() if you want key deserialization
         assert_eq!(
             all,
             vec![
@@ -738,7 +738,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_de_triple_key() {
+    fn range_triple_key() {
         let mut store = MockStorage::new();
 
         // save and load on three keys, one under different owner
@@ -769,7 +769,7 @@ mod test {
             ]
         );
 
-        // let's iterate over a sub_prefix_de
+        // let's iterate over a sub_prefix
         let all: StdResult<Vec<_>> = TRIPLE
             .sub_prefix(b"owner")
             .range(&store, None, None, Order::Ascending)
@@ -785,7 +785,7 @@ mod test {
             ]
         );
 
-        // let's iterate over a prefix_de
+        // let's iterate over a prefix
         let all: StdResult<Vec<_>> = TRIPLE
             .prefix((b"owner", 9))
             .range(&store, None, None, Order::Ascending)
@@ -931,7 +931,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn readme_with_range() -> StdResult<()> {
+    fn readme_with_range_raw() -> StdResult<()> {
         let mut store = MockStorage::new();
 
         // save and load on two keys
@@ -998,7 +998,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefixed_range_works() {
+    fn prefixed_range_raw_works() {
         // this is designed to look as much like a secondary index as possible
         // we want to query over a range of u32 for the first key and all subkeys
         const AGES: Map<(u32, Vec<u8>), u64> = Map::new("ages");
@@ -1084,7 +1084,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefixed_range_de_works() {
+    fn prefixed_range_works() {
         // this is designed to look as much like a secondary index as possible
         // we want to query over a range of u32 for the first key and all subkeys
         const AGES: Map<(u32, &str), u64> = Map::new("ages");

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -1104,7 +1104,7 @@ mod test {
         // typical range under one prefix as a control
         let fives = AGES
             .prefix_de(5)
-            .range(&store, None, None, Order::Ascending)
+            .range_de(&store, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
         assert_eq!(fives.len(), 2);

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -160,7 +160,7 @@ where
         let de_fn = self.de_fn_v;
         let pk_name = self.pk_name.clone();
         let mapped = range_with_prefix(store, &self.storage_prefix, min, max, order)
-            .map(move |kv| (de_fn)(store, &*pk_name, kv));
+            .map(move |kv| (de_fn)(store, &pk_name, kv));
         Box::new(mapped)
     }
 
@@ -190,7 +190,7 @@ where
         let de_fn = self.de_fn_kv;
         let pk_name = self.pk_name.clone();
         let mapped = range_with_prefix(store, &self.storage_prefix, min, max, order)
-            .map(move |kv| (de_fn)(store, &*pk_name, kv));
+            .map(move |kv| (de_fn)(store, &pk_name, kv));
         Box::new(mapped)
     }
 
@@ -208,7 +208,7 @@ where
         let de_fn = self.de_fn_kv;
         let pk_name = self.pk_name.clone();
         let mapped = range_with_prefix(store, &self.storage_prefix, min, max, order)
-            .map(move |kv| (de_fn)(store, &*pk_name, kv).map(|(k, _)| Ok(k)))
+            .map(move |kv| (de_fn)(store, &pk_name, kv).map(|(k, _)| Ok(k)))
             .flatten();
         Box::new(mapped)
     }

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -182,7 +182,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn keys<'a>(
+    pub fn keys_raw<'a>(
         &self,
         store: &'a dyn Storage,
         min: Option<Bound>,

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -176,7 +176,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn range_de<'a>(
+    pub fn range<'a>(
         &self,
         store: &'a dyn Storage,
         min: Option<Bound>,
@@ -194,7 +194,7 @@ where
         Box::new(mapped)
     }
 
-    pub fn keys_de<'a>(
+    pub fn keys<'a>(
         &self,
         store: &'a dyn Storage,
         min: Option<Bound>,

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -156,7 +156,7 @@ where
     }
 }
 
-// short-cut for simple keys, rather than .prefix(()).range(...)
+// short-cut for simple keys, rather than .prefix(()).range_raw(...)
 impl<'a, K, T> SnapshotMap<'a, K, T>
 where
     T: Serialize + DeserializeOwned + Clone,
@@ -333,7 +333,7 @@ mod tests {
     const VALUES_START_5: &[(&str, Option<u64>)] =
         &[("A", Some(8)), ("B", None), ("C", Some(13)), ("D", None)];
 
-    // Same as `init_data`, but we have a composite key for testing range_de.
+    // Same as `init_data`, but we have a composite key for testing range.
     fn init_data_composite_key(map: &TestMapCompositeKey, storage: &mut dyn Storage) {
         map.save(storage, ("A", "B"), &5, 1).unwrap();
         map.save(storage, ("B", "A"), &7, 2).unwrap();
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_de_simple_string_key() {
+    fn range_simple_string_key() {
         use cosmwasm_std::Order;
 
         let mut store = MockStorage::new();
@@ -501,7 +501,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range_de_composite_key() {
+    fn range_composite_key() {
         use cosmwasm_std::Order;
 
         let mut store = MockStorage::new();
@@ -524,7 +524,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_range_de_composite_key() {
+    fn prefix_range_composite_key() {
         use cosmwasm_std::Order;
 
         let mut store = MockStorage::new();
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn prefix_de_composite_key() {
+    fn prefix_composite_key() {
         use cosmwasm_std::Order;
 
         let mut store = MockStorage::new();
@@ -564,7 +564,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn sub_prefix_de_composite_key() {
+    fn sub_prefix_composite_key() {
         use cosmwasm_std::Order;
 
         let mut store = MockStorage::new();
@@ -572,7 +572,7 @@ mod tests {
 
         // Let's sub-prefix and iterate.
         // This is similar to calling range() directly, but added here for completeness /
-        // sub_prefix_de type checks
+        // sub_prefix type checks
         let all: StdResult<Vec<_>> = EVERY_COMPOSITE_KEY
             .sub_prefix(())
             .range(&store, None, None, Order::Ascending)

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -69,10 +69,6 @@ where
         self.primary.key(k)
     }
 
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<Vec<u8>, T> {
-        self.primary.prefix(p)
-    }
-
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
         self.primary.sub_prefix(p)
     }

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -174,7 +174,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range(store, min, max, order)
+        self.no_prefix().range_raw(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -164,7 +164,7 @@ where
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
-    pub fn range<'c>(
+    pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
         min: Option<Bound>,
@@ -175,6 +175,19 @@ where
         T: 'c,
     {
         self.no_prefix().range_raw(store, min, max, order)
+    }
+
+    pub fn keys_raw<'c>(
+        &self,
+        store: &'c dyn Storage,
+        min: Option<Bound>,
+        max: Option<Bound>,
+        order: cosmwasm_std::Order,
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c>
+    where
+        T: 'c,
+    {
+        self.no_prefix().keys_raw(store, min, max, order)
     }
 }
 

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -69,7 +69,7 @@ where
         self.primary.key(k)
     }
 
-    fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
+    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
         self.primary.no_prefix_raw()
     }
 
@@ -174,7 +174,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().range_raw(store, min, max, order)
+        self.no_prefix_raw().range_raw(store, min, max, order)
     }
 
     pub fn keys_raw<'c>(
@@ -187,7 +187,7 @@ where
     where
         T: 'c,
     {
-        self.no_prefix().keys_raw(store, min, max, order)
+        self.no_prefix_raw().keys_raw(store, min, max, order)
     }
 }
 
@@ -232,7 +232,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().range(store, min, max, order)
+        self.no_prefix().range(store, min, max, order)
     }
 
     pub fn keys<'c>(
@@ -246,7 +246,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().keys(store, min, max, order)
+        self.no_prefix().keys(store, min, max, order)
     }
 
     pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
@@ -257,7 +257,7 @@ where
         Prefix::new(self.primary.namespace(), &p.prefix())
     }
 
-    fn no_prefix_de(&self) -> Prefix<K, T> {
+    fn no_prefix(&self) -> Prefix<K, T> {
         Prefix::new(self.primary.namespace(), &[])
     }
 }

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -70,7 +70,7 @@ where
     }
 
     fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
-        self.primary.no_prefix()
+        self.primary.no_prefix_raw()
     }
 
     /// load old value and store changelog

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -69,10 +69,6 @@ where
         self.primary.key(k)
     }
 
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<Vec<u8>, T> {
-        self.primary.sub_prefix(p)
-    }
-
     fn no_prefix(&self) -> Prefix<Vec<u8>, T> {
         self.primary.no_prefix()
     }

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -232,7 +232,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().range_de(store, min, max, order)
+        self.no_prefix_de().range(store, min, max, order)
     }
 
     pub fn keys_de<'c>(
@@ -246,7 +246,7 @@ where
         T: 'c,
         K::Output: 'static,
     {
-        self.no_prefix_de().keys_de(store, min, max, order)
+        self.no_prefix_de().keys(store, min, max, order)
     }
 
     pub fn prefix_de(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
@@ -557,7 +557,7 @@ mod tests {
         // let's prefix and iterate
         let all: StdResult<Vec<_>> = EVERY_COMPOSITE_KEY
             .prefix_de("C")
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(1, all.len());
@@ -577,7 +577,7 @@ mod tests {
         // sub_prefix_de type checks
         let all: StdResult<Vec<_>> = EVERY_COMPOSITE_KEY
             .sub_prefix_de(())
-            .range_de(&store, None, None, Order::Ascending)
+            .range(&store, None, None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -87,8 +87,8 @@ where
             let start = Bound::inclusive(height);
             let first = self
                 .changelog
-                .prefix(k.clone())
-                .range(store, Some(start), None, Order::Ascending)
+                .prefix_de(k.clone())
+                .range_raw(store, Some(start), None, Order::Ascending)
                 .next()
                 .transpose()?;
             if first.is_none() {
@@ -146,8 +146,8 @@ where
         let start = Bound::inclusive_int(height);
         let first = self
             .changelog
-            .prefix(key)
-            .range(store, Some(start), None, Order::Ascending)
+            .prefix_de(key)
+            .range_raw(store, Some(start), None, Order::Ascending)
             .next();
 
         if let Some(r) = first {

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -87,7 +87,7 @@ where
             let start = Bound::inclusive(height);
             let first = self
                 .changelog
-                .prefix_de(k.clone())
+                .prefix(k.clone())
                 .range_raw(store, Some(start), None, Order::Ascending)
                 .next()
                 .transpose()?;
@@ -146,7 +146,7 @@ where
         let start = Bound::inclusive_int(height);
         let first = self
             .changelog
-            .prefix_de(key)
+            .prefix(key)
             .range_raw(store, Some(start), None, Order::Ascending)
             .next();
 

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -79,7 +79,7 @@ where
         // most recent checkpoint
         let checkpoint = self
             .checkpoints
-            .range(store, None, None, Order::Descending)
+            .range_raw(store, None, None, Order::Descending)
             .next()
             .transpose()?;
         if let Some((height, _)) = checkpoint {

--- a/packages/utils/src/pagination.rs
+++ b/packages/utils/src/pagination.rs
@@ -73,7 +73,7 @@ mod test {
             let start = calc_range_start(start_after).map(Bound::exclusive);
 
             let holders: Vec<(String, usize)> = HOLDERS
-                .range(&deps.storage, start, None, Order::Ascending)
+                .range_raw(&deps.storage, start, None, Order::Ascending)
                 .map(deser_holder_kv)
                 .take(LIMIT)
                 .collect();
@@ -102,7 +102,7 @@ mod test {
             let end = calc_range_end(end_before).map(Bound::exclusive);
 
             let holders: Vec<(String, usize)> = HOLDERS
-                .range(&deps.storage, None, end, Order::Descending)
+                .range_raw(&deps.storage, None, end, Order::Descending)
                 .map(deser_holder_kv)
                 .take(LIMIT)
                 .collect();

--- a/packages/utils/src/pagination.rs
+++ b/packages/utils/src/pagination.rs
@@ -36,7 +36,7 @@ pub fn calc_range_start_string(start_after: Option<String>) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm_std::{testing::mock_dependencies, Order, StdError};
+    use cosmwasm_std::{testing::mock_dependencies, Order};
     use cw_storage_plus::{Bound, Map};
 
     pub const HOLDERS: Map<&Addr, usize> = Map::new("some_data");
@@ -44,12 +44,6 @@ mod test {
 
     fn addr_from_i(i: usize) -> Addr {
         Addr::unchecked(format!("addr{:0>8}", i))
-    }
-
-    fn deser_holder_kv(holder_kv: Result<(Vec<u8>, usize), StdError>) -> (String, usize) {
-        let (k_bytes, v) = holder_kv.unwrap();
-        let key = std::str::from_utf8(&k_bytes).unwrap().to_string();
-        (key, v)
     }
 
     #[test]
@@ -72,15 +66,15 @@ mod test {
 
             let start = calc_range_start(start_after).map(Bound::exclusive);
 
-            let holders: Vec<(String, usize)> = HOLDERS
-                .range_raw(&deps.storage, start, None, Order::Ascending)
-                .map(deser_holder_kv)
+            let holders = HOLDERS
+                .keys(&deps.storage, start, None, Order::Ascending)
                 .take(LIMIT)
-                .collect();
+                .collect::<StdResult<Vec<_>>>()
+                .unwrap();
 
             for (i, holder) in holders.into_iter().enumerate() {
                 let global_index = j * LIMIT + i;
-                assert_eq!(holder.0, addr_from_i(global_index));
+                assert_eq!(holder, addr_from_i(global_index));
             }
         }
     }
@@ -101,15 +95,15 @@ mod test {
 
             let end = calc_range_end(end_before).map(Bound::exclusive);
 
-            let holders: Vec<(String, usize)> = HOLDERS
-                .range_raw(&deps.storage, None, end, Order::Descending)
-                .map(deser_holder_kv)
+            let holders = HOLDERS
+                .keys(&deps.storage, None, end, Order::Descending)
                 .take(LIMIT)
-                .collect();
+                .collect::<StdResult<Vec<_>>>()
+                .unwrap();
 
             for (i, holder) in holders.into_iter().enumerate() {
                 let global_index = total_elements_count - i - j * LIMIT - 1;
-                assert_eq!(holder.0, addr_from_i(global_index));
+                assert_eq!(holder, addr_from_i(global_index));
             }
         }
     }


### PR DESCRIPTION
Closes #460.

Lots of changes, but basically renaming `range` to `range_raw`, and `range_de` to `range`.

- [x] Deprecates `range` in favour of `range_de`, keeping `range` as `range_raw`.
- [x] Keeps `prefix_de` as `prefix`, and remove the currents `prefix`. That is, no `prefix_raw` impl, which will be confusing. That implies making `range_raw` work with / over `prefix_de`.
- [x] Migrates the code in contracts to take advantage of the new key deserialization when useful.
- [x] ~~Improve traits segregation over `Map` and `Prefix` range-related methods, so that trait bounds are enforced only when strictly needed~~. (out of scope for this PR)

Could have chosen to provide two prefix functions, `prefix` and `prefix_raw`, but opted instead to provide one `prefix` with two ranges over it, `range` and `range_raw`, for simplicity of use. The only drawback is that if you want to prefix, you need to provide key deserialization impls for the involved keys, even if / when using only `range_raw`. This is reasonable IMO, as we are providing many of those impls already.

Most interesting stuff is in the contracts, where we leverage the new key deserialization functionality for clarity and convenience.