### PR TITLE
Signed int keys order

### DIFF
--- a/contracts/cw3-fixed-multisig/src/state.rs
+++ b/contracts/cw3-fixed-multisig/src/state.rs
@@ -1,8 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
-use cosmwasm_std::{Addr, BlockInfo, CosmosMsg, Empty, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, BlockInfo, CosmosMsg, Empty, StdResult, Storage};
 
 use cw3::{Status, Vote};
 use cw_storage_plus::{Item, Map};
@@ -65,13 +64,4 @@ pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;
     PROPOSAL_COUNT.save(store, &id)?;
     Ok(id)
-}
-
-pub fn parse_id(data: &[u8]) -> StdResult<u64> {
-    match data[0..8].try_into() {
-        Ok(bytes) => Ok(u64::from_be_bytes(bytes)),
-        Err(_) => Err(StdError::generic_err(
-            "Corrupted data found. 8 byte expected.",
-        )),
-    }
 }

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -1,10 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
-use cosmwasm_std::{
-    Addr, BlockInfo, CosmosMsg, Decimal, Empty, StdError, StdResult, Storage, Uint128,
-};
+use cosmwasm_std::{Addr, BlockInfo, CosmosMsg, Decimal, Empty, StdResult, Storage, Uint128};
 
 use cw3::{Status, Vote};
 use cw4::Cw4Contract;
@@ -160,15 +157,6 @@ pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
     let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;
     PROPOSAL_COUNT.save(store, &id)?;
     Ok(id)
-}
-
-pub fn parse_id(data: &[u8]) -> StdResult<u64> {
-    match data[0..8].try_into() {
-        Ok(bytes) => Ok(u64::from_be_bytes(bytes)),
-        Err(_) => Err(StdError::generic_err(
-            "Corrupted data found. 8 byte expected.",
-        )),
-    }
 }
 
 #[cfg(test)]

--- a/packages/storage-plus/src/de.rs
+++ b/packages/storage-plus/src/de.rs
@@ -231,6 +231,54 @@ mod test {
     }
 
     #[test]
