### PR TITLE
Signed int key benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +84,24 @@ checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"
@@ -81,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +135,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
+]
 
 [[package]]
 name = "const-oid"
@@ -166,6 +221,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +326,28 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -240,6 +397,8 @@ name = "cw-storage-plus"
 version = "0.11.1"
 dependencies = [
  "cosmwasm-std",
+ "criterion",
+ "rand",
  "schemars",
  "serde",
 ]
@@ -633,6 +792,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,9 +833,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "k256"
@@ -676,16 +865,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -698,6 +911,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +937,12 @@ checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -721,6 +959,40 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
@@ -764,6 +1036,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.3",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,16 +1076,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schemars"
@@ -818,6 +1185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +1211,16 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "042ac496d97e5885149d34139bad1d617192770d7eb8f1866da2317ff4501853"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -869,7 +1252,7 @@ version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -930,6 +1313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +1339,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -968,6 +1370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1388,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1409,101 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -13,7 +13,18 @@ documentation = "https://docs.cosmwasm.com"
 default = ["iterator"]
 iterator = ["cosmwasm-std/iterator"]
 
+[lib]
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
+
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta3", default-features = false }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+
+[dev-dependencies]
+criterion = { version = "0.3", features = [ "html_reports" ] }
+
+[[bench]]
+name = "main"
+harness = false

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = [ "html_reports" ] }
+rand = "0.8"
 
 [[bench]]
 name = "main"

--- a/packages/storage-plus/benches/main.rs
+++ b/packages/storage-plus/benches/main.rs
@@ -1,12 +1,23 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use rand::Rng;
 use std::mem;
 use std::time::Duration;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
 use cw_storage_plus::CwIntKey;
 
 fn bench_signed_int_key(c: &mut Criterion) {
     let mut group = c.benchmark_group("Signed int keys");
 
-    let k: i32 = 0x42434445;
+    fn k() -> i32 {
+        // let k: i32 = 0x42434445;
+        // k
+        let r = rand::thread_rng().gen_range(i32::MIN..i32::MAX);
+        r
+    }
+    // For the asserts
+    let k_check = k();
+
     type Buf = [u8; mem::size_of::<i32>()];
 
     group.bench_function("i32 to_cw_bytes: xored (u32) + to_be_bytes", |b| {
@@ -16,11 +27,12 @@ fn bench_signed_int_key(c: &mut Criterion) {
         }
 
         assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
-        assert_eq!(to_cw_bytes(&k), i32::to_cw_bytes(&k));
-        assert_eq!(to_cw_bytes(&-k), i32::to_cw_bytes(&-k));
+        assert_eq!(to_cw_bytes(&k_check), i32::to_cw_bytes(&k_check));
+        assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
 
         b.iter(|| {
-            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&k()));
+            black_box(to_cw_bytes(&-k()));
         });
     });
 
@@ -31,11 +43,12 @@ fn bench_signed_int_key(c: &mut Criterion) {
         }
 
         assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
-        assert_eq!(to_cw_bytes(&k), i32::to_cw_bytes(&k));
-        assert_eq!(to_cw_bytes(&-k), i32::to_cw_bytes(&-k));
+        assert_eq!(to_cw_bytes(&k_check), i32::to_cw_bytes(&k_check));
+        assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
 
         b.iter(|| {
-            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&k()));
+            black_box(to_cw_bytes(&-k()));
         });
     });
 
@@ -48,11 +61,12 @@ fn bench_signed_int_key(c: &mut Criterion) {
         }
 
         assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
-        assert_eq!(to_cw_bytes(&k), i32::to_cw_bytes(&k));
-        assert_eq!(to_cw_bytes(&-k), i32::to_cw_bytes(&-k));
+        assert_eq!(to_cw_bytes(&k_check), i32::to_cw_bytes(&k_check));
+        assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
 
         b.iter(|| {
-            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&k()));
+            black_box(to_cw_bytes(&-k()));
         });
     });
 
@@ -67,11 +81,12 @@ fn bench_signed_int_key(c: &mut Criterion) {
         }
 
         assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
-        assert_eq!(to_cw_bytes(&k), i32::to_cw_bytes(&k));
-        assert_eq!(to_cw_bytes(&-k), i32::to_cw_bytes(&-k));
+        assert_eq!(to_cw_bytes(&k_check), i32::to_cw_bytes(&k_check));
+        assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
 
         b.iter(|| {
-            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&k()));
+            black_box(to_cw_bytes(&-k()));
         });
     });
 
@@ -81,8 +96,8 @@ fn bench_signed_int_key(c: &mut Criterion) {
 fn make_config() -> Criterion {
     Criterion::default()
         .without_plots()
-        .measurement_time(Duration::new(10, 0))
-        .sample_size(12)
+        .measurement_time(Duration::new(5, 0))
+        .sample_size(10)
         .configure_from_args()
 }
 

--- a/packages/storage-plus/benches/main.rs
+++ b/packages/storage-plus/benches/main.rs
@@ -31,8 +31,9 @@ fn bench_signed_int_key(c: &mut Criterion) {
         assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
 
         b.iter(|| {
-            black_box(to_cw_bytes(&k()));
-            black_box(to_cw_bytes(&-k()));
+            let k = k();
+            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&-k));
         });
     });
 
@@ -47,8 +48,9 @@ fn bench_signed_int_key(c: &mut Criterion) {
         assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
 
         b.iter(|| {
-            black_box(to_cw_bytes(&k()));
-            black_box(to_cw_bytes(&-k()));
+            let k = k();
+            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&-k));
         });
     });
 
