### PR TITLE
Rename utils to cw-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,10 +245,10 @@ version = "0.11.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -259,13 +259,13 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-storage-plus",
+ "cw-utils",
  "derivative",
  "itertools",
  "prost",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -275,6 +275,18 @@ dependencies = [
  "cosmwasm-std",
  "schemars",
  "serde",
+]
+
+[[package]]
+name = "cw-utils"
+version = "0.11.0"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "prost",
+ "schemars",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -294,6 +306,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "cw1",
  "cw1-whitelist",
  "cw2",
@@ -301,7 +314,6 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -314,13 +326,13 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus",
+ "cw-utils",
  "cw1",
  "cw2",
  "derivative",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -333,13 +345,13 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus",
+ "cw-utils",
  "cw1",
  "cw2",
  "derivative",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -348,9 +360,9 @@ version = "0.11.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-utils",
  "schemars",
  "serde",
- "utils",
 ]
 
 [[package]]
@@ -360,12 +372,12 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "cw1155",
  "cw2",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -384,9 +396,9 @@ version = "0.11.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-utils",
  "schemars",
  "serde",
- "utils",
 ]
 
 [[package]]
@@ -396,6 +408,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "hex 0.3.2",
@@ -403,7 +416,6 @@ dependencies = [
  "serde",
  "sha2 0.8.2",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -413,12 +425,12 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -428,6 +440,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "cw20-base",
@@ -437,7 +450,6 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -448,13 +460,13 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "cw20-base",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -464,12 +476,12 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -479,6 +491,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "hex 0.4.3",
@@ -487,7 +500,6 @@ dependencies = [
  "serde_json",
  "sha2 0.9.8",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -498,13 +510,13 @@ dependencies = [
  "cosmwasm-std",
  "cw-controllers",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "cw20-base",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -513,9 +525,9 @@ version = "0.11.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-utils",
  "schemars",
  "serde",
- "utils",
 ]
 
 [[package]]
@@ -526,6 +538,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "cw20-base",
@@ -533,7 +546,6 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -544,6 +556,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw3",
  "cw3-fixed-multisig",
@@ -552,7 +565,6 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -574,12 +586,12 @@ dependencies = [
  "cosmwasm-std",
  "cw-controllers",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw4",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -590,13 +602,13 @@ dependencies = [
  "cosmwasm-std",
  "cw-controllers",
  "cw-storage-plus",
+ "cw-utils",
  "cw2",
  "cw20",
  "cw4",
  "schemars",
  "serde",
  "thiserror",
- "utils",
 ]
 
 [[package]]
@@ -1167,18 +1179,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "utils"
-version = "0.11.0"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus",
- "prost",
- "schemars",
- "serde",
- "thiserror",
-]
 
 [[package]]
 name = "version_check"

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -16,7 +16,7 @@ index 1924b655..37af477d 100644
 --- a/contracts/cw1-subkeys/Cargo.toml
 +++ b/contracts/cw1-subkeys/Cargo.toml
 -cw0 = { path = "../../packages/cw0", version = "0.10.3" }
-+utils = { path = "../../packages/utils", version = "0.10.3" }
++cw-utils = { path = "../../packages/utils", version = "0.10.3" }
 ```
 
 ```diff
@@ -25,7 +25,7 @@ index b4852225..f20a65ec 100644
 --- a/contracts/cw1-subkeys/src/contract.rs
 +++ b/contracts/cw1-subkeys/src/contract.rs
 -use cw0::Expiration;
-+use utils::Expiration;
++use cw_utils::Expiration;
 ```
 
 ---
@@ -244,7 +244,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 `Threshold` type was moved to `packages/utils` along with surrounding implementations like `ThresholdResponse` etc.
 
 ```diff
-use utils::Threshold;
+use cw_utils::Threshold;
 
 pub struct InstantiateMsg {
     pub voters: Vec<Voter>,

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -19,7 +19,7 @@ library = []
 test-utils = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw1 = { path = "../../packages/cw1", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw1-whitelist = { path = "../cw1-whitelist", version = "0.11.0", features = ["library"] }

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -19,8 +19,8 @@ use cw1_whitelist::{
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw_storage_plus::Bound;
+use cw_utils::Expiration;
 use semver::Version;
-use utils::Expiration;
 
 use crate::error::ContractError;
 use crate::msg::{
@@ -477,7 +477,7 @@ mod tests {
 
     use cw1_whitelist::msg::AdminListResponse;
     use cw2::{get_contract_version, ContractVersion};
-    use utils::NativeBalance;
+    use cw_utils::NativeBalance;
 
     use crate::state::Permissions;
 

--- a/contracts/cw1-subkeys/src/error.rs
+++ b/contracts/cw1-subkeys/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::StdError;
+use cw_utils::Expiration;
 use thiserror::Error;
-use utils::Expiration;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {

--- a/contracts/cw1-subkeys/src/msg.rs
+++ b/contracts/cw1-subkeys/src/msg.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use cosmwasm_std::{Coin, CosmosMsg, Empty};
-use utils::{Expiration, NativeBalance};
+use cw_utils::{Expiration, NativeBalance};
 
 use crate::state::Permissions;
 
@@ -112,7 +112,7 @@ impl AllowanceInfo {
     /// Example:
     ///
     /// ```
-    /// # use utils::{Expiration, NativeBalance};
+    /// # use cw_utils::{Expiration, NativeBalance};
     /// # use cw1_subkeys::msg::AllowanceInfo;
     /// # use cosmwasm_std::coin;
     ///

--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use cosmwasm_std::Addr;
 use cw_storage_plus::Map;
-use utils::{Expiration, NativeBalance};
+use cw_utils::{Expiration, NativeBalance};
 
 // Permissions struct defines users message execution permissions.
 // Could have implemented permissions for each cosmos module(StakingPermissions, GovPermissions etc...)
@@ -46,7 +46,7 @@ impl Allowance {
     /// Example:
     ///
     /// ```
-    /// # use utils::{Expiration, NativeBalance};
+    /// # use cw_utils::{Expiration, NativeBalance};
     /// # use cw1_subkeys::state::Allowance;
     /// # use cosmwasm_std::coin;
     ///

--- a/contracts/cw1-whitelist-ng/Cargo.toml
+++ b/contracts/cw1-whitelist-ng/Cargo.toml
@@ -22,7 +22,7 @@ querier = ["library"]
 multitest = ["cw-multi-test", "anyhow"]
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw1 = { path = "../../packages/cw1", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3", features = ["staking"] }

--- a/contracts/cw1-whitelist-ng/src/contract.rs
+++ b/contracts/cw1-whitelist-ng/src/contract.rs
@@ -19,7 +19,7 @@ const CONTRACT_NAME: &str = "crates.io:cw1-whitelist";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn validate_admins(api: &dyn Api, admins: &[String]) -> StdResult<Vec<Addr>> {
-    admins.iter().map(|addr| api.addr_validate(&addr)).collect()
+    admins.iter().map(|addr| api.addr_validate(addr)).collect()
 }
 
 impl<T> Cw1WhitelistContract<T> {

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -19,7 +19,7 @@ library = []
 test-utils = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw1 = { path = "../../packages/cw1", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3", features = ["staking"] }

--- a/contracts/cw1-whitelist/src/contract.rs
+++ b/contracts/cw1-whitelist/src/contract.rs
@@ -36,7 +36,7 @@ pub fn instantiate(
 }
 
 pub fn map_validate(api: &dyn Api, admins: &[String]) -> StdResult<Vec<Addr>> {
-    admins.iter().map(|addr| api.addr_validate(&addr)).collect()
+    admins.iter().map(|addr| api.addr_validate(addr)).collect()
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/cw1155-base/Cargo.toml
+++ b/contracts/cw1155-base/Cargo.toml
@@ -18,7 +18,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw1155 = { path = "../../packages/cw1155", version = "0.11.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.0" }

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -11,7 +11,7 @@ use cw1155::{
     IsApprovedForAllResponse, TokenId, TokenInfoResponse, TokensResponse, TransferEvent,
 };
 use cw2::set_contract_version;
-use utils::{maybe_addr, Event};
+use cw_utils::{maybe_addr, Event};
 
 use crate::error::ContractError;
 use crate::msg::InstantiateMsg;

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -133,7 +133,7 @@ fn check_can_approve(deps: Deps, env: &Env, owner: &Addr, operator: &Addr) -> St
         return Ok(true);
     }
     // operator can approve
-    let op = APPROVES.may_load(deps.storage, (&owner, &operator))?;
+    let op = APPROVES.may_load(deps.storage, (owner, operator))?;
     Ok(match op {
         Some(ex) => !ex.is_expired(&env.block),
         None => false,
@@ -325,13 +325,13 @@ pub fn execute_batch_mint(
     let mut rsp = Response::default();
 
     for (token_id, amount) in batch.iter() {
-        let event = execute_transfer_inner(&mut deps, None, Some(&to_addr), &token_id, *amount)?;
+        let event = execute_transfer_inner(&mut deps, None, Some(&to_addr), token_id, *amount)?;
         event.add_attributes(&mut rsp);
 
         // insert if not exist
-        if !TOKENS.has(deps.storage, &token_id) {
+        if !TOKENS.has(deps.storage, token_id) {
             // we must save some valid data here
-            TOKENS.save(deps.storage, &token_id, &String::new())?;
+            TOKENS.save(deps.storage, token_id, &String::new())?;
         }
     }
 

--- a/contracts/cw20-atomic-swap/Cargo.toml
+++ b/contracts/cw20-atomic-swap/Cargo.toml
@@ -15,7 +15,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw20 = { path = "../../packages/cw20", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3" }

--- a/contracts/cw20-atomic-swap/src/state.rs
+++ b/contracts/cw20-atomic-swap/src/state.rs
@@ -19,7 +19,7 @@ pub struct AtomicSwap {
 
 impl AtomicSwap {
     pub fn is_expired(&self, block: &BlockInfo) -> bool {
-        self.expires.is_expired(&block)
+        self.expires.is_expired(block)
     }
 }
 

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -18,7 +18,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw20 = { path = "../../packages/cw20", version = "0.11.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.0" }

--- a/contracts/cw20-bonding/Cargo.toml
+++ b/contracts/cw20-bonding/Cargo.toml
@@ -20,7 +20,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw20 = { path = "../../packages/cw20", version = "0.11.0" }
 cw20-base = { path = "../../contracts/cw20-base", version = "0.11.0", features = ["library"] }

--- a/contracts/cw20-bonding/src/contract.rs
+++ b/contracts/cw20-bonding/src/contract.rs
@@ -19,7 +19,7 @@ use crate::curves::DecimalPlaces;
 use crate::error::ContractError;
 use crate::msg::{CurveFn, CurveInfoResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state::{CurveState, CURVE_STATE, CURVE_TYPE};
-use utils::{must_pay, nonpayable};
+use cw_utils::{must_pay, nonpayable};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw20-bonding";
@@ -314,7 +314,7 @@ mod tests {
     use crate::msg::CurveType;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{coin, Decimal, OverflowError, OverflowOperation, StdError, SubMsg};
-    use utils::PaymentError;
+    use cw_utils::PaymentError;
 
     const DENOM: &str = "satoshi";
     const CREATOR: &str = "creator";

--- a/contracts/cw20-bonding/src/error.rs
+++ b/contracts/cw20-bonding/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::StdError;
+use cw_utils::PaymentError;
 use thiserror::Error;
-use utils::PaymentError;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {

--- a/contracts/cw20-escrow/Cargo.toml
+++ b/contracts/cw20-escrow/Cargo.toml
@@ -18,7 +18,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw20 = { path = "../../packages/cw20", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3" }

--- a/contracts/cw20-ics20/Cargo.toml
+++ b/contracts/cw20-ics20/Cargo.toml
@@ -18,7 +18,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw20 = { path = "../../packages/cw20", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3", features = ["stargate"] }

--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -16,7 +16,7 @@ use crate::msg::{
     TransferMsg,
 };
 use crate::state::{Config, CHANNEL_INFO, CHANNEL_STATE, CONFIG};
-use utils::{nonpayable, one_coin};
+use cw_utils::{nonpayable, one_coin};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw20-ics20";
@@ -191,7 +191,7 @@ mod test {
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{coin, coins, CosmosMsg, IbcMsg, StdError, Uint128};
 
-    use utils::PaymentError;
+    use cw_utils::PaymentError;
 
     #[test]
     fn setup_and_query() {

--- a/contracts/cw20-ics20/src/error.rs
+++ b/contracts/cw20-ics20/src/error.rs
@@ -3,7 +3,7 @@ use std::string::FromUtf8Error;
 use thiserror::Error;
 
 use cosmwasm_std::StdError;
-use utils::PaymentError;
+use cw_utils::PaymentError;
 
 /// Never is a placeholder to ensure we don't return any errors
 #[derive(Error, Debug)]

--- a/contracts/cw20-merkle-airdrop/Cargo.toml
+++ b/contracts/cw20-merkle-airdrop/Cargo.toml
@@ -19,7 +19,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw20 = { path = "../../packages/cw20", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3" }

--- a/contracts/cw20-staking/Cargo.toml
+++ b/contracts/cw20-staking/Cargo.toml
@@ -20,7 +20,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw20 = { path = "../../packages/cw20", version = "0.11.0" }
 cw-controllers = { path = "../../packages/controllers", version = "0.11.0" }

--- a/contracts/cw20-staking/src/contract.rs
+++ b/contracts/cw20-staking/src/contract.rs
@@ -439,7 +439,7 @@ mod tests {
         Validator,
     };
     use cw_controllers::Claim;
-    use utils::{Duration, DAY, HOUR, WEEK};
+    use cw_utils::{Duration, DAY, HOUR, WEEK};
 
     fn sample_validator(addr: &str) -> Validator {
         Validator {

--- a/contracts/cw20-staking/src/msg.rs
+++ b/contracts/cw20-staking/src/msg.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Binary, Coin, Decimal, Uint128};
 use cw20::Expiration;
 pub use cw_controllers::ClaimsResponse;
-use utils::Duration;
+use cw_utils::Duration;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {

--- a/contracts/cw20-staking/src/state.rs
+++ b/contracts/cw20-staking/src/state.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Addr, Decimal, Uint128};
 use cw_controllers::Claims;
 use cw_storage_plus::Item;
-use utils::Duration;
+use cw_utils::Duration;
 
 pub const CLAIMS: Claims = Claims::new("claims");
 

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -18,7 +18,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw3 = { path = "../../packages/cw3", version = "0.11.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.0" }

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -13,7 +13,7 @@ use cw3::{
     VoterDetail, VoterListResponse, VoterResponse,
 };
 use cw_storage_plus::Bound;
-use utils::{Expiration, ThresholdResponse};
+use cw_utils::{Expiration, ThresholdResponse};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -403,7 +403,7 @@ mod tests {
     use cosmwasm_std::{coin, from_binary, BankMsg, Decimal};
 
     use cw2::{get_contract_version, ContractVersion};
-    use utils::{Duration, Threshold};
+    use cw_utils::{Duration, Threshold};
 
     use crate::msg::Voter;
 
@@ -516,7 +516,7 @@ mod tests {
             instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap_err();
         assert_eq!(
             err,
-            ContractError::Threshold(utils::ThresholdError::InvalidThreshold {})
+            ContractError::Threshold(cw_utils::ThresholdError::InvalidThreshold {})
         );
 
         // Total weight less than required weight not allowed
@@ -525,7 +525,7 @@ mod tests {
             setup_test_case(deps.as_mut(), info.clone(), threshold, max_voting_period).unwrap_err();
         assert_eq!(
             err,
-            ContractError::Threshold(utils::ThresholdError::UnreachableWeight {})
+            ContractError::Threshold(cw_utils::ThresholdError::UnreachableWeight {})
         );
 
         // All valid

--- a/contracts/cw3-fixed-multisig/src/error.rs
+++ b/contracts/cw3-fixed-multisig/src/error.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::StdError;
-use utils::ThresholdError;
+use cw_utils::ThresholdError;
 
 use thiserror::Error;
 

--- a/contracts/cw3-fixed-multisig/src/integration_tests.rs
+++ b/contracts/cw3-fixed-multisig/src/integration_tests.rs
@@ -5,7 +5,7 @@ use cw20::{BalanceResponse, MinterResponse};
 use cw20_base::msg::QueryMsg;
 use cw3::Vote;
 use cw_multi_test::{App, Contract, ContractWrapper, Executor};
-use utils::{Duration, Threshold};
+use cw_utils::{Duration, Threshold};
 
 use crate::contract::{execute, instantiate, query};
 use crate::msg::{ExecuteMsg, InstantiateMsg, Voter};

--- a/contracts/cw3-fixed-multisig/src/msg.rs
+++ b/contracts/cw3-fixed-multisig/src/msg.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{CosmosMsg, Empty};
 use cw3::Vote;
-use utils::{Duration, Expiration, Threshold};
+use cw_utils::{Duration, Expiration, Threshold};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct InstantiateMsg {

--- a/contracts/cw3-fixed-multisig/src/state.rs
+++ b/contracts/cw3-fixed-multisig/src/state.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{Addr, BlockInfo, CosmosMsg, Decimal, Empty, StdResult, Storag
 
 use cw3::{Status, Vote};
 use cw_storage_plus::{Item, Map};
-use utils::{Duration, Expiration, Threshold};
+use cw_utils::{Duration, Expiration, Threshold};
 
 // we multiply by this when calculating needed_votes in order to round up properly
 // Note: `10u128.pow(9)` fails as "u128::pow` is not yet stable as a const fn"

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -18,7 +18,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw3 = { path = "../../packages/cw3", version = "0.11.0" }
 cw3-fixed-multisig = { path = "../cw3-fixed-multisig", version = "0.11.0", features = ["library"] }

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -15,7 +15,7 @@ use cw3::{
 use cw3_fixed_multisig::state::{next_id, Ballot, Proposal, Votes, BALLOTS, PROPOSALS};
 use cw4::{Cw4Contract, MemberChangedHookMsg, MemberDiff};
 use cw_storage_plus::Bound;
-use utils::{maybe_addr, Expiration, ThresholdResponse};
+use cw_utils::{maybe_addr, Expiration, ThresholdResponse};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -432,7 +432,7 @@ mod tests {
     use cw4::{Cw4ExecuteMsg, Member};
     use cw4_group::helpers::Cw4GroupContract;
     use cw_multi_test::{next_block, App, AppBuilder, Contract, ContractWrapper, Executor};
-    use utils::{Duration, Threshold};
+    use cw_utils::{Duration, Threshold};
 
     use super::*;
 
@@ -626,7 +626,7 @@ mod tests {
             )
             .unwrap_err();
         assert_eq!(
-            ContractError::Threshold(utils::ThresholdError::InvalidThreshold {}),
+            ContractError::Threshold(cw_utils::ThresholdError::InvalidThreshold {}),
             err.downcast().unwrap()
         );
 
@@ -647,7 +647,7 @@ mod tests {
             )
             .unwrap_err();
         assert_eq!(
-            ContractError::Threshold(utils::ThresholdError::UnreachableWeight {}),
+            ContractError::Threshold(cw_utils::ThresholdError::UnreachableWeight {}),
             err.downcast().unwrap()
         );
 

--- a/contracts/cw3-flex-multisig/src/error.rs
+++ b/contracts/cw3-flex-multisig/src/error.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::StdError;
-use utils::ThresholdError;
+use cw_utils::ThresholdError;
 
 use thiserror::Error;
 

--- a/contracts/cw3-flex-multisig/src/msg.rs
+++ b/contracts/cw3-flex-multisig/src/msg.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{CosmosMsg, Empty};
 use cw3::Vote;
 use cw4::MemberChangedHookMsg;
-use utils::{Duration, Expiration, Threshold};
+use cw_utils::{Duration, Expiration, Threshold};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct InstantiateMsg {

--- a/contracts/cw3-flex-multisig/src/state.rs
+++ b/contracts/cw3-flex-multisig/src/state.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use cw4::Cw4Contract;
 use cw_storage_plus::Item;
-use utils::{Duration, Threshold};
+use cw_utils::{Duration, Threshold};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Config {

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -26,7 +26,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw4 = { path = "../../packages/cw4", version = "0.11.0" }
 cw-controllers = { path = "../../packages/controllers", version = "0.11.0" }

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -10,7 +10,7 @@ use cw4::{
     TotalWeightResponse,
 };
 use cw_storage_plus::Bound;
-use utils::maybe_addr;
+use cw_utils::maybe_addr;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -26,7 +26,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw2 = { path = "../../packages/cw2", version = "0.11.0" }
 cw4 = { path = "../../packages/cw4", version = "0.11.0" }
 cw20 = { path = "../../packages/cw20", version = "0.11.0" }

--- a/contracts/cw4-stake/src/contract.rs
+++ b/contracts/cw4-stake/src/contract.rs
@@ -12,7 +12,7 @@ use cw4::{
     TotalWeightResponse,
 };
 use cw_storage_plus::Bound;
-use utils::{maybe_addr, NativeBalance};
+use cw_utils::{maybe_addr, NativeBalance};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, ReceiveMsg, StakedResponse};
@@ -364,7 +364,7 @@ mod tests {
     use cw20::Denom;
     use cw4::{member_key, TOTAL_KEY};
     use cw_controllers::{AdminError, Claim, HookError};
-    use utils::Duration;
+    use cw_utils::Duration;
 
     use crate::error::ContractError;
 

--- a/contracts/cw4-stake/src/msg.rs
+++ b/contracts/cw4-stake/src/msg.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use cw20::{Cw20ReceiveMsg, Denom};
 pub use cw_controllers::ClaimsResponse;
-use utils::Duration;
+use cw_utils::Duration;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct InstantiateMsg {

--- a/contracts/cw4-stake/src/state.rs
+++ b/contracts/cw4-stake/src/state.rs
@@ -6,7 +6,7 @@ use cw20::Denom;
 use cw4::TOTAL_KEY;
 use cw_controllers::{Admin, Claims, Hooks};
 use cw_storage_plus::{Item, Map, SnapshotMap, Strategy};
-use utils::Duration;
+use cw_utils::Duration;
 
 pub const CLAIMS: Claims = Claims::new("claims");
 

--- a/packages/controllers/Cargo.toml
+++ b/packages/controllers/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta3" }
-utils = { path = "../utils", version = "0.11.0" }
+cw-utils = { path = "../utils", version = "0.11.0" }
 cw-storage-plus = { path = "../storage-plus", version = "0.11.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/controllers/src/claim.rs
+++ b/packages/controllers/src/claim.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, BlockInfo, Deps, StdResult, Storage, Uint128};
 use cw_storage_plus::Map;
-use utils::Expiration;
+use cw_utils::Expiration;
 
 // TODO: pull into utils?
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/cw1155/Cargo.toml
+++ b/packages/cw1155/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw1155/src/event.rs
+++ b/packages/cw1155/src/event.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{attr, Response, Uint128};
-use utils::Event;
+use cw_utils::Event;
 
 /// Tracks token transfer/mint/burn actions
 pub struct TransferEvent<'a> {

--- a/packages/cw1155/src/lib.rs
+++ b/packages/cw1155/src/lib.rs
@@ -1,4 +1,4 @@
-pub use utils::Expiration;
+pub use cw_utils::Expiration;
 
 pub use crate::event::{ApproveAllEvent, MetadataEvent, TransferEvent};
 pub use crate::msg::{Cw1155ExecuteMsg, TokenId};

--- a/packages/cw1155/src/msg.rs
+++ b/packages/cw1155/src/msg.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Binary, Uint128};
-use utils::Expiration;
+use cw_utils::Expiration;
 
 pub type TokenId = String;
 

--- a/packages/cw1155/src/query.rs
+++ b/packages/cw1155/src/query.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::Uint128;
-use utils::Expiration;
+use cw_utils::Expiration;
 
 use crate::msg::TokenId;
 

--- a/packages/cw20/Cargo.toml
+++ b/packages/cw20/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw20/src/balance.rs
+++ b/packages/cw20/src/balance.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use utils::NativeBalance;
+use cw_utils::NativeBalance;
 
 use crate::Cw20CoinVerified;
 

--- a/packages/cw20/src/lib.rs
+++ b/packages/cw20/src/lib.rs
@@ -1,4 +1,4 @@
-pub use utils::Expiration;
+pub use cw_utils::Expiration;
 
 pub use crate::balance::Balance;
 pub use crate::coin::{Cw20Coin, Cw20CoinVerified};

--- a/packages/cw20/src/msg.rs
+++ b/packages/cw20/src/msg.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::logo::Logo;
 use cosmwasm_std::{Binary, Uint128};
-use utils::Expiration;
+use cw_utils::Expiration;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]

--- a/packages/cw20/src/query.rs
+++ b/packages/cw20/src/query.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Addr, Binary, Uint128};
 
 use crate::logo::LogoInfo;
-use utils::Expiration;
+use cw_utils::Expiration;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]

--- a/packages/cw3/Cargo.toml
+++ b/packages/cw3/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw3/examples/schema.rs
+++ b/packages/cw3/examples/schema.rs
@@ -7,7 +7,7 @@ use cw3::{
     Cw3ExecuteMsg, Cw3QueryMsg, ProposalListResponse, ProposalResponse, VoteListResponse,
     VoteResponse, VoterDetail, VoterListResponse, VoterResponse,
 };
-use utils::ThresholdResponse;
+use cw_utils::ThresholdResponse;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/packages/cw3/src/helpers.rs
+++ b/packages/cw3/src/helpers.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{to_binary, Addr, CosmosMsg, StdResult, WasmMsg};
 
 use crate::msg::{Cw3ExecuteMsg, Vote};
-use utils::Expiration;
+use cw_utils::Expiration;
 
 /// Cw3Contract is a wrapper around Addr that provides a lot of helpers
 /// for working with this.

--- a/packages/cw3/src/msg.rs
+++ b/packages/cw3/src/msg.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use cosmwasm_std::{CosmosMsg, Empty};
-use utils::Expiration;
+use cw_utils::Expiration;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]

--- a/packages/cw3/src/query.rs
+++ b/packages/cw3/src/query.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use cosmwasm_std::{CosmosMsg, Empty};
-use utils::{Expiration, ThresholdResponse};
+use cw_utils::{Expiration, ThresholdResponse};
 
 use crate::msg::Vote;
 

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -18,7 +18,7 @@ staking = ["cosmwasm-std/staking"]
 backtrace = ["anyhow/backtrace"]
 
 [dependencies]
-utils = { path = "../../packages/utils", version = "0.11.0" }
+cw-utils = { path = "../../packages/utils", version = "0.11.0" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.0"}
 cosmwasm-std = { version = "1.0.0-beta3", features = ["staking"] }
 cosmwasm-storage = { version = "1.0.0-beta3" }

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -2441,7 +2441,7 @@ mod test {
     mod protobuf_wrapped_data {
         use super::*;
         use crate::test_helpers::contracts::echo::EXECUTE_REPLY_BASE_ID;
-        use utils::parse_instantiate_response_data;
+        use cw_utils::parse_instantiate_response_data;
 
         #[test]
         fn instantiate_wrapped_properly() {

--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 };
 use cosmwasm_storage::{prefixed, prefixed_read};
 use cw_storage_plus::Map;
-use utils::NativeBalance;
+use cw_utils::NativeBalance;
 
 use crate::app::CosmosRouter;
 use crate::executor::AppResponse;

--- a/packages/multi-test/src/executor.rs
+++ b/packages/multi-test/src/executor.rs
@@ -4,9 +4,9 @@ use cosmwasm_std::{
     to_binary, Addr, Attribute, BankMsg, Binary, Coin, CosmosMsg, Event, SubMsgExecutionResponse,
     WasmMsg,
 };
+use cw_utils::{parse_execute_response_data, parse_instantiate_response_data};
 use schemars::JsonSchema;
 use serde::Serialize;
-use utils::{parse_execute_response_data, parse_instantiate_response_data};
 
 use anyhow::Result as AnyResult;
 

--- a/packages/multi-test/src/test_helpers/contracts/echo.rs
+++ b/packages/multi-test/src/test_helpers/contracts/echo.rs
@@ -13,8 +13,8 @@ use crate::{test_helpers::EmptyMsg, Contract, ContractWrapper};
 use schemars::JsonSchema;
 use std::fmt::Debug;
 
+use cw_utils::{parse_execute_response_data, parse_instantiate_response_data};
 use derivative::Derivative;
-use utils::{parse_execute_response_data, parse_instantiate_response_data};
 
 // Choosing a reply id less than ECHO_EXECUTE_BASE_ID indicates an Instantiate message reply by convention.
 // An Execute message reply otherwise.

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "utils"
+name = "cw-utils"
 version = "0.11.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"


### PR DESCRIPTION
Someone already claimed the `utils` crate on crates.io (not surprisingly).
Let's use our standard name spacing here.

(Needed so I can publish 0.11)