### PR TITLE
Access SnapshotMap Changelog

### DIFF
--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -17,7 +17,7 @@ use crate::{Bound, Prefixer, Strategy};
 /// What data is snapshotted depends on the Strategy.
 pub struct SnapshotMap<'a, K, T> {
     primary: Map<'a, K, T>,
-    snapshots: Snapshot<'a, K, T>,
+    pub snapshots: Snapshot<'a, K, T>,
 }
 
 impl<'a, K, T> SnapshotMap<'a, K, T> {


### PR DESCRIPTION
Interested in thoughts on implementing this. I am writing a staking rewards contract and i would like to be able to access the underlying change log from a snapshot map. This would make calculations of rewards much more efficient. Curious on thoughts here for best ways of implementing. Easiest approach is implemented below by simply making the snapshots field public on the SnapshotMap struct. 

A more refined approach that would guard against users modifying underlying state in unexpected ways would be to write a new range function that returns am iterator from the changelog field. IMO, This feels a little bit like reimplementing something that already exists in the underlying objects. 

Interested in thoughts, thanks! 