### PR TITLE
Add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ After that, fuzzing it (ideally with an intelligent fuzzer that understands the 
 can be valuable. And beyond that formal verification can provide even more assurance
 (but is very time consuming and expensive).
 
+For critical security issues & disclosure, see [SECURITY.md](SECURITY.md).
+
 ### Code Coverage
 
 I recommend the use of [tarpaulin](https://github.com/xd009642/tarpaulin): `cargo install cargo-tarpaulin`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Critical bugs and security issues 💥
+
+If you're here because you're trying to figure out how to notify us of a security issue, go to [Discord](https://discord.gg/VNyAnw7e), and alert:
+
+
+- Ethan Frey `ethanfrey#9693`
+- elsehow `elsehow#3115`
+
+Please avoid opening public issues on GitHub that contain information about a potential security vulnerability as this makes it difficult to reduce the impact and harm of valid security issues.
+
+### Coordinated Vulnerability Disclosure Policy
+
+We ask security researchers to keep vulnerabilities and communications around vulnerability submissions private and confidential until a patch is developed. In addition to this, we ask that you:
+
+- Allow us a reasonable amount of time to correct or address security vulnerabilities.
+- Avoid exploiting any vulnerabilities that you discover.
+- Demonstrate good faith by not disrupting or degrading services built on top of cw-plus.
+
+### Vulnerability Disclosure Process
+
+cw-plus uses the following disclosure process:
+
+- Once a security report is received, the cw-plus core development team works to verify the issue.
+- Patches are prepared for eligible releases in private repositories.
+- We notify the community that a security release is coming, to give users time to prepare their systems for the update. Notifications can include Discord messages, tweets, and emails to partners and validators.
+- 24 hours following this notification, the fixes are applied publicly and new releases are issued.
+- Once releases are available for cw-plus, we notify the community, again, through the same channels as above.
+- Once the community is notified, we will pay out any relevant bug bounties to submitters.
+- One week after the releases go out, we will publish a post with further details on the vulnerability as well as our response to it.
+
+This process can take some time. Every effort will be made to handle the bug in as timely a manner as possible. However, it's important that we follow the process described above to ensure that disclosures are handled consistently and to keep the cw-plus contracts and the projects that depend on them secure.


### PR DESCRIPTION
Addresses #580. Add an explicit disclosure process (adapted from Tendermint's) to build common expectations about how critical security issues are disclosed to the community, on what timeline, and via what channels.
