### PR TITLE
Assert non-empty send/burn/mint in multitest bank module

### DIFF
--- a/packages/multi-test/src/bank.rs
+++ b/packages/multi-test/src/bank.rs
@@ -395,4 +395,79 @@ mod test {
             .unwrap_err();
         assert!(matches!(err.downcast().unwrap(), StdError::Overflow { .. }));
     }
+
+    #[test]
+    fn fail_on_zero_values() {
+        let api = MockApi::default();
+        let mut store = MockStorage::new();
+        let block = mock_env().block;
+        let router = MockRouter::default();
+
+        let owner = Addr::unchecked("owner");
+        let rcpt = Addr::unchecked("recipient");
+        let init_funds = vec![coin(5000, "atom"), coin(100, "eth")];
+
+        // set money
+        let bank = BankKeeper::new();
+        bank.init_balance(&mut store, &owner, init_funds).unwrap();
+
+        // can send normal amounts
+        let msg = BankMsg::Send {
+            to_address: rcpt.to_string(),
+            amount: coins(100, "atom"),
+        };
+        bank.execute(&api, &mut store, &router, &block, owner.clone(), msg)
+            .unwrap();
+
+        // fails send on no coins
+        let msg = BankMsg::Send {
+            to_address: rcpt.to_string(),
+            amount: vec![],
+        };
+        bank.execute(&api, &mut store, &router, &block, owner.clone(), msg)
+            .unwrap_err();
+
+        // fails send on 0 coins
+        let msg = BankMsg::Send {
+            to_address: rcpt.to_string(),
+            amount: coins(0, "atom"),
+        };
+        bank.execute(&api, &mut store, &router, &block, owner.clone(), msg)
+            .unwrap_err();
+
+        // fails burn on no coins
+        let msg = BankMsg::Burn { amount: vec![] };
+        bank.execute(&api, &mut store, &router, &block, owner.clone(), msg)
+            .unwrap_err();
+
+        // fails burn on 0 coins
+        let msg = BankMsg::Burn {
+            amount: coins(0, "atom"),
+        };
+        bank.execute(&api, &mut store, &router, &block, owner, msg)
+            .unwrap_err();
+
+        // can mint via sudo
+        let msg = BankSudo::Mint {
+            to_address: rcpt.to_string(),
+            amount: coins(4321, "atom"),
+        };
+        bank.sudo(&api, &mut store, &router, &block, msg).unwrap();
+
+        // mint fails with 0 tokens
+        let msg = BankSudo::Mint {
+            to_address: rcpt.to_string(),
+            amount: coins(0, "atom"),
+        };
+        bank.sudo(&api, &mut store, &router, &block, msg)
+            .unwrap_err();
+
+        // mint fails with no tokens
+        let msg = BankSudo::Mint {
+            to_address: rcpt.to_string(),
+            amount: vec![],
+        };
+        bank.sudo(&api, &mut store, &router, &block, msg)
+            .unwrap_err();
+    }
 }


### PR DESCRIPTION
Closes #610 

This matches the actual behaviour of wasmd, ensuring we catch such issues earlier.