### PR TITLE
Implement HookMap

### DIFF
--- a/packages/controllers/src/lib.rs
+++ b/packages/controllers/src/lib.rs
@@ -4,4 +4,4 @@ mod hooks;
 
 pub use admin::{Admin, AdminError, AdminResponse};
 pub use claim::{Claim, Claims, ClaimsResponse};
-pub use hooks::{HookError, Hooks};
+pub use hooks::{HookError, Hooks, HookMap};


### PR DESCRIPTION
`HookMap` enables developers to set up multiplexed hooks. This opens up flexibility for the hook design.