### PR TITLE
cw-storage-plus: Expose keys::Key

### DIFF
--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -33,7 +33,7 @@ pub use keys::{I128Key, I16Key, I32Key, I64Key, I8Key};
 // TODO: Remove along with `IntKey`
 pub use int_key::CwIntKey;
 #[allow(deprecated)]
-pub use keys::{Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key, Key};
+pub use keys::{Key, Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
 pub use keys_old::IntKeyOld;
 pub use map::Map;
 pub use path::Path;

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -33,7 +33,7 @@ pub use keys::{I128Key, I16Key, I32Key, I64Key, I8Key};
 // TODO: Remove along with `IntKey`
 pub use int_key::CwIntKey;
 #[allow(deprecated)]
-pub use keys::{Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key};
+pub use keys::{Prefixer, PrimaryKey, U128Key, U16Key, U32Key, U64Key, U8Key, Key};
 pub use keys_old::IntKeyOld;
 pub use map::Map;
 pub use path::Path;


### PR DESCRIPTION
This is required for the external contracts that will implement custom `PrimaryKey`