@@ -65,8 +67,9 @@ fn bench_signed_int_key(c: &mut Criterion) {
         assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
 
         b.iter(|| {
-            black_box(to_cw_bytes(&k()));
-            black_box(to_cw_bytes(&-k()));
+            let k = k();
+            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&-k));
         });
     });
 
@@ -85,8 +88,42 @@ fn bench_signed_int_key(c: &mut Criterion) {
         assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
 
         b.iter(|| {
-            black_box(to_cw_bytes(&k()));
-            black_box(to_cw_bytes(&-k()));
+            let k = k();
+            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&-k));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_unsigned_int_key(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Unsigned int keys");
+
+    fn k() -> u32 {
+        // let k: u32 = 0x42434445;
+        // k
+        let r = rand::thread_rng().gen_range(u32::MIN..u32::MAX);
+        r
+    }
+    // For the asserts
+    let k_check = k();
+
+    type Buf = [u8; mem::size_of::<u32>()];
+
+    group.bench_function("u32 to_cw_bytes", |b| {
+        #[inline]
+        fn to_cw_bytes(value: &u32) -> Buf {
+            value.to_be_bytes()
+        }
+
+        assert_eq!(to_cw_bytes(&0), u32::to_cw_bytes(&0));
+        assert_eq!(to_cw_bytes(&k_check), u32::to_cw_bytes(&k_check));
+
+        b.iter(|| {
+            let k = k();
+            black_box(to_cw_bytes(&k));
+            black_box(to_cw_bytes(&k)); // twice for comparability
         });
     });
 
@@ -106,4 +143,9 @@ criterion_group!(
     config = make_config();
     targets = bench_signed_int_key
 );
-criterion_main!(signed_int_key);
+criterion_group!(
+    name = unsigned_int_key;
+    config = make_config();
+    targets = bench_unsigned_int_key
+);
+criterion_main!(signed_int_key, unsigned_int_key);

--- a/packages/storage-plus/benches/main.rs
+++ b/packages/storage-plus/benches/main.rs
@@ -1,0 +1,94 @@
+use std::mem;
+use std::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use cw_storage_plus::CwIntKey;
+
+fn bench_signed_int_key(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Signed int keys");
+
+    let k: i32 = 0x42434445;
+    type Buf = [u8; mem::size_of::<i32>()];
+
+    group.bench_function("i32 to_cw_bytes: xored (u32) + to_be_bytes", |b| {
+        #[inline]
+        fn to_cw_bytes(value: &i32) -> Buf {
+            (*value as u32 ^ i32::MIN as u32).to_be_bytes()
+        }
+
+        assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
+        assert_eq!(to_cw_bytes(&k), i32::to_cw_bytes(&k));
+        assert_eq!(to_cw_bytes(&-k), i32::to_cw_bytes(&-k));
+
+        b.iter(|| {
+            black_box(to_cw_bytes(&k));
+        });
+    });
+
+    group.bench_function("i32 to_cw_bytes: xored (u128) + to_be_bytes", |b| {
+        #[inline]
+        fn to_cw_bytes(value: &i32) -> Buf {
+            ((*value as u128 ^ i32::MIN as u128) as i32).to_be_bytes()
+        }
+
+        assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
+        assert_eq!(to_cw_bytes(&k), i32::to_cw_bytes(&k));
+        assert_eq!(to_cw_bytes(&-k), i32::to_cw_bytes(&-k));
+
+        b.iter(|| {
+            black_box(to_cw_bytes(&k));
+        });
+    });
+
+    group.bench_function("i32 to_cw_bytes: mut to_be_bytes + xor", |b| {
+        #[inline]
+        fn to_cw_bytes(value: &i32) -> Buf {
+            let mut buf = i32::to_be_bytes(*value);
+            buf[0] ^= 0x80;
+            buf
+        }
+
+        assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
+        assert_eq!(to_cw_bytes(&k), i32::to_cw_bytes(&k));
+        assert_eq!(to_cw_bytes(&-k), i32::to_cw_bytes(&-k));
+
+        b.iter(|| {
+            black_box(to_cw_bytes(&k));
+        });
+    });
+
+    group.bench_function("i32 to_cw_bytes: branching plus / minus", |b| {
+        #[inline]
+        fn to_cw_bytes(value: &i32) -> Buf {
+            if value >= &0i32 {
+                (*value as u32 - i32::MIN as u32).to_be_bytes()
+            } else {
+                (*value as u32 + i32::MIN as u32).to_be_bytes()
+            }
+        }
+
+        assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
+        assert_eq!(to_cw_bytes(&k), i32::to_cw_bytes(&k));
+        assert_eq!(to_cw_bytes(&-k), i32::to_cw_bytes(&-k));
+
+        b.iter(|| {
+            black_box(to_cw_bytes(&k));
+        });
+    });
+
+    group.finish();
+}
+
+fn make_config() -> Criterion {
+    Criterion::default()
+        .without_plots()
+        .measurement_time(Duration::new(10, 0))
+        .sample_size(12)
+        .configure_from_args()
+}
+
+criterion_group!(
+    name = signed_int_key;
+    config = make_config();
+    targets = bench_signed_int_key
+);
+criterion_main!(signed_int_key);


### PR DESCRIPTION
Just an exercise to confirm the different methods of doing `to-cw-bytes` are not incurring a significant performance loss.

Not sure this needs to be merged. Just but published it for reference.