+    fn deserialize_naked_integer_works() {
+        assert_eq!(u8::from_slice(&[1]).unwrap(), 1u8);
+        assert_eq!(i8::from_slice(&[127]).unwrap(), -1i8);
+        assert_eq!(i8::from_slice(&[128]).unwrap(), 0i8);
+
+        assert_eq!(u16::from_slice(&[1, 0]).unwrap(), 256u16);
+        assert_eq!(i16::from_slice(&[128, 0]).unwrap(), 0i16);
+        assert_eq!(i16::from_slice(&[127, 255]).unwrap(), -1i16);
+
+        assert_eq!(u32::from_slice(&[1, 0, 0, 0]).unwrap(), 16777216u32);
+        assert_eq!(i32::from_slice(&[128, 0, 0, 0]).unwrap(), 0i32);
+        assert_eq!(i32::from_slice(&[127, 255, 255, 255]).unwrap(), -1i32);
+
+        assert_eq!(
+            u64::from_slice(&[1, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
+            72057594037927936u64
+        );
+        assert_eq!(i64::from_slice(&[128, 0, 0, 0, 0, 0, 0, 0]).unwrap(), 0i64);
+        assert_eq!(
+            i64::from_slice(&[127, 255, 255, 255, 255, 255, 255, 255]).unwrap(),
+            -1i64
+        );
+
+        assert_eq!(
+            u128::from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
+            1329227995784915872903807060280344576u128
+        );
+        assert_eq!(
+            i128::from_slice(&[128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
+            0i128
+        );
+        assert_eq!(
+            i128::from_slice(&[
+                127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+            ])
+            .unwrap(),
+            -1i128
+        );
+        assert_eq!(
+            i128::from_slice(&[
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+            ])
+            .unwrap(),
+            170141183460469231731687303715884105727i128,
+        );
+    }
+
+    #[test]
     fn deserialize_integer_works() {
         assert_eq!(<IntKey<u8>>::from_slice(&[1]).unwrap(), 1u8);
         assert_eq!(<IntKey<i8>>::from_slice(&[127]).unwrap(), -1i8);

--- a/packages/storage-plus/src/de.rs
+++ b/packages/storage-plus/src/de.rs
@@ -237,10 +237,18 @@ mod test {
             <IntKey<i8>>::from_slice(&[128]).unwrap(),
             ((-1i8 << 7) as u8 ^ 0x80) as i8
         );
+        assert_eq!(
+            <IntKey<i8>>::from_slice(&[127]).unwrap(),
+            (127 ^ 0x80) as i8
+        );
         assert_eq!(<IntKey<u16>>::from_slice(&[1, 0]).unwrap(), 1u16 << 8);
         assert_eq!(
             <IntKey<i16>>::from_slice(&[128, 0]).unwrap(),
-            ((-1i16 << (8 + 7)) as u16 ^ 0x8000) as i16
+            ((-1i16 << 15) as u16 ^ 0x8000) as i16
+        );
+        assert_eq!(
+            <IntKey<i16>>::from_slice(&[127, 255]).unwrap(),
+            (((1u16 << 15) - 1) ^ 0x8000) as i16
         );
         assert_eq!(
             <IntKey<u32>>::from_slice(&[1, 0, 0, 0]).unwrap(),
@@ -248,7 +256,11 @@ mod test {
         );
         assert_eq!(
             <IntKey<i32>>::from_slice(&[128, 0, 0, 0]).unwrap(),
-            ((-1i32 << (3 * 8 + 7)) as u32 ^ 0x80000000) as i32
+            ((-1i32 << 31) as u32 ^ 0x80000000) as i32
+        );
+        assert_eq!(
+            <IntKey<i32>>::from_slice(&[127, 255, 255, 255]).unwrap(),
+            (((1u32 << 31) - 1) ^ 0x80000000) as i32
         );
         assert_eq!(
             <IntKey<u64>>::from_slice(&[1, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
@@ -256,7 +268,11 @@ mod test {
         );
         assert_eq!(
             <IntKey<i64>>::from_slice(&[128, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-            ((-1i64 << (7 * 8 + 7)) as u64 ^ 0x8000000000000000) as i64
+            ((-1i64 << 63) as u64 ^ 0x8000000000000000) as i64
+        );
+        assert_eq!(
+            <IntKey<i64>>::from_slice(&[127, 255, 255, 255, 255, 255, 255, 255]).unwrap(),
+            (((1u64 << 63) - 1) ^ 0x8000000000000000) as i64
         );
         assert_eq!(
             <IntKey<u128>>::from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
@@ -267,7 +283,7 @@ mod test {
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
             ])
             .unwrap(),
-            (-1i128 as u128 ^ 0x80000000000000000000000000000000u128) as i128
+            (-1i128 as u128 ^ 0x80000000000000000000000000000000) as i128
         );
     }
 

--- a/packages/storage-plus/src/de.rs
+++ b/packages/storage-plus/src/de.rs
@@ -233,57 +233,58 @@ mod test {
     #[test]
     fn deserialize_integer_works() {
         assert_eq!(<IntKey<u8>>::from_slice(&[1]).unwrap(), 1u8);
-        assert_eq!(
-            <IntKey<i8>>::from_slice(&[128]).unwrap(),
-            ((-1i8 << 7) as u8 ^ 0x80) as i8
-        );
-        assert_eq!(
-            <IntKey<i8>>::from_slice(&[127]).unwrap(),
-            (127 ^ 0x80) as i8
-        );
-        assert_eq!(<IntKey<u16>>::from_slice(&[1, 0]).unwrap(), 1u16 << 8);
-        assert_eq!(
-            <IntKey<i16>>::from_slice(&[128, 0]).unwrap(),
-            ((-1i16 << 15) as u16 ^ 0x8000) as i16
-        );
-        assert_eq!(
-            <IntKey<i16>>::from_slice(&[127, 255]).unwrap(),
-            (((1u16 << 15) - 1) ^ 0x8000) as i16
-        );
+        assert_eq!(<IntKey<i8>>::from_slice(&[127]).unwrap(), -1i8);
+        assert_eq!(<IntKey<i8>>::from_slice(&[128]).unwrap(), 0i8);
+
+        assert_eq!(<IntKey<u16>>::from_slice(&[1, 0]).unwrap(), 256u16);
+        assert_eq!(<IntKey<i16>>::from_slice(&[128, 0]).unwrap(), 0i16);
+        assert_eq!(<IntKey<i16>>::from_slice(&[127, 255]).unwrap(), -1i16);
+
         assert_eq!(
             <IntKey<u32>>::from_slice(&[1, 0, 0, 0]).unwrap(),
-            1u32 << (3 * 8)
+            16777216u32
         );
-        assert_eq!(
-            <IntKey<i32>>::from_slice(&[128, 0, 0, 0]).unwrap(),
-            ((-1i32 << 31) as u32 ^ 0x80000000) as i32
-        );
+        assert_eq!(<IntKey<i32>>::from_slice(&[128, 0, 0, 0]).unwrap(), 0i32);
         assert_eq!(
             <IntKey<i32>>::from_slice(&[127, 255, 255, 255]).unwrap(),
-            (((1u32 << 31) - 1) ^ 0x80000000) as i32
+            -1i32
         );
+
         assert_eq!(
             <IntKey<u64>>::from_slice(&[1, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-            1u64 << (7 * 8)
+            72057594037927936u64
         );
         assert_eq!(
             <IntKey<i64>>::from_slice(&[128, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-            ((-1i64 << 63) as u64 ^ 0x8000000000000000) as i64
+            0i64
         );
         assert_eq!(
             <IntKey<i64>>::from_slice(&[127, 255, 255, 255, 255, 255, 255, 255]).unwrap(),
-            (((1u64 << 63) - 1) ^ 0x8000000000000000) as i64
+            -1i64
         );
+
         assert_eq!(
             <IntKey<u128>>::from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-            1u128 << (15 * 8)
+            1329227995784915872903807060280344576u128
+        );
+        assert_eq!(
+            <IntKey<i128>>::from_slice(&[128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+                .unwrap(),
+            0i128
+        );
+        assert_eq!(
+            <IntKey<i128>>::from_slice(&[
+                127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+            ])
+            .unwrap(),
+            -1i128
         );
         assert_eq!(
             <IntKey<i128>>::from_slice(&[
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
             ])
             .unwrap(),
-            (-1i128 as u128 ^ 0x80000000000000000000000000000000) as i128
+            170141183460469231731687303715884105727i128,
         );
     }
 
@@ -306,7 +307,7 @@ mod test {
     fn deserialize_timestamp_works() {
         assert_eq!(
             <TimestampKey>::from_slice(&[1, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-            1u64 << (7 * 8)
+            72057594037927936
         );
     }
 

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -17,10 +17,12 @@ macro_rules! cw_uint_keys {
         $(impl CwIntKey for $t {
             type Buf = [u8; mem::size_of::<$t>()];
 
+            #[inline]
             fn to_cw_bytes(&self) -> Self::Buf {
                 self.to_be_bytes()
             }
 
+            #[inline]
             fn from_cw_bytes(bytes: Self::Buf) -> Self {
                 Self::from_be_bytes(bytes)
             }
@@ -35,10 +37,12 @@ macro_rules! cw_int_keys {
         $(impl CwIntKey for $t {
             type Buf = [u8; mem::size_of::<$t>()];
 
+            #[inline]
             fn to_cw_bytes(&self) -> Self::Buf {
                 (*self as $ut ^ <$t>::MIN as $ut).to_be_bytes()
             }
 
+            #[inline]
             fn from_cw_bytes(bytes: Self::Buf) -> Self {
                 (Self::from_be_bytes(bytes) as $ut ^ <$t>::MIN as $ut) as _
             }

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -30,19 +30,19 @@ macro_rules! cw_uint_keys {
 cw_uint_keys!(for u8, u16, u32, u64, u128);
 
 macro_rules! cw_int_keys {
-    (for $($t:ty),+) => {
+    (for $($t:ty, $ut:ty),+) => {
         $(impl CwIntKey for $t {
             type Buf = [u8; mem::size_of::<$t>()];
 
             fn to_cw_bytes(&self) -> Self::Buf {
-                ((*self as u128 ^ <$t>::MIN as u128) as $t).to_be_bytes()
+                (*self as $ut ^ <$t>::MIN as $ut).to_be_bytes()
             }
 
             fn from_cw_bytes(bytes: Self::Buf) -> Self {
-                (Self::from_be_bytes(bytes) as u128 ^ <$t>::MIN as u128) as _
+                (Self::from_be_bytes(bytes) as $ut ^ <$t>::MIN as $ut) as _
             }
         })*
     }
 }
 
-cw_int_keys!(for i8, i16, i32, i64, i128);
+cw_int_keys!(for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -47,3 +47,80 @@ macro_rules! cw_int_keys {
 }
 
 cw_int_keys!(for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn x8_int_key_works() {
+        let k: u8 = 42u8;
+        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
+
+        let k: i8 = 42i8;
+        assert_eq!(k.to_cw_bytes(), (k as u8 ^ 0x80).to_be_bytes());
+
+        let k: i8 = -42i8;
+        assert_eq!(k.to_cw_bytes(), (k as u8 ^ 0x80).to_be_bytes());
+    }
+
+    #[test]
+    fn x16_int_key_works() {
+        let k: u16 = 4243u16;
+        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
+
+        let k: i16 = 4445i16;
+        assert_eq!(k.to_cw_bytes(), (k as u16 ^ 0x8000).to_be_bytes());
+
+        let k: i16 = -4748i16;
+        assert_eq!(k.to_cw_bytes(), (k as u16 ^ 0x8000).to_be_bytes());
+    }
+
+    #[test]
+    fn x32_int_key_works() {
+        let k: u32 = 424344u32;
+        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
+
+        let k: i32 = 454647i32;
+        assert_eq!(k.to_cw_bytes(), (k as u32 ^ 0x80000000).to_be_bytes());
+
+        let k: i32 = -484950i32;
+        assert_eq!(k.to_cw_bytes(), (k as u32 ^ 0x80000000).to_be_bytes());
+    }
+
+    #[test]
+    fn x64_int_key_works() {
+        let k: u64 = 42434445u64;
+        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
+
+        let k: i64 = 46474849i64;
+        assert_eq!(
+            k.to_cw_bytes(),
+            (k as u64 ^ 0x8000000000000000).to_be_bytes()
+        );
+
+        let k: i64 = -50515253i64;
+        assert_eq!(
+            k.to_cw_bytes(),
+            (k as u64 ^ 0x8000000000000000).to_be_bytes()
+        );
+    }
+
+    #[test]
+    fn x128_int_key_works() {
+        let k: u128 = 4243444546u128;
+        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
+
+        let k: i128 = 4748495051i128;
+        assert_eq!(
+            k.to_cw_bytes(),
+            (k as u128 ^ 0x80000000000000000000000000000000).to_be_bytes()
+        );
+
+        let k: i128 = -5253545556i128;
+        assert_eq!(
+            k.to_cw_bytes(),
+            (k as u128 ^ 0x80000000000000000000000000000000).to_be_bytes()
+        );
+    }
+}

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -1,9 +1,10 @@
 use std::mem;
 
-/// Our int keys are simply the Big-endian representation bytes for unsigned ints,
-/// but "sign-flipped" (xored msb) Big-endian bytes for signed ints.
-/// So that the representation of signed integers is correctly ordered lexicographically.
-// TODO: Rename to `IntKey` when deprecating actual `IntKey`
+/// Our int keys are simply the big-endian representation bytes for unsigned ints,
+/// but "sign-flipped" (xored msb) big-endian bytes for signed ints.
+///
+/// So that the representation of signed integers is in the right lexicographical order.
+// TODO: Rename to `IntKey` when deprecating current `IntKey`
 pub trait CwIntKey: Sized + Copy {
     type Buf: AsRef<[u8]> + AsMut<[u8]> + Into<Vec<u8>> + Default;
 

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -3,6 +3,7 @@ use std::mem;
 /// Our int keys are simply the Big-endian representation bytes for unsigned ints,
 /// but "sign-flipped" (xored msb) Big-endian bytes for signed ints.
 /// So that the representation of signed integers is correctly ordered lexicographically.
+// TODO: Rename to `IntKey` when deprecating actual `IntKey`
 pub trait CwIntKey: Sized + Copy {
     type Buf: AsRef<[u8]> + AsMut<[u8]> + Into<Vec<u8>> + Default;
 
@@ -34,15 +35,11 @@ macro_rules! cw_int_keys {
             type Buf = [u8; mem::size_of::<$t>()];
 
             fn to_cw_bytes(&self) -> Self::Buf {
-                let mut bytes = self.to_be_bytes();
-                bytes[0] ^= 0x80;
-                bytes
+                ((*self as u128 ^ <$t>::MIN as u128) as $t).to_be_bytes()
             }
 
             fn from_cw_bytes(bytes: Self::Buf) -> Self {
-                let mut bytes = bytes;
-                bytes[0] ^= 0x80;
-                Self::from_be_bytes(bytes)
+                (Self::from_be_bytes(bytes) as u128 ^ <$t>::MIN as u128) as _
             }
         })*
     }

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -58,73 +58,63 @@ mod test {
 
     #[test]
     fn x8_int_key_works() {
-        let k: u8 = 42u8;
-        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
-
-        let k: i8 = 42i8;
-        assert_eq!(k.to_cw_bytes(), (k as u8 ^ 0x80).to_be_bytes());
-
-        let k: i8 = -42i8;
-        assert_eq!(k.to_cw_bytes(), (k as u8 ^ 0x80).to_be_bytes());
+        assert_eq!(0x42u8.to_cw_bytes(), [0x42]);
+        assert_eq!(0x42i8.to_cw_bytes(), [0xc2]);
+        assert_eq!((-0x3ei8).to_cw_bytes(), [0x42]);
     }
 
     #[test]
     fn x16_int_key_works() {
-        let k: u16 = 4243u16;
-        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
-
-        let k: i16 = 4445i16;
-        assert_eq!(k.to_cw_bytes(), (k as u16 ^ 0x8000).to_be_bytes());
-
-        let k: i16 = -4748i16;
-        assert_eq!(k.to_cw_bytes(), (k as u16 ^ 0x8000).to_be_bytes());
+        assert_eq!(0x4243u16.to_cw_bytes(), [0x42, 0x43]);
+        assert_eq!(0x4243i16.to_cw_bytes(), [0xc2, 0x43]);
+        assert_eq!((-0x3dbdi16).to_cw_bytes(), [0x42, 0x43]);
     }
 
     #[test]
     fn x32_int_key_works() {
-        let k: u32 = 424344u32;
-        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
-
-        let k: i32 = 454647i32;
-        assert_eq!(k.to_cw_bytes(), (k as u32 ^ 0x80000000).to_be_bytes());
-
-        let k: i32 = -484950i32;
-        assert_eq!(k.to_cw_bytes(), (k as u32 ^ 0x80000000).to_be_bytes());
+        assert_eq!(0x424344u32.to_cw_bytes(), [0x00, 0x42, 0x43, 0x44]);
+        assert_eq!(0x424344i32.to_cw_bytes(), [0x80, 0x42, 0x43, 0x44]);
+        assert_eq!((-0x7fbdbcbci32).to_cw_bytes(), [0x00, 0x42, 0x43, 0x44]);
     }
 
     #[test]
     fn x64_int_key_works() {
-        let k: u64 = 42434445u64;
-        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
-
-        let k: i64 = 46474849i64;
         assert_eq!(
-            k.to_cw_bytes(),
-            (k as u64 ^ 0x8000000000000000).to_be_bytes()
+            0x42434445u64.to_cw_bytes(),
+            [0x00, 0x00, 0x00, 0x00, 0x42, 0x43, 0x44, 0x45]
         );
-
-        let k: i64 = -50515253i64;
         assert_eq!(
-            k.to_cw_bytes(),
-            (k as u64 ^ 0x8000000000000000).to_be_bytes()
+            0x42434445i64.to_cw_bytes(),
+            [0x80, 0x00, 0x00, 0x00, 0x42, 0x43, 0x44, 0x45]
+        );
+        assert_eq!(
+            (-0x7fffffffbdbcbbbbi64).to_cw_bytes(),
+            [0x00, 0x00, 0x00, 0x00, 0x42, 0x43, 0x44, 0x45]
         );
     }
 
     #[test]
     fn x128_int_key_works() {
-        let k: u128 = 4243444546u128;
-        assert_eq!(k.to_cw_bytes(), k.to_be_bytes());
-
-        let k: i128 = 4748495051i128;
         assert_eq!(
-            k.to_cw_bytes(),
-            (k as u128 ^ 0x80000000000000000000000000000000).to_be_bytes()
+            0x4243444546u128.to_cw_bytes(),
+            [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42, 0x43, 0x44,
+                0x45, 0x46
+            ]
         );
-
-        let k: i128 = -5253545556i128;
         assert_eq!(
-            k.to_cw_bytes(),
-            (k as u128 ^ 0x80000000000000000000000000000000).to_be_bytes()
+            0x4243444546i128.to_cw_bytes(),
+            [
+                0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42, 0x43, 0x44,
+                0x45, 0x46
+            ]
+        );
+        assert_eq!(
+            (-0x7fffffffffffffffffffffbdbcbbbabai128).to_cw_bytes(),
+            [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42, 0x43, 0x44,
+                0x45, 0x46
+            ]
         );
     }
 }

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -117,4 +117,15 @@ mod test {
             ]
         );
     }
+
+    #[test]
+    fn unsigned_int_key_order() {
+        assert!(0u32.to_cw_bytes() < 652u32.to_cw_bytes());
+    }
+
+    #[test]
+    fn signed_int_key_order() {
+        assert!((-321i32).to_cw_bytes() < 0i32.to_cw_bytes());
+        assert!(0i32.to_cw_bytes() < 652i32.to_cw_bytes());
+    }
 }

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -1,0 +1,51 @@
+use std::mem;
+
+/// Our int keys are simply the Big-endian representation bytes for unsigned ints,
+/// but "sign-flipped" (xored msb) Big-endian bytes for signed ints.
+/// So that the representation of signed integers is correctly ordered lexicographically.
+pub trait CwIntKey: Sized + Copy {
+    type Buf: AsRef<[u8]> + AsMut<[u8]> + Into<Vec<u8>> + Default;
+
+    fn to_cw_bytes(&self) -> Self::Buf;
+    fn from_cw_bytes(bytes: Self::Buf) -> Self;
+}
+
+macro_rules! cw_uint_keys {
+    (for $($t:ty),+) => {
+        $(impl CwIntKey for $t {
+            type Buf = [u8; mem::size_of::<$t>()];
+
+            fn to_cw_bytes(&self) -> Self::Buf {
+                self.to_be_bytes()
+            }
+
+            fn from_cw_bytes(bytes: Self::Buf) -> Self {
+                Self::from_be_bytes(bytes)
+            }
+        })*
+    }
+}
+
+cw_uint_keys!(for u8, u16, u32, u64, u128);
+
+macro_rules! cw_int_keys {
+    (for $($t:ty),+) => {
+        $(impl CwIntKey for $t {
+            type Buf = [u8; mem::size_of::<$t>()];
+
+            fn to_cw_bytes(&self) -> Self::Buf {
+                let mut bytes = self.to_be_bytes();
+                bytes[0] ^= 0x80;
+                bytes
+            }
+
+            fn from_cw_bytes(bytes: Self::Buf) -> Self {
+                let mut bytes = bytes;
+                bytes[0] ^= 0x80;
+                Self::from_be_bytes(bytes)
+            }
+        })*
+    }
+}
+
+cw_int_keys!(for i8, i16, i32, i64, i128);

--- a/packages/storage-plus/src/int_key.rs
+++ b/packages/storage-plus/src/int_key.rs
@@ -4,7 +4,7 @@ use std::mem;
 /// but "sign-flipped" (xored msb) big-endian bytes for signed ints.
 ///
 /// So that the representation of signed integers is in the right lexicographical order.
-// TODO: Rename to `IntKey` when deprecating current `IntKey`
+// TODO: Rename to `IntKey` after deprecating current `IntKey` (https://github.com/CosmWasm/cw-plus/issues/570)
 pub trait CwIntKey: Sized + Copy {
     type Buf: AsRef<[u8]> + AsMut<[u8]> + Into<Vec<u8>> + Default;
 

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -326,16 +326,26 @@ impl<'a, T: Endian> Prefixer<'a> for IntKey<T> {
     }
 }
 
+#[deprecated(note = "It is suggested to use `u8` as key type instead of the `U8Key` wrapper")]
 pub type U8Key = IntKey<u8>;
+#[deprecated(note = "It is suggested to use `u16` as key type instead of the `U16Key` wrapper")]
 pub type U16Key = IntKey<u16>;
+#[deprecated(note = "It is suggested to use `u32` as key type instead of the `U32Key` wrapper")]
 pub type U32Key = IntKey<u32>;
+#[deprecated(note = "It is suggested to use `u64` as key type instead of the `U64Key` wrapper")]
 pub type U64Key = IntKey<u64>;
+#[deprecated(note = "Consider using 64-bit keys instead of the `U128Key` wrapper")]
 pub type U128Key = IntKey<u128>;
 
+#[deprecated(note = "It is suggested to use `i8` as key type instead of the `I8Key` wrapper")]
 pub type I8Key = IntKey<i8>;
+#[deprecated(note = "It is suggested to use `i16` as key type instead of the `I16Key` wrapper")]
 pub type I16Key = IntKey<i16>;
+#[deprecated(note = "It is suggested to use `i32` as key type instead of the `I32Key` wrapper")]
 pub type I32Key = IntKey<i32>;
+#[deprecated(note = "It is suggested to use `i64` as key type instead of the `I64Key` wrapper")]
 pub type I64Key = IntKey<i64>;
+#[deprecated(note = "Consider using 64-bit keys instead of the `I128Key` wrapper")]
 pub type I128Key = IntKey<i128>;
 
 /// It will cast one-particular int type into a Key via Vec<u8>, ensuring you don't mix up u32 and u64

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -626,7 +626,8 @@ mod test {
         assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
 
         let pair: (i8, &[u8]) = (123, b"random");
-        let one: Vec<u8> = vec![123 + 128];
+        // Signed int keys are "sign-flipped"
+        let one: Vec<u8> = vec![123 ^ 0x80];
         let two: Vec<u8> = b"random".to_vec();
         assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
     }
@@ -639,7 +640,8 @@ mod test {
         assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
 
         let pair: (i16, &[u8]) = (12345, b"random");
-        let one: Vec<u8> = vec![48 + 128, 57];
+        // Signed int keys are "sign-flipped"
+        let one: Vec<u8> = vec![48 ^ 0x80, 57];
         let two: Vec<u8> = b"random".to_vec();
         assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
     }
@@ -652,7 +654,9 @@ mod test {
         assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
 
         let pair: (i64, &[u8]) = (12345, b"random");
-        let one: Vec<u8> = vec![128, 0, 0, 0, 0, 0, 48, 57];
+        // Signed int keys are "sign-flipped"
+        #[allow(clippy::identity_op)]
+        let one: Vec<u8> = vec![0 ^ 0x80, 0, 0, 0, 0, 0, 48, 57];
         let two: Vec<u8> = b"random".to_vec();
         assert_eq!(pair.prefix(), vec![one.as_slice(), two.as_slice()]);
     }

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -29,6 +29,7 @@ pub use item::Item;
 #[allow(deprecated)]
 pub use keys::{I128Key, I16Key, I32Key, I64Key, I8Key};
 // TODO: Remove along with `IntKey`
+pub use int_key::CwIntKey;
 #[allow(deprecated)]
 pub use keys::{Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
 pub use map::Map;

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -24,7 +24,11 @@ pub use indexes::UniqueIndex;
 #[cfg(feature = "iterator")]
 pub use indexes::{index_string, index_string_tuple, index_triple, index_tuple, Index};
 pub use item::Item;
+// TODO: Remove along with `IntKey`
+#[allow(deprecated)]
 pub use keys::{I128Key, I16Key, I32Key, I64Key, I8Key};
+// TODO: Remove along with `IntKey`
+#[allow(deprecated)]
 pub use keys::{Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
 pub use map::Map;
 pub use path::Path;

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -4,6 +4,7 @@ mod helpers;
 mod indexed_map;
 mod indexed_snapshot;
 mod indexes;
+mod int_key;
 mod item;
 mod iter_helpers;
 mod keys;

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -254,6 +254,8 @@ mod test {
     #[cfg(feature = "iterator")]
     use cosmwasm_std::{Order, StdResult};
 
+    use crate::int_key::CwIntKey;
+
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Data {
         pub name: String,
@@ -297,7 +299,7 @@ mod test {
         );
         assert_eq!(b"triple".to_vec().as_slice(), &key[2..8]);
         assert_eq!(b"john".to_vec().as_slice(), &key[10..14]);
-        assert_eq!(8u8.to_be_bytes(), &key[16..17]);
+        assert_eq!(8u8.to_cw_bytes(), &key[16..17]);
         assert_eq!(b"pedro".to_vec().as_slice(), &key[17..]);
     }
 

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 
 use crate::de::KeyDeserialize;
 use crate::helpers::{namespaces_with_key, nested_namespaces_with_key};
+use crate::int_key::CwIntKey;
 use crate::iter_helpers::{concat, deserialize_kv, deserialize_v, trim};
 use crate::keys::Key;
 use crate::{Endian, Prefixer};
@@ -34,13 +35,13 @@ impl Bound {
     }
 
     /// Turns an int, like Option<u32> into an inclusive bound
-    pub fn inclusive_int<T: Endian>(limit: T) -> Self {
-        Bound::Inclusive(limit.to_be_bytes().into())
+    pub fn inclusive_int<T: CwIntKey + Endian>(limit: T) -> Self {
+        Bound::Inclusive(limit.to_cw_bytes().into())
     }
 
     /// Turns an int, like Option<u64> into an exclusive bound
-    pub fn exclusive_int<T: Endian>(limit: T) -> Self {
-        Bound::Exclusive(limit.to_be_bytes().into())
+    pub fn exclusive_int<T: CwIntKey + Endian>(limit: T) -> Self {
+        Bound::Exclusive(limit.to_cw_bytes().into())
     }
 }
 


### PR DESCRIPTION
Closes #489.

There are a number of different ways to do the signed int key modification (a number of different impls in the commits). Not sure what is the best one; opted for doing it without mutable slices, and without branching.

I guess the only way to know for sure would be by benchmarking them. Will create an issue for it, and we can do  in the future.