### PR TITLE
Publish snapshot map changelog

### DIFF
--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -9,8 +9,8 @@ use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::{Prefixer, PrimaryKey};
 use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
-use crate::snapshot::SnapshotMap;
-use crate::{IndexList, Path, Strategy};
+use crate::snapshot::{ChangeSet, SnapshotMap};
+use crate::{IndexList, Map, Path, Strategy};
 
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
 pub struct IndexedSnapshotMap<'a, K, T, I> {
@@ -55,6 +55,10 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
             primary: SnapshotMap::new(pk_namespace, checkpoints, changelog, strategy),
             idx: indexes,
         }
+    }
+
+    pub fn changelog(&self) -> &Map<'a, (K, u64), ChangeSet<T>> {
+        &self.primary.changelog()
     }
 }
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -31,6 +31,10 @@ impl<'a, K, T> Map<'a, K, T> {
             key_type: PhantomData,
         }
     }
+
+    pub fn namespace(&self) -> &'a [u8] {
+        self.namespace
+    }
 }
 
 impl<'a, K, T> Map<'a, K, T>
@@ -38,10 +42,6 @@ where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
 {
-    pub fn namespace(&self) -> &'a [u8] {
-        self.namespace
-    }
-
     pub fn key(&self, k: K) -> Path<T> {
         Path::new(
             self.namespace,

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -5,13 +5,13 @@ use cosmwasm_std::{StdError, StdResult, Storage};
 
 use crate::snapshot::{ChangeSet, Snapshot};
 use crate::{Item, Map, Strategy};
-use std::str::from_utf8_unchecked;
 
 /// Item that maintains a snapshot of one or more checkpoints.
 /// We can query historical data as well as current state.
 /// What data is snapshotted depends on the Strategy.
 pub struct SnapshotItem<'a, T> {
     primary: Item<'a, T>,
+    changelog_namespace: &'a str,
     snapshots: Snapshot<'a, (), T>,
 }
 
@@ -35,6 +35,7 @@ impl<'a, T> SnapshotItem<'a, T> {
     ) -> Self {
         SnapshotItem {
             primary: Item::new(storage_key),
+            changelog_namespace: changelog,
             snapshots: Snapshot::new(checkpoints, changelog, strategy),
         }
     }
@@ -49,7 +50,7 @@ impl<'a, T> SnapshotItem<'a, T> {
 
     pub fn changelog(&self) -> Map<u64, ChangeSet<T>> {
         // Build and return a compatible Map with the proper key type
-        Map::new(unsafe { from_utf8_unchecked(self.snapshots.changelog.namespace()) })
+        Map::new(self.changelog_namespace)
     }
 }
 

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -464,6 +464,70 @@ mod tests {
 
     #[test]
     #[cfg(feature = "iterator")]
+    fn changelog_range_works() {
+        use cosmwasm_std::Order;
+
+        let mut store = MockStorage::new();
+
+        // simple data for testing
+        EVERY.save(&mut store, "A", &5, 1).unwrap();
+        EVERY.save(&mut store, "B", &7, 2).unwrap();
+        EVERY
+            .update(&mut store, "A", 3, |_| -> StdResult<u64> { Ok(8) })
+            .unwrap();
+        EVERY.remove(&mut store, "B", 4).unwrap();
+
+        // let's try to iterate over the changelog
+        let all: StdResult<Vec<_>> = EVERY
+            .changelog()
+            .range(&store, None, None, Order::Ascending)
+            .collect();
+        let all = all.unwrap();
+        assert_eq!(4, all.len());
+        assert_eq!(
+            all,
+            vec![
+                (("A".into(), 1), ChangeSet { old: None }),
+                (("A".into(), 3), ChangeSet { old: Some(5) }),
+                (("B".into(), 2), ChangeSet { old: None }),
+                (("B".into(), 4), ChangeSet { old: Some(7) })
+            ]
+        );
+
+        // let's try to iterate over a changelog key/prefix
+        let all: StdResult<Vec<_>> = EVERY
+            .changelog()
+            .prefix("B")
+            .range(&store, None, None, Order::Ascending)
+            .collect();
+        let all = all.unwrap();
+        assert_eq!(2, all.len());
+        assert_eq!(
+            all,
+            vec![
+                (2, ChangeSet { old: None }),
+                (4, ChangeSet { old: Some(7) })
+            ]
+        );
+
+        // let's try to iterate over a changelog prefixed range
+        let all: StdResult<Vec<_>> = EVERY
+            .changelog()
+            .prefix("A")
+            .range(
+                &store,
+                Some(Bound::inclusive_int(3u64)),
+                None,
+                Order::Ascending,
+            )
+            .collect();
+        let all = all.unwrap();
+        assert_eq!(1, all.len());
+        assert_eq!(all, vec![(3, ChangeSet { old: Some(5) }),]);
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
     fn range_simple_string_key() {
         use cosmwasm_std::Order;
 

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -9,7 +9,7 @@ use crate::keys::PrimaryKey;
 use crate::map::Map;
 use crate::path::Path;
 use crate::prefix::{namespaced_prefix_range, Prefix, PrefixBound};
-use crate::snapshot::Snapshot;
+use crate::snapshot::{ChangeSet, Snapshot};
 use crate::{Bound, Prefixer, Strategy};
 
 /// Map that maintains a snapshots of one or more checkpoints.
@@ -43,6 +43,10 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
             primary: Map::new(pk),
             snapshots: Snapshot::new(checkpoints, changelog, strategy),
         }
+    }
+
+    pub fn changelog(&self) -> &Map<'a, (K, u64), ChangeSet<T>> {
+        &self.snapshots.changelog
     }
 }
 

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -172,7 +172,7 @@ pub enum Strategy {
 }
 
 #[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
-pub(crate) struct ChangeSet<T> {
+pub struct ChangeSet<T> {
     pub old: Option<T>,
 }
 


### PR DESCRIPTION
Related to #600 and #621.

To allow prefixing / iteration over the changelog entries.