### PR TITLE
Type safe bounds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ workflows:
 jobs:
   contract_cw1_subkeys:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw1-subkeys
     steps:
       - checkout:
@@ -62,7 +62,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw1-subkeys-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw1-subkeys-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -75,11 +75,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw1-subkeys-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw1-subkeys-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw1_whitelist:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw1-whitelist
     steps:
       - checkout:
@@ -89,7 +89,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw1-whitelist-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw1-whitelist-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -102,11 +102,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw1-whitelist-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw1-whitelist-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw1_whitelist_ng:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw1-whitelist-ng
     steps:
       - checkout:
@@ -116,7 +116,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw1-whitelist-ng-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw1-whitelist-ng-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -129,11 +129,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw1-whitelist-ng-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw1-whitelist-ng-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw3_fixed_multisig:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw3-fixed-multisig
     steps:
       - checkout:
@@ -143,7 +143,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw3-fixed-multisig-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw3-fixed-multisig-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -156,11 +156,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw3-fixed-multisig-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw3-fixed-multisig-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw3_flex_multisig:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw3-flex-multisig
     steps:
       - checkout:
@@ -170,7 +170,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw3-flex-multisig-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw3-flex-multisig-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -183,11 +183,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw3-flex-multisig-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw3-flex-multisig-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw4_group:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw4-group
     steps:
       - checkout:
@@ -197,7 +197,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw4-group-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw4-group-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -210,11 +210,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw4-group-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw4-group-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw4_stake:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw4-stake
     steps:
       - checkout:
@@ -224,7 +224,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw4-stake-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw4-stake-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -237,11 +237,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw4-stake-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw4-stake-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw20_base:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw20-base
     steps:
       - checkout:
@@ -251,7 +251,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw20-base-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw20-base-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -264,11 +264,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw20-base-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw20-base-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw20_ics20:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw20-ics20
     steps:
       - checkout:
@@ -278,7 +278,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw20-ics20-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw20-ics20-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -291,11 +291,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw20-ics20-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw20-ics20-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw1155_base:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/contracts/cw1155-base
     steps:
       - checkout:
@@ -305,7 +305,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw1155-base-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw1155-base-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -318,11 +318,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw1155-base-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw1155-base-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_controllers:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/controllers
     steps:
       - checkout:
@@ -332,7 +332,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-controllers:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-controllers:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -343,11 +343,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-controllers:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-controllers:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_utils:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/utils
     steps:
       - checkout:
@@ -357,7 +357,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-utils:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-utils:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -368,11 +368,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-utils:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-utils:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw1:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/cw1
     steps:
       - checkout:
@@ -382,7 +382,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw1:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw1:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -396,11 +396,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw1:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw1:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw2:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/cw2
     steps:
       - checkout:
@@ -410,7 +410,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw2:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw2:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -422,11 +422,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw2:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw2:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw3:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/cw3
     steps:
       - checkout:
@@ -436,7 +436,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw3:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw3:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -450,11 +450,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw3:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw3:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw4:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/cw4
     steps:
       - checkout:
@@ -464,7 +464,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw4:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw4:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -478,11 +478,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw4:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw4:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw20:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/cw20
     steps:
       - checkout:
@@ -492,7 +492,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw20:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw20:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -506,11 +506,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw20:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw20:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw1155:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/cw1155
     steps:
       - checkout:
@@ -520,7 +520,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw1155:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw1155:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -534,11 +534,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw1155:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw1155:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     steps:
       - checkout
       - run:
@@ -546,7 +546,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.54.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.58.1-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -565,7 +565,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.54.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.58.1-{{ checksum "Cargo.lock" }}
 
   # This runs one time on the top level to ensure all contracts compile properly into wasm.
   # We don't run the wasm build per contract build, and then reuse a lot of the same dependencies, so this speeds up CI time
@@ -573,7 +573,7 @@ jobs:
   # We also sanity-check the resultant wasm files.
   wasm-build:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     steps:
       - checkout:
           path: ~/project
@@ -582,7 +582,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-wasm-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-wasm-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -602,7 +602,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-wasm-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-wasm-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Check wasm contracts
           command: |
@@ -614,7 +614,7 @@ jobs:
 
   package_multi_test:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/multi-test
     steps:
       - checkout:
@@ -624,7 +624,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-multi-test:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-multi-test:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -638,11 +638,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-multi-test:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-multi-test:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   package_storage_plus:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project/packages/storage-plus
     steps:
       - checkout:
@@ -652,7 +652,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-storage-plus:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-storage-plus:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target (no iterator)
           command: cargo build --locked --no-default-features
@@ -669,11 +669,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-storage-plus:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-storage-plus:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   benchmarking:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     environment:
       RUST_BACKTRACE: 1
     steps:
@@ -684,7 +684,7 @@ jobs:
           command: rustc --version && cargo --version
       - restore_cache:
           keys:
-            - cargocache-v2-benchmarking-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-benchmarking-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Run storage-plus benchmarks
           working_directory: ~/project/packages/storage-plus
@@ -693,7 +693,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-benchmarking-rust:1.54.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-benchmarking-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
 
   # This job roughly follows the instructions from https://circleci.com/blog/publishing-to-github-releases-via-circleci/
   build_and_upload_contracts:
@@ -743,7 +743,7 @@ jobs:
 
   build_and_upload_schemas:
     docker:
-      - image: rust:1.54.0
+      - image: rust:1.58.1
     working_directory: ~/project
     steps:
       - checkout:

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -18,7 +18,7 @@ use cw1_whitelist::{
     state::ADMIN_LIST,
 };
 use cw2::{get_contract_version, set_contract_version};
-use cw_storage_plus::RawBound;
+use cw_storage_plus::Bound;
 use cw_utils::Expiration;
 use semver::Version;
 
@@ -407,7 +407,7 @@ pub fn query_all_allowances(
 ) -> StdResult<AllAllowancesResponse> {
     let limit = calc_limit(limit);
     // we use raw addresses here....
-    let start = start_after.map(RawBound::exclusive);
+    let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
 
     let allowances = ALLOWANCES
         .range(deps.storage, start, None, Order::Ascending)
@@ -437,7 +437,7 @@ pub fn query_all_permissions(
     limit: Option<u32>,
 ) -> StdResult<AllPermissionsResponse> {
     let limit = calc_limit(limit);
-    let start = start_after.map(RawBound::exclusive);
+    let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
 
     let permissions = PERMISSIONS
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -18,7 +18,7 @@ use cw1_whitelist::{
     state::ADMIN_LIST,
 };
 use cw2::{get_contract_version, set_contract_version};
-use cw_storage_plus::Bound;
+use cw_storage_plus::RawBound;
 use cw_utils::Expiration;
 use semver::Version;
 
@@ -407,7 +407,7 @@ pub fn query_all_allowances(
 ) -> StdResult<AllAllowancesResponse> {
     let limit = calc_limit(limit);
     // we use raw addresses here....
-    let start = start_after.map(Bound::exclusive);
+    let start = start_after.map(RawBound::exclusive);
 
     let allowances = ALLOWANCES
         .range(deps.storage, start, None, Order::Ascending)
@@ -437,7 +437,7 @@ pub fn query_all_permissions(
     limit: Option<u32>,
 ) -> StdResult<AllPermissionsResponse> {
     let limit = calc_limit(limit);
-    let start = start_after.map(Bound::exclusive);
+    let start = start_after.map(RawBound::exclusive);
 
     let permissions = PERMISSIONS
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::{
     to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult, SubMsg,
     Uint128,
 };
-use cw_storage_plus::RawBound;
+use cw_storage_plus::Bound;
 
 use cw1155::{
     ApproveAllEvent, ApprovedForAllResponse, BalanceResponse, BatchBalanceResponse,
@@ -494,7 +494,7 @@ fn query_all_approvals(
     limit: Option<u32>,
 ) -> StdResult<ApprovedForAllResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(|addr| RawBound::exclusive(addr.as_ref()));
+    let start = start_after.as_ref().map(Bound::exclusive);
 
     let operators = APPROVES
         .prefix(&owner)
@@ -513,7 +513,7 @@ fn query_tokens(
     limit: Option<u32>,
 ) -> StdResult<TokensResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(RawBound::exclusive);
+    let start = start_after.as_ref().map(|s| Bound::exclusive(s.as_str()));
 
     let tokens = BALANCES
         .prefix(&owner)
@@ -529,7 +529,7 @@ fn query_all_tokens(
     limit: Option<u32>,
 ) -> StdResult<TokensResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(RawBound::exclusive);
+    let start = start_after.as_ref().map(|s| Bound::exclusive(s.as_str()));
     let tokens = TOKENS
         .keys(deps.storage, start, None, Order::Ascending)
         .take(limit)

--- a/contracts/cw1155-base/src/contract.rs
+++ b/contracts/cw1155-base/src/contract.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::{
     to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult, SubMsg,
     Uint128,
 };
-use cw_storage_plus::Bound;
+use cw_storage_plus::RawBound;
 
 use cw1155::{
     ApproveAllEvent, ApprovedForAllResponse, BalanceResponse, BatchBalanceResponse,
@@ -494,7 +494,7 @@ fn query_all_approvals(
     limit: Option<u32>,
 ) -> StdResult<ApprovedForAllResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(|addr| Bound::exclusive(addr.as_ref()));
+    let start = start_after.map(|addr| RawBound::exclusive(addr.as_ref()));
 
     let operators = APPROVES
         .prefix(&owner)
@@ -513,7 +513,7 @@ fn query_tokens(
     limit: Option<u32>,
 ) -> StdResult<TokensResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(Bound::exclusive);
+    let start = start_after.map(RawBound::exclusive);
 
     let tokens = BALANCES
         .prefix(&owner)
@@ -529,7 +529,7 @@ fn query_all_tokens(
     limit: Option<u32>,
 ) -> StdResult<TokensResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(Bound::exclusive);
+    let start = start_after.map(RawBound::exclusive);
     let tokens = TOKENS
         .keys(deps.storage, start, None, Order::Ascending)
         .take(limit)

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Deps, Order, StdResult};
 use cw20::{AllAccountsResponse, AllAllowancesResponse, AllowanceInfo};
 
 use crate::state::{ALLOWANCES, BALANCES};
-use cw_storage_plus::Bound;
+use cw_storage_plus::RawBound;
 
 // settings for pagination
 const MAX_LIMIT: u32 = 30;
@@ -16,7 +16,7 @@ pub fn query_all_allowances(
 ) -> StdResult<AllAllowancesResponse> {
     let owner_addr = deps.api.addr_validate(&owner)?;
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(Bound::exclusive);
+    let start = start_after.map(RawBound::exclusive);
 
     let allowances = ALLOWANCES
         .prefix(&owner_addr)
@@ -39,7 +39,7 @@ pub fn query_all_accounts(
     limit: Option<u32>,
 ) -> StdResult<AllAccountsResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(Bound::exclusive);
+    let start = start_after.map(RawBound::exclusive);
 
     let accounts = BALANCES
         .keys(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Deps, Order, StdResult};
 use cw20::{AllAccountsResponse, AllAllowancesResponse, AllowanceInfo};
 
 use crate::state::{ALLOWANCES, BALANCES};
-use cw_storage_plus::RawBound;
+use cw_storage_plus::Bound;
 
 // settings for pagination
 const MAX_LIMIT: u32 = 30;
@@ -16,7 +16,7 @@ pub fn query_all_allowances(
 ) -> StdResult<AllAllowancesResponse> {
     let owner_addr = deps.api.addr_validate(&owner)?;
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(RawBound::exclusive);
+    let start = start_after.map(|s| Bound::ExclusiveRaw(s.as_bytes().into()));
 
     let allowances = ALLOWANCES
         .prefix(&owner_addr)
@@ -39,7 +39,7 @@ pub fn query_all_accounts(
     limit: Option<u32>,
 ) -> StdResult<AllAccountsResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(RawBound::exclusive);
+    let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
 
     let accounts = BALANCES
         .keys(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -17,7 +17,7 @@ use crate::msg::{
     ListAllowedResponse, ListChannelsResponse, MigrateMsg, PortResponse, QueryMsg, TransferMsg,
 };
 use crate::state::{AllowInfo, Config, ALLOW_LIST, CHANNEL_INFO, CHANNEL_STATE, CONFIG};
-use cw_utils::{nonpayable, one_coin};
+use cw_utils::{maybe_addr, nonpayable, one_coin};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw20-ics20";
@@ -284,10 +284,8 @@ fn list_allowed(
     limit: Option<u32>,
 ) -> StdResult<ListAllowedResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = match start_after {
-        Some(x) => Some(Bound::exclusive(deps.api.addr_validate(&x)?.into_string())),
-        None => None,
-    };
+    let addr = maybe_addr(deps.api, start_after)?;
+    let start = addr.as_ref().map(Bound::exclusive);
 
     let allow = ALLOW_LIST
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -12,7 +12,7 @@ use cw3::{
     ProposalListResponse, ProposalResponse, Status, Vote, VoteInfo, VoteListResponse, VoteResponse,
     VoterDetail, VoterListResponse, VoterResponse,
 };
-use cw_storage_plus::Bound;
+use cw_storage_plus::RawBound;
 use cw_utils::{Expiration, ThresholdResponse};
 
 use crate::error::ContractError;
@@ -287,7 +287,7 @@ fn list_proposals(
     limit: Option<u32>,
 ) -> StdResult<ProposalListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(Bound::exclusive_int);
+    let start = start_after.map(RawBound::exclusive_int);
     let proposals = PROPOSALS
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -304,7 +304,7 @@ fn reverse_proposals(
     limit: Option<u32>,
 ) -> StdResult<ProposalListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let end = start_before.map(Bound::exclusive_int);
+    let end = start_before.map(RawBound::exclusive_int);
     let props: StdResult<Vec<_>> = PROPOSALS
         .range(deps.storage, None, end, Order::Descending)
         .take(limit)
@@ -351,7 +351,7 @@ fn list_votes(
     limit: Option<u32>,
 ) -> StdResult<VoteListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(Bound::exclusive);
+    let start = start_after.map(RawBound::exclusive);
 
     let votes = BALLOTS
         .prefix(proposal_id)
@@ -381,7 +381,7 @@ fn list_voters(
     limit: Option<u32>,
 ) -> StdResult<VoterListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(Bound::exclusive);
+    let start = start_after.map(RawBound::exclusive);
 
     let voters = VOTERS
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw3-fixed-multisig/src/contract.rs
+++ b/contracts/cw3-fixed-multisig/src/contract.rs
@@ -12,7 +12,7 @@ use cw3::{
     ProposalListResponse, ProposalResponse, Status, Vote, VoteInfo, VoteListResponse, VoteResponse,
     VoterDetail, VoterListResponse, VoterResponse,
 };
-use cw_storage_plus::RawBound;
+use cw_storage_plus::Bound;
 use cw_utils::{Expiration, ThresholdResponse};
 
 use crate::error::ContractError;
@@ -287,7 +287,7 @@ fn list_proposals(
     limit: Option<u32>,
 ) -> StdResult<ProposalListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(RawBound::exclusive_int);
+    let start = start_after.map(Bound::exclusive);
     let proposals = PROPOSALS
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -304,7 +304,7 @@ fn reverse_proposals(
     limit: Option<u32>,
 ) -> StdResult<ProposalListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let end = start_before.map(RawBound::exclusive_int);
+    let end = start_before.map(Bound::exclusive);
     let props: StdResult<Vec<_>> = PROPOSALS
         .range(deps.storage, None, end, Order::Descending)
         .take(limit)
@@ -351,7 +351,7 @@ fn list_votes(
     limit: Option<u32>,
 ) -> StdResult<VoteListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(RawBound::exclusive);
+    let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
 
     let votes = BALLOTS
         .prefix(proposal_id)
@@ -381,7 +381,7 @@ fn list_voters(
     limit: Option<u32>,
 ) -> StdResult<VoterListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(RawBound::exclusive);
+    let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
 
     let voters = VOTERS
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -14,7 +14,7 @@ use cw3::{
 };
 use cw3_fixed_multisig::state::{next_id, Ballot, Proposal, Votes, BALLOTS, PROPOSALS};
 use cw4::{Cw4Contract, MemberChangedHookMsg, MemberDiff};
-use cw_storage_plus::Bound;
+use cw_storage_plus::RawBound;
 use cw_utils::{maybe_addr, Expiration, ThresholdResponse};
 
 use crate::error::ContractError;
@@ -315,7 +315,7 @@ fn list_proposals(
     limit: Option<u32>,
 ) -> StdResult<ProposalListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(Bound::exclusive_int);
+    let start = start_after.map(RawBound::exclusive_int);
     let proposals = PROPOSALS
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -332,7 +332,7 @@ fn reverse_proposals(
     limit: Option<u32>,
 ) -> StdResult<ProposalListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let end = start_before.map(Bound::exclusive_int);
+    let end = start_before.map(RawBound::exclusive_int);
     let props: StdResult<Vec<_>> = PROPOSALS
         .range(deps.storage, None, end, Order::Descending)
         .take(limit)
@@ -380,7 +380,7 @@ fn list_votes(
 ) -> StdResult<VoteListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
+    let start = addr.map(|addr| RawBound::exclusive(addr.as_ref()));
 
     let votes = BALLOTS
         .prefix(proposal_id)

--- a/contracts/cw3-flex-multisig/src/contract.rs
+++ b/contracts/cw3-flex-multisig/src/contract.rs
@@ -14,7 +14,7 @@ use cw3::{
 };
 use cw3_fixed_multisig::state::{next_id, Ballot, Proposal, Votes, BALLOTS, PROPOSALS};
 use cw4::{Cw4Contract, MemberChangedHookMsg, MemberDiff};
-use cw_storage_plus::RawBound;
+use cw_storage_plus::Bound;
 use cw_utils::{maybe_addr, Expiration, ThresholdResponse};
 
 use crate::error::ContractError;
@@ -315,7 +315,7 @@ fn list_proposals(
     limit: Option<u32>,
 ) -> StdResult<ProposalListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(RawBound::exclusive_int);
+    let start = start_after.map(Bound::exclusive);
     let proposals = PROPOSALS
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -332,7 +332,7 @@ fn reverse_proposals(
     limit: Option<u32>,
 ) -> StdResult<ProposalListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let end = start_before.map(RawBound::exclusive_int);
+    let end = start_before.map(Bound::exclusive);
     let props: StdResult<Vec<_>> = PROPOSALS
         .range(deps.storage, None, end, Order::Descending)
         .take(limit)
@@ -380,7 +380,7 @@ fn list_votes(
 ) -> StdResult<VoteListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| RawBound::exclusive(addr.as_ref()));
+    let start = addr.as_ref().map(Bound::exclusive);
 
     let votes = BALLOTS
         .prefix(proposal_id)

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -9,7 +9,7 @@ use cw4::{
     Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
     TotalWeightResponse,
 };
-use cw_storage_plus::RawBound;
+use cw_storage_plus::Bound;
 use cw_utils::maybe_addr;
 
 use crate::error::ContractError;
@@ -190,7 +190,7 @@ fn list_members(
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| RawBound::exclusive(addr.to_string()));
+    let start = addr.as_ref().map(Bound::exclusive);
 
     let members = MEMBERS
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw4-group/src/contract.rs
+++ b/contracts/cw4-group/src/contract.rs
@@ -9,7 +9,7 @@ use cw4::{
     Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
     TotalWeightResponse,
 };
-use cw_storage_plus::Bound;
+use cw_storage_plus::RawBound;
 use cw_utils::maybe_addr;
 
 use crate::error::ContractError;
@@ -190,7 +190,7 @@ fn list_members(
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| Bound::exclusive(addr.to_string()));
+    let start = addr.map(|addr| RawBound::exclusive(addr.to_string()));
 
     let members = MEMBERS
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw4-stake/src/contract.rs
+++ b/contracts/cw4-stake/src/contract.rs
@@ -11,7 +11,7 @@ use cw4::{
     Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
     TotalWeightResponse,
 };
-use cw_storage_plus::RawBound;
+use cw_storage_plus::Bound;
 use cw_utils::{maybe_addr, NativeBalance};
 
 use crate::error::ContractError;
@@ -339,7 +339,7 @@ fn list_members(
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| RawBound::exclusive(addr.as_ref()));
+    let start = addr.as_ref().map(Bound::exclusive);
 
     let members = MEMBERS
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/cw4-stake/src/contract.rs
+++ b/contracts/cw4-stake/src/contract.rs
@@ -11,7 +11,7 @@ use cw4::{
     Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
     TotalWeightResponse,
 };
-use cw_storage_plus::Bound;
+use cw_storage_plus::RawBound;
 use cw_utils::{maybe_addr, NativeBalance};
 
 use crate::error::ContractError;
@@ -339,7 +339,7 @@ fn list_members(
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
+    let start = addr.map(|addr| RawBound::exclusive(addr.as_ref()));
 
     let members = MEMBERS
         .range(deps.storage, start, None, Order::Ascending)

--- a/packages/storage-plus/src/bound.rs
+++ b/packages/storage-plus/src/bound.rs
@@ -1,0 +1,184 @@
+#![cfg(feature = "iterator")]
+
+use cosmwasm_std::Addr;
+use std::marker::PhantomData;
+
+use crate::de::KeyDeserialize;
+use crate::{Prefixer, PrimaryKey};
+
+/// `RawBound` is used to define the two ends of a range, more explicit than `Option<u8>`.
+/// `None` means that we don't limit that side of the range at all.
+/// `Inclusive` means we use the given bytes as a limit and *include* anything at that exact key.
+/// `Exclusive` means we use the given bytes as a limit and *exclude* anything at that exact key.
+/// See `Bound` for a type safe way to build these bounds.
+#[derive(Clone, Debug)]
+pub enum RawBound {
+    Inclusive(Vec<u8>),
+    Exclusive(Vec<u8>),
+}
+
+/// `Bound` is used to define the two ends of a range.
+/// `None` means that we don't limit that side of the range at all.
+/// `Inclusive` means we use the given value as a limit and *include* anything at that exact key.
+/// `Exclusive` means we use the given value as a limit and *exclude* anything at that exact key.
+#[derive(Clone, Debug)]
+pub enum Bound<'a, K: PrimaryKey<'a>> {
+    Inclusive((K, PhantomData<&'a bool>)),
+    Exclusive((K, PhantomData<&'a bool>)),
+    InclusiveRaw(Vec<u8>),
+    ExclusiveRaw(Vec<u8>),
+}
+
+impl<'a, K: PrimaryKey<'a>> Bound<'a, K> {
+    pub fn inclusive<T: Into<K>>(k: T) -> Self {
+        Self::Inclusive((k.into(), PhantomData))
+    }
+
+    pub fn exclusive<T: Into<K>>(k: T) -> Self {
+        Self::Exclusive((k.into(), PhantomData))
+    }
+
+    pub fn to_raw_bound(&self) -> RawBound {
+        match self {
+            Bound::Inclusive((k, _)) => RawBound::Inclusive(k.joined_key()),
+            Bound::Exclusive((k, _)) => RawBound::Exclusive(k.joined_key()),
+            Bound::ExclusiveRaw(raw_k) => RawBound::Exclusive(raw_k.clone()),
+            Bound::InclusiveRaw(raw_k) => RawBound::Inclusive(raw_k.clone()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum PrefixBound<'a, K: Prefixer<'a>> {
+    Inclusive((K, PhantomData<&'a bool>)),
+    Exclusive((K, PhantomData<&'a bool>)),
+}
+
+impl<'a, K: Prefixer<'a>> PrefixBound<'a, K> {
+    pub fn inclusive<T: Into<K>>(k: T) -> Self {
+        Self::Inclusive((k.into(), PhantomData))
+    }
+
+    pub fn exclusive<T: Into<K>>(k: T) -> Self {
+        Self::Exclusive((k.into(), PhantomData))
+    }
+
+    pub fn to_raw_bound(&self) -> RawBound {
+        match self {
+            PrefixBound::Exclusive((k, _)) => RawBound::Exclusive(k.joined_prefix()),
+            PrefixBound::Inclusive((k, _)) => RawBound::Inclusive(k.joined_prefix()),
+        }
+    }
+}
+
+pub trait Bounder<'a>: PrimaryKey<'a> + Sized {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>>;
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>>;
+}
+
+impl<'a> Bounder<'a> for () {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        None
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        None
+    }
+}
+
+impl<'a> Bounder<'a> for &'a [u8] {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<
+        'a,
+        T: PrimaryKey<'a> + KeyDeserialize + Prefixer<'a> + Clone,
+        U: PrimaryKey<'a> + KeyDeserialize + Clone,
+    > Bounder<'a> for (T, U)
+{
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<
+        'a,
+        T: PrimaryKey<'a> + Prefixer<'a> + Clone,
+        U: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize + Clone,
+        V: PrimaryKey<'a> + KeyDeserialize + Clone,
+    > Bounder<'a> for (T, U, V)
+{
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for &'a str {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for String {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for Vec<u8> {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for &'a Addr {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for Addr {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+macro_rules! integer_bound {
+    (for $($t:ty),+) => {
+        $(impl<'a> Bounder<'a> for $t {
+            fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+                Some(Bound::inclusive(self))
+            }
+            fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+                Some(Bound::exclusive(self))
+            }
+        })*
+    }
+}
+
+integer_bound!(for i8, u8, i16, u16, i32, u32, i64, u64);

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -461,7 +461,7 @@ mod test {
             .name
             .range_raw(
                 &store,
-                Some(RawBound::inclusive(key)),
+                Some(Bound::InclusiveRaw(key)),
                 None,
                 Order::Ascending,
             )
@@ -481,7 +481,7 @@ mod test {
             .name
             .range_raw(
                 &store,
-                Some(RawBound::exclusive(key)),
+                Some(Bound::ExclusiveRaw(key)),
                 None,
                 Order::Ascending,
             )
@@ -491,15 +491,13 @@ mod test {
 
         // index_key() over UniqueIndex works.
         let age_key = 23u32;
-        // Use the index_key() helper to build the (raw) index key
-        let age_key = map.idx.age.index_key(age_key);
         // Iterate using a (inclusive) bound over the raw key.
         let count = map
             .idx
             .age
             .range_raw(
                 &store,
-                Some(RawBound::inclusive(age_key)),
+                Some(Bound::inclusive(age_key)),
                 None,
                 Order::Ascending,
             )
@@ -1007,12 +1005,7 @@ mod test {
 
         // let's try to iterate over a range
         let all: StdResult<Vec<_>> = map
-            .range(
-                &store,
-                Some(RawBound::Inclusive(b"3".to_vec())),
-                None,
-                Order::Ascending,
-            )
+            .range(&store, Some(Bound::inclusive("3")), None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -10,7 +10,7 @@ use crate::indexes::Index;
 use crate::iter_helpers::{deserialize_kv, deserialize_v};
 use crate::keys::{Prefixer, PrimaryKey};
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Prefix, PrefixBound, RawBound};
 use crate::Path;
 
 pub trait IndexList<T> {
@@ -147,8 +147,8 @@ where
     pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::Record<T>>> + 'c>
     where
@@ -160,8 +160,8 @@ where
     pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
         self.no_prefix_raw().keys_raw(store, min, max, order)
@@ -247,8 +247,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(K::Output, T)>> + 'c>
     where
@@ -261,8 +261,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<K::Output>> + 'c>
     where
@@ -469,7 +469,12 @@ mod test {
         let count = map
             .idx
             .name
-            .range_raw(&store, Some(Bound::inclusive(key)), None, Order::Ascending)
+            .range_raw(
+                &store,
+                Some(RawBound::inclusive(key)),
+                None,
+                Order::Ascending,
+            )
             .count();
         // gets from the first "Maria" until the end
         assert_eq!(4, count);
@@ -484,7 +489,12 @@ mod test {
         let count = map
             .idx
             .name
-            .range_raw(&store, Some(Bound::exclusive(key)), None, Order::Ascending)
+            .range_raw(
+                &store,
+                Some(RawBound::exclusive(key)),
+                None,
+                Order::Ascending,
+            )
             .count();
         // gets from the 2nd "Maria" until the end
         assert_eq!(3, count);
@@ -499,7 +509,7 @@ mod test {
             .age
             .range_raw(
                 &store,
-                Some(Bound::inclusive(age_key)),
+                Some(RawBound::inclusive(age_key)),
                 None,
                 Order::Ascending,
             )
@@ -1009,7 +1019,7 @@ mod test {
         let all: StdResult<Vec<_>> = map
             .range(
                 &store,
-                Some(Bound::Inclusive(b"3".to_vec())),
+                Some(RawBound::Inclusive(b"3".to_vec())),
                 None,
                 Order::Ascending,
             )

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1,6 +1,7 @@
 // this module requires iterator to be useful at all
 #![cfg(feature = "iterator")]
 
+use crate::PrefixBound;
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -10,8 +11,8 @@ use crate::indexes::Index;
 use crate::iter_helpers::{deserialize_kv, deserialize_v};
 use crate::keys::{Prefixer, PrimaryKey};
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
-use crate::Path;
+use crate::prefix::{namespaced_prefix_range, Prefix};
+use crate::{Bound, Path};
 
 pub trait IndexList<T> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<T>> + '_>;

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -453,17 +453,18 @@ mod test {
         // Primary key may be empty (so that to iterate over all elements that match just the index)
         let key = ("Maria".to_string(), "".to_string());
         // Iterate using an inclusive bound over the key
-        let count = map
+        let marias = map
             .idx
             .name
             .range_raw(&store, Some(Bound::inclusive(key)), None, Order::Ascending)
-            .count();
+            .collect::<StdResult<Vec<_>>>()
+            .unwrap();
         // gets from the first "Maria" until the end
-        assert_eq!(4, count);
+        assert_eq!(4, marias.len());
 
         // This is equivalent to using prefix_range
         let key = "Maria".to_string();
-        let count = map
+        let marias2 = map
             .idx
             .name
             .prefix_range_raw(
@@ -472,9 +473,10 @@ mod test {
                 None,
                 Order::Ascending,
             )
-            .count();
-        // gets from the first "Maria" until the end
-        assert_eq!(4, count);
+            .collect::<StdResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(4, marias2.len());
+        assert_eq!(marias, marias2);
 
         // Build key including a non-empty pk
         let key = ("Maria".to_string(), "1".to_string());

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -8,9 +8,10 @@ use serde::Serialize;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::{Prefixer, PrimaryKey};
-use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, SnapshotMap};
-use crate::{IndexList, Map, Path, Strategy};
+use crate::PrefixBound;
+use crate::{Bound, IndexList, Map, Path, Strategy};
 
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
 pub struct IndexedSnapshotMap<'a, K, T, I> {

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::{Prefixer, PrimaryKey};
-use crate::prefix::{namespaced_prefix_range, Prefix, PrefixBound, RawBound};
+use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
 use crate::snapshot::{ChangeSet, SnapshotMap};
 use crate::{IndexList, Map, Path, Strategy};
 
@@ -179,7 +179,7 @@ where
     }
 
     // use no_prefix to scan -> range
-    pub fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
+    pub fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, K> {
         Prefix::new(self.pk_namespace, &[])
     }
 }
@@ -196,8 +196,8 @@ where
     pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, K>>,
+        max: Option<Bound<'a, K>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::Record<T>>> + 'c>
     where
@@ -209,8 +209,8 @@ where
     pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, K>>,
+        max: Option<Bound<'a, K>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
         self.no_prefix_raw().keys_raw(store, min, max, order)
@@ -267,8 +267,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, K>>,
+        max: Option<Bound<'a, K>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(K::Output, T)>> + 'c>
     where
@@ -281,8 +281,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, K>>,
+        max: Option<Bound<'a, K>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<K::Output>> + 'c>
     where
@@ -292,7 +292,7 @@ where
         self.no_prefix().keys(store, min, max, order)
     }
 
-    fn no_prefix(&self) -> Prefix<K, T> {
+    fn no_prefix(&self) -> Prefix<K, T, K> {
         Prefix::new(self.pk_namespace, &[])
     }
 }

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -1058,12 +1058,7 @@ mod test {
 
         // let's try to iterate over a range
         let all: StdResult<Vec<_>> = map
-            .range(
-                &store,
-                Some(RawBound::Inclusive(b"3".to_vec())),
-                None,
-                Order::Ascending,
-            )
+            .range(&store, Some(Bound::inclusive("3")), None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::{Prefixer, PrimaryKey};
-use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Prefix, PrefixBound, RawBound};
 use crate::snapshot::{ChangeSet, SnapshotMap};
 use crate::{IndexList, Map, Path, Strategy};
 
@@ -196,8 +196,8 @@ where
     pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::Record<T>>> + 'c>
     where
@@ -209,8 +209,8 @@ where
     pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
         self.no_prefix_raw().keys_raw(store, min, max, order)
@@ -267,8 +267,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(K::Output, T)>> + 'c>
     where
@@ -281,8 +281,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<K::Output>> + 'c>
     where
@@ -1060,7 +1060,7 @@ mod test {
         let all: StdResult<Vec<_>> = map
             .range(
                 &store,
-                Some(Bound::Inclusive(b"3".to_vec())),
+                Some(RawBound::Inclusive(b"3".to_vec())),
                 None,
                 Order::Ascending,
             )

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -6,12 +6,13 @@ use serde::Serialize;
 
 use cosmwasm_std::{from_slice, Order, Record, StdError, StdResult, Storage};
 
+use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
 use crate::helpers::namespaces_with_key;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, Bound, PrefixBound};
-use crate::{Index, Prefix, Prefixer, PrimaryKey};
+use crate::prefix::namespaced_prefix_range;
+use crate::{Bound, Index, Prefix, Prefixer, PrimaryKey};
 use std::marker::PhantomData;
 
 /// MultiIndex stores (namespace, index_name, idx_value, pk) -> b"pk_len".

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -11,7 +11,7 @@ use crate::helpers::namespaces_with_key;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
 use crate::prefix::{namespaced_prefix_range, PrefixBound};
-use crate::{Bound, Index, Prefix, Prefixer, PrimaryKey};
+use crate::{Index, Prefix, Prefixer, PrimaryKey, RawBound};
 use std::marker::PhantomData;
 
 /// MultiIndex stores (namespace, index_name, idx_value, pk) -> b"pk_len".
@@ -198,8 +198,8 @@ where
     pub fn range_raw<'c>(
         &'c self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = StdResult<Record<T>>> + 'c>
     where
@@ -211,8 +211,8 @@ where
     pub fn keys_raw<'c>(
         &'c self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
         self.no_prefix_raw().keys_raw(store, min, max, order)
@@ -304,8 +304,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(PK::Output, T)>> + 'c>
     where
@@ -318,8 +318,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<PK::Output>> + 'c>
     where

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -10,8 +10,8 @@ use crate::de::KeyDeserialize;
 use crate::helpers::namespaces_with_key;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, PrefixBound};
-use crate::{Index, Prefix, Prefixer, PrimaryKey, RawBound};
+use crate::prefix::{namespaced_prefix_range, Bound, PrefixBound};
+use crate::{Index, Prefix, Prefixer, PrimaryKey};
 use std::marker::PhantomData;
 
 /// MultiIndex stores (namespace, index_name, idx_value, pk) -> b"pk_len".
@@ -143,7 +143,7 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a> + Prefixer<'a>,
 {
-    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
+    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, IK> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],
@@ -198,8 +198,8 @@ where
     pub fn range_raw<'c>(
         &'c self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
         order: Order,
     ) -> Box<dyn Iterator<Item = StdResult<Record<T>>> + 'c>
     where
@@ -211,8 +211,8 @@ where
     pub fn keys_raw<'c>(
         &'c self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
         self.no_prefix_raw().keys_raw(store, min, max, order)
@@ -304,8 +304,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(PK::Output, T)>> + 'c>
     where
@@ -318,8 +318,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<PK::Output>> + 'c>
     where
@@ -329,7 +329,7 @@ where
         self.no_prefix().keys(store, min, max, order)
     }
 
-    fn no_prefix(&self) -> Prefix<PK, T> {
+    fn no_prefix(&self) -> Prefix<PK, T, IK> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -12,7 +12,7 @@ use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
 use crate::prefix::{namespaced_prefix_range, PrefixBound};
-use crate::{Bound, Index, Prefix, Prefixer, PrimaryKey};
+use crate::{Index, Prefix, Prefixer, PrimaryKey, RawBound};
 
 /// UniqueRef stores Binary(Vec[u8]) representation of private key and index value
 #[derive(Deserialize, Serialize)]
@@ -143,8 +143,8 @@ where
     pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = StdResult<Record<T>>> + 'c>
     where
@@ -156,8 +156,8 @@ where
     pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
         self.no_prefix_raw().keys_raw(store, min, max, order)
@@ -199,8 +199,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(PK::Output, T)>> + 'c>
     where
@@ -213,8 +213,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<PK::Output>> + 'c>
     where

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -8,11 +8,12 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{from_slice, Binary, Order, Record, StdError, StdResult, Storage};
 
+use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, Bound, PrefixBound};
-use crate::{Index, Prefix, Prefixer, PrimaryKey};
+use crate::prefix::namespaced_prefix_range;
+use crate::{Bound, Index, Prefix, Prefixer, PrimaryKey};
 
 /// UniqueRef stores Binary(Vec[u8]) representation of private key and index value
 #[derive(Deserialize, Serialize)]

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -11,8 +11,8 @@ use cosmwasm_std::{from_slice, Binary, Order, Record, StdError, StdResult, Stora
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, PrefixBound};
-use crate::{Index, Prefix, Prefixer, PrimaryKey, RawBound};
+use crate::prefix::{namespaced_prefix_range, Bound, PrefixBound};
+use crate::{Index, Prefix, Prefixer, PrimaryKey};
 
 /// UniqueRef stores Binary(Vec[u8]) representation of private key and index value
 #[derive(Deserialize, Serialize)]
@@ -112,7 +112,7 @@ where
         k.joined_key()
     }
 
-    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
+    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, IK> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],
@@ -143,8 +143,8 @@ where
     pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
         order: Order,
     ) -> Box<dyn Iterator<Item = StdResult<Record<T>>> + 'c>
     where
@@ -156,8 +156,8 @@ where
     pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c> {
         self.no_prefix_raw().keys_raw(store, min, max, order)
@@ -199,8 +199,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(PK::Output, T)>> + 'c>
     where
@@ -213,8 +213,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<PK::Output>> + 'c>
     where
@@ -224,7 +224,7 @@ where
         self.no_prefix().keys(store, min, max, order)
     }
 
-    pub fn prefix(&self, p: IK::Prefix) -> Prefix<PK, T> {
+    pub fn prefix(&self, p: IK::Prefix) -> Prefix<PK, T, IK::Suffix> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
@@ -234,7 +234,7 @@ where
         )
     }
 
-    pub fn sub_prefix(&self, p: IK::SubPrefix) -> Prefix<PK, T> {
+    pub fn sub_prefix(&self, p: IK::SubPrefix) -> Prefix<PK, T, IK::SuperSuffix> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
@@ -244,7 +244,7 @@ where
         )
     }
 
-    fn no_prefix(&self) -> Prefix<PK, T> {
+    fn no_prefix(&self) -> Prefix<PK, T, IK> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &[],

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -302,25 +302,25 @@ macro_rules! integer_prefix {
 integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64);
 
 pub trait Bounder<'a>: PrimaryKey<'a> + Sized {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>>;
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>>;
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>>;
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>>;
 }
 
 impl<'a> Bounder<'a> for () {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
         None
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
         None
     }
 }
 
 impl<'a> Bounder<'a> for &'a [u8] {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(*self))
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self))
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(*self))
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self))
     }
 }
 
@@ -330,11 +330,11 @@ impl<
         U: PrimaryKey<'a> + KeyDeserialize + Clone,
     > Bounder<'a> for (T, U)
 {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self.clone()))
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self))
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self.clone()))
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self))
     }
 }
 
@@ -345,67 +345,67 @@ impl<
         V: PrimaryKey<'a> + KeyDeserialize + Clone,
     > Bounder<'a> for (T, U, V)
 {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self.clone()))
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self))
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self.clone()))
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for &'a str {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(*self))
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self))
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(*self))
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for String {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self.clone()))
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self))
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self.clone()))
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for Vec<u8> {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self.clone()))
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self))
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self.clone()))
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for &'a Addr {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(*self))
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self))
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(*self))
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for Addr {
-    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self.clone()))
+    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self))
     }
-    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self.clone()))
+    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self))
     }
 }
 
 macro_rules! integer_bound {
     (for $($t:ty),+) => {
         $(impl<'a> Bounder<'a> for $t {
-            fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-                Some(Bound2::inclusive(*self))
+            fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+                Some(Bound2::inclusive(self))
             }
-            fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
-                Some(Bound2::exclusive(*self))
+            fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+                Some(Bound2::exclusive(self))
             }
         })*
     }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -301,7 +301,7 @@ macro_rules! integer_prefix {
 
 integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64);
 
-pub trait Bounder<'a>: Prefixer<'a> + Sized {
+pub trait Bounder<'a>: PrimaryKey<'a> + Sized {
     fn inclusive_bound(&self) -> Option<Bound2<'a, Self>>;
     fn exclusive_bound(&self) -> Option<Bound2<'a, Self>>;
 }
@@ -324,7 +324,12 @@ impl<'a> Bounder<'a> for &'a [u8] {
     }
 }
 
-impl<'a, T: Prefixer<'a> + Clone, U: Prefixer<'a> + Clone> Bounder<'a> for (T, U) {
+impl<
+        'a,
+        T: PrimaryKey<'a> + KeyDeserialize + Prefixer<'a> + Clone,
+        U: PrimaryKey<'a> + KeyDeserialize + Clone,
+    > Bounder<'a> for (T, U)
+{
     fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
         Some(Bound2::inclusive(self.clone()))
     }
@@ -333,8 +338,12 @@ impl<'a, T: Prefixer<'a> + Clone, U: Prefixer<'a> + Clone> Bounder<'a> for (T, U
     }
 }
 
-impl<'a, T: Prefixer<'a> + Clone, U: Prefixer<'a> + Clone, V: Prefixer<'a> + Clone> Bounder<'a>
-    for (T, U, V)
+impl<
+        'a,
+        T: PrimaryKey<'a> + Prefixer<'a> + Clone,
+        U: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize + Clone,
+        V: PrimaryKey<'a> + KeyDeserialize + Clone,
+    > Bounder<'a> for (T, U, V)
 {
     fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
         Some(Bound2::inclusive(self.clone()))

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -301,7 +301,7 @@ macro_rules! integer_prefix {
 
 integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64);
 
-pub trait Bounder<'a> {
+pub trait Bounder<'a>: Prefixer<'a> {
     fn inclusive_bound(&self) -> Option<Bound>;
     fn exclusive_bound(&self) -> Option<Bound>;
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::Addr;
 use crate::de::KeyDeserialize;
 use crate::helpers::namespaces_with_key;
 use crate::int_key::CwIntKey;
-use crate::Bound;
+use crate::prefix::Bound2;
 
 #[derive(Debug)]
 pub enum Key<'a> {
@@ -301,100 +301,102 @@ macro_rules! integer_prefix {
 
 integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64);
 
-pub trait Bounder<'a>: Prefixer<'a> {
-    fn inclusive_bound(&self) -> Option<Bound>;
-    fn exclusive_bound(&self) -> Option<Bound>;
+pub trait Bounder<'a>: Prefixer<'a> + Sized {
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>>;
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>>;
 }
 
 impl<'a> Bounder<'a> for () {
-    fn inclusive_bound(&self) -> Option<Bound> {
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
         None
     }
-    fn exclusive_bound(&self) -> Option<Bound> {
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
         None
     }
 }
 
 impl<'a> Bounder<'a> for &'a [u8] {
-    fn inclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::inclusive(self.to_vec()))
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(*self))
     }
-    fn exclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::exclusive(self.to_vec()))
-    }
-}
-
-impl<'a, T: Prefixer<'a>, U: Prefixer<'a>> Bounder<'a> for (T, U) {
-    fn inclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::Inclusive(self.joined_prefix()))
-    }
-    fn exclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::Exclusive(self.joined_prefix()))
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(*self))
     }
 }
 
-impl<'a, T: Prefixer<'a>, U: Prefixer<'a>, V: Prefixer<'a>> Bounder<'a> for (T, U, V) {
-    fn inclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::Inclusive(self.joined_prefix()))
+impl<'a, T: Prefixer<'a> + Clone, U: Prefixer<'a> + Clone> Bounder<'a> for (T, U) {
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self.clone()))
     }
-    fn exclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::Exclusive(self.joined_prefix()))
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self.clone()))
+    }
+}
+
+impl<'a, T: Prefixer<'a> + Clone, U: Prefixer<'a> + Clone, V: Prefixer<'a> + Clone> Bounder<'a>
+    for (T, U, V)
+{
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self.clone()))
+    }
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self.clone()))
     }
 }
 
 impl<'a> Bounder<'a> for &'a str {
-    fn inclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::inclusive(self.as_bytes().to_vec()))
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(*self))
     }
-    fn exclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::exclusive(self.as_bytes().to_vec()))
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(*self))
     }
 }
 
 impl<'a> Bounder<'a> for String {
-    fn inclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::inclusive(self.as_bytes().to_vec()))
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self.clone()))
     }
-    fn exclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::exclusive(self.as_bytes().to_vec()))
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self.clone()))
     }
 }
 
 impl<'a> Bounder<'a> for Vec<u8> {
-    fn inclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::inclusive(self.clone()))
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self.clone()))
     }
-    fn exclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::exclusive(self.clone()))
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self.clone()))
     }
 }
 
 impl<'a> Bounder<'a> for &'a Addr {
-    fn inclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::Inclusive(self.as_ref().into()))
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(*self))
     }
-    fn exclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::Exclusive(self.as_ref().into()))
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(*self))
     }
 }
 
 impl<'a> Bounder<'a> for Addr {
-    fn inclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::Inclusive(self.as_ref().into()))
+    fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::inclusive(self.clone()))
     }
-    fn exclusive_bound(&self) -> Option<Bound> {
-        Some(Bound::Exclusive(self.as_ref().into()))
+    fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+        Some(Bound2::exclusive(self.clone()))
     }
 }
 
 macro_rules! integer_bound {
     (for $($t:ty),+) => {
         $(impl<'a> Bounder<'a> for $t {
-            fn inclusive_bound(&self) -> Option<Bound> {
-                Some(Bound::inclusive_int(*self))
+            fn inclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+                Some(Bound2::inclusive(*self))
             }
-            fn exclusive_bound(&self) -> Option<Bound> {
-                Some(Bound::exclusive_int(*self))
+            fn exclusive_bound(&self) -> Option<Bound2<'a, Self>> {
+                Some(Bound2::exclusive(*self))
             }
         })*
     }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::Addr;
 use crate::de::KeyDeserialize;
 use crate::helpers::namespaces_with_key;
 use crate::int_key::CwIntKey;
-use crate::prefix::Bound2;
+use crate::prefix::Bound;
 
 #[derive(Debug)]
 pub enum Key<'a> {
@@ -302,25 +302,25 @@ macro_rules! integer_prefix {
 integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64);
 
 pub trait Bounder<'a>: PrimaryKey<'a> + Sized {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>>;
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>>;
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>>;
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>>;
 }
 
 impl<'a> Bounder<'a> for () {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
         None
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
         None
     }
 }
 
 impl<'a> Bounder<'a> for &'a [u8] {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self))
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self))
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 
@@ -330,11 +330,11 @@ impl<
         U: PrimaryKey<'a> + KeyDeserialize + Clone,
     > Bounder<'a> for (T, U)
 {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self))
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self))
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 
@@ -345,67 +345,67 @@ impl<
         V: PrimaryKey<'a> + KeyDeserialize + Clone,
     > Bounder<'a> for (T, U, V)
 {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self))
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self))
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for &'a str {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self))
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self))
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for String {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self))
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self))
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for Vec<u8> {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self))
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self))
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for &'a Addr {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self))
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self))
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 
 impl<'a> Bounder<'a> for Addr {
-    fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::inclusive(self))
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
     }
-    fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-        Some(Bound2::exclusive(self))
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 
 macro_rules! integer_bound {
     (for $($t:ty),+) => {
         $(impl<'a> Bounder<'a> for $t {
-            fn inclusive_bound(self) -> Option<Bound2<'a, Self>> {
-                Some(Bound2::inclusive(self))
+            fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+                Some(Bound::inclusive(self))
             }
-            fn exclusive_bound(self) -> Option<Bound2<'a, Self>> {
-                Some(Bound2::exclusive(self))
+            fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+                Some(Bound::exclusive(self))
             }
         })*
     }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -324,6 +324,24 @@ impl<'a> Bounder<'a> for &'a [u8] {
     }
 }
 
+impl<'a, T: Prefixer<'a>, U: Prefixer<'a>> Bounder<'a> for (T, U) {
+    fn inclusive_bound(&self) -> Option<Bound> {
+        Some(Bound::Inclusive(self.joined_prefix()))
+    }
+    fn exclusive_bound(&self) -> Option<Bound> {
+        Some(Bound::Exclusive(self.joined_prefix()))
+    }
+}
+
+impl<'a, T: Prefixer<'a>, U: Prefixer<'a>, V: Prefixer<'a>> Bounder<'a> for (T, U, V) {
+    fn inclusive_bound(&self) -> Option<Bound> {
+        Some(Bound::Inclusive(self.joined_prefix()))
+    }
+    fn exclusive_bound(&self) -> Option<Bound> {
+        Some(Bound::Exclusive(self.joined_prefix()))
+    }
+}
+
 impl<'a> Bounder<'a> for &'a str {
     fn inclusive_bound(&self) -> Option<Bound> {
         Some(Bound::inclusive(self.as_bytes().to_vec()))

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -3,7 +3,6 @@ use cosmwasm_std::Addr;
 use crate::de::KeyDeserialize;
 use crate::helpers::namespaces_with_key;
 use crate::int_key::CwIntKey;
-use crate::prefix::Bound;
 
 #[derive(Debug)]
 pub enum Key<'a> {
@@ -300,118 +299,6 @@ macro_rules! integer_prefix {
 }
 
 integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64);
-
-pub trait Bounder<'a>: PrimaryKey<'a> + Sized {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>>;
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>>;
-}
-
-impl<'a> Bounder<'a> for () {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        None
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        None
-    }
-}
-
-impl<'a> Bounder<'a> for &'a [u8] {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<
-        'a,
-        T: PrimaryKey<'a> + KeyDeserialize + Prefixer<'a> + Clone,
-        U: PrimaryKey<'a> + KeyDeserialize + Clone,
-    > Bounder<'a> for (T, U)
-{
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<
-        'a,
-        T: PrimaryKey<'a> + Prefixer<'a> + Clone,
-        U: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize + Clone,
-        V: PrimaryKey<'a> + KeyDeserialize + Clone,
-    > Bounder<'a> for (T, U, V)
-{
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for &'a str {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for String {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for Vec<u8> {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for &'a Addr {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for Addr {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-macro_rules! integer_bound {
-    (for $($t:ty),+) => {
-        $(impl<'a> Bounder<'a> for $t {
-            fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-                Some(Bound::inclusive(self))
-            }
-            fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-                Some(Bound::exclusive(self))
-            }
-        })*
-    }
-}
-
-integer_bound!(for i8, u8, i16, u16, i32, u32, i64, u64);
 
 #[cfg(test)]
 mod test {

--- a/packages/storage-plus/src/keys_old.rs
+++ b/packages/storage-plus/src/keys_old.rs
@@ -1,6 +1,6 @@
 use crate::de::KeyDeserialize;
 use crate::keys::Key;
-use crate::{Endian, Prefixer, PrimaryKey};
+use crate::{Bound, Bounder, Endian, Prefixer, PrimaryKey};
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -58,6 +58,20 @@ where
 impl<'a, T: Endian> Prefixer<'a> for IntKeyOld<T> {
     fn prefix(&self) -> Vec<Key> {
         self.wrapped.prefix()
+    }
+}
+
+// this auto-implements Bounder for all the IntKey types
+impl<'a, T: Endian> Bounder<'a> for IntKeyOld<T>
+where
+    IntKeyOld<T>: KeyDeserialize,
+{
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
     }
 }
 

--- a/packages/storage-plus/src/keys_old.rs
+++ b/packages/storage-plus/src/keys_old.rs
@@ -1,6 +1,8 @@
 use crate::de::KeyDeserialize;
 use crate::keys::Key;
-use crate::{Bound, Bounder, Endian, Prefixer, PrimaryKey};
+#[cfg(feature = "iterator")]
+use crate::{Bound, Bounder};
+use crate::{Endian, Prefixer, PrimaryKey};
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -62,6 +64,7 @@ impl<'a, T: Endian> Prefixer<'a> for IntKeyOld<T> {
 }
 
 // this auto-implements Bounder for all the IntKey types
+#[cfg(feature = "iterator")]
 impl<'a, T: Endian> Bounder<'a> for IntKeyOld<T>
 where
     IntKeyOld<T>: KeyDeserialize,

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -33,6 +33,6 @@ pub use keys_old::IntKeyOld;
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
-pub use prefix::{range_with_prefix, Bound, Prefix, PrefixBound};
+pub use prefix::{range_with_prefix, Prefix, PrefixBound, RawBound};
 #[cfg(feature = "iterator")]
 pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -28,11 +28,11 @@ pub use indexes::UniqueIndex;
 pub use indexes::{index_string, index_string_tuple, index_triple, index_tuple, Index};
 pub use int_key::CwIntKey;
 pub use item::Item;
-pub use keys::{Key, Prefixer, PrimaryKey};
+pub use keys::{Bounder, Key, Prefixer, PrimaryKey};
 pub use keys_old::IntKeyOld;
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
-pub use prefix::{range_with_prefix, Prefix, PrefixBound, RawBound};
+pub use prefix::{range_with_prefix, Bound, Prefix, PrefixBound, RawBound};
 #[cfg(feature = "iterator")]
 pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -1,3 +1,4 @@
+mod bound;
 mod de;
 mod de_old;
 mod endian;
@@ -15,6 +16,8 @@ mod path;
 mod prefix;
 mod snapshot;
 
+#[cfg(feature = "iterator")]
+pub use bound::{Bound, Bounder, PrefixBound, RawBound};
 pub use endian::Endian;
 #[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};
@@ -28,11 +31,11 @@ pub use indexes::UniqueIndex;
 pub use indexes::{index_string, index_string_tuple, index_triple, index_tuple, Index};
 pub use int_key::CwIntKey;
 pub use item::Item;
-pub use keys::{Bounder, Key, Prefixer, PrimaryKey};
+pub use keys::{Key, Prefixer, PrimaryKey};
 pub use keys_old::IntKeyOld;
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
-pub use prefix::{range_with_prefix, Bound, Prefix, PrefixBound, RawBound};
+pub use prefix::{range_with_prefix, Prefix};
 #[cfg(feature = "iterator")]
 pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -3,17 +3,18 @@ use serde::Serialize;
 use std::marker::PhantomData;
 
 #[cfg(feature = "iterator")]
+use crate::bound::{Bound, Bounder, PrefixBound};
+#[cfg(feature = "iterator")]
 use crate::de::KeyDeserialize;
 use crate::helpers::query_raw;
 #[cfg(feature = "iterator")]
 use crate::iter_helpers::{deserialize_kv, deserialize_v};
 #[cfg(feature = "iterator")]
 use crate::keys::Prefixer;
-use crate::keys::{Bounder, Key, PrimaryKey};
+use crate::keys::{Key, PrimaryKey};
 use crate::path::Path;
-use crate::prefix::Bound;
 #[cfg(feature = "iterator")]
-use crate::prefix::{namespaced_prefix_range, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Prefix};
 use cosmwasm_std::{from_slice, Addr, QuerierWrapper, StdError, StdResult, Storage};
 
 #[derive(Debug, Clone)]
@@ -263,6 +264,7 @@ mod test {
     use cosmwasm_std::{Order, StdResult};
 
     use crate::int_key::CwIntKey;
+    #[cfg(feature = "iterator")]
     use crate::IntKeyOld;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -263,7 +263,7 @@ mod test {
     use cosmwasm_std::{Order, StdResult};
 
     use crate::int_key::CwIntKey;
-    // use crate::keys_old::IntKeyOld;
+    use crate::IntKeyOld;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Data {
@@ -274,8 +274,8 @@ mod test {
     const PEOPLE: Map<&[u8], Data> = Map::new("people");
     #[cfg(feature = "iterator")]
     const PEOPLE_ID: Map<u32, Data> = Map::new("people_id");
-    // #[cfg(feature = "iterator")]
-    // const SIGNED_ID_OLD: Map<IntKeyOld<i32>, Data> = Map::new("signed_id");
+    #[cfg(feature = "iterator")]
+    const SIGNED_ID_OLD: Map<IntKeyOld<i32>, Data> = Map::new("signed_id");
     #[cfg(feature = "iterator")]
     const SIGNED_ID: Map<i32, Data> = Map::new("signed_id");
 
@@ -803,7 +803,6 @@ mod test {
         assert_eq!(all, vec![(50, data3)]);
     }
 
-    /*
     #[test]
     #[cfg(feature = "iterator")]
     fn range_signed_integer_key_migration() {
@@ -873,7 +872,6 @@ mod test {
         // confirm new order is right
         assert_eq!(new, vec![(-1234, data), (-56, data2), (50, data3)]);
     }
-     */
 
     #[test]
     #[cfg(feature = "iterator")]

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -263,7 +263,7 @@ mod test {
     use cosmwasm_std::{Order, StdResult};
 
     use crate::int_key::CwIntKey;
-    use crate::keys_old::IntKeyOld;
+    // use crate::keys_old::IntKeyOld;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Data {
@@ -274,8 +274,8 @@ mod test {
     const PEOPLE: Map<&[u8], Data> = Map::new("people");
     #[cfg(feature = "iterator")]
     const PEOPLE_ID: Map<u32, Data> = Map::new("people_id");
-    #[cfg(feature = "iterator")]
-    const SIGNED_ID_OLD: Map<IntKeyOld<i32>, Data> = Map::new("signed_id");
+    // #[cfg(feature = "iterator")]
+    // const SIGNED_ID_OLD: Map<IntKeyOld<i32>, Data> = Map::new("signed_id");
     #[cfg(feature = "iterator")]
     const SIGNED_ID: Map<i32, Data> = Map::new("signed_id");
 
@@ -444,7 +444,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE
             .range_raw(
                 &store,
-                Some(RawBound::Inclusive(b"j".to_vec())),
+                Some(Bound::inclusive(b"j" as &[u8])),
                 None,
                 Order::Ascending,
             )
@@ -460,7 +460,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE
             .range_raw(
                 &store,
-                Some(RawBound::Inclusive(b"jo".to_vec())),
+                Some(Bound::inclusive(b"jo" as &[u8])),
                 None,
                 Order::Ascending,
             )
@@ -504,7 +504,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE
             .range(
                 &store,
-                Some(RawBound::Inclusive(b"j".to_vec())),
+                Some(Bound::inclusive(b"j" as &[u8])),
                 None,
                 Order::Ascending,
             )
@@ -520,7 +520,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE
             .range(
                 &store,
-                Some(RawBound::Inclusive(b"jo".to_vec())),
+                Some(Bound::inclusive(b"jo" as &[u8])),
                 None,
                 Order::Ascending,
             )
@@ -617,7 +617,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE_ID
             .range(
                 &store,
-                Some(RawBound::inclusive_int(56u32)),
+                Some(Bound::inclusive(56u32)),
                 None,
                 Order::Ascending,
             )
@@ -630,7 +630,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE_ID
             .range(
                 &store,
-                Some(RawBound::inclusive_int(57u32)),
+                Some(Bound::inclusive(57u32)),
                 None,
                 Order::Ascending,
             )
@@ -722,7 +722,7 @@ mod test {
         let all: StdResult<Vec<_>> = SIGNED_ID
             .range(
                 &store,
-                Some(RawBound::inclusive_int(-56i32)),
+                Some(Bound::inclusive(-56i32)),
                 None,
                 Order::Ascending,
             )
@@ -735,8 +735,8 @@ mod test {
         let all: StdResult<Vec<_>> = SIGNED_ID
             .range(
                 &store,
-                Some(RawBound::inclusive_int(-55i32)),
-                Some(RawBound::inclusive_int(50i32)),
+                Some(Bound::inclusive(-55i32)),
+                Some(Bound::inclusive(50i32)),
                 Order::Descending,
             )
             .collect();
@@ -803,6 +803,7 @@ mod test {
         assert_eq!(all, vec![(50, data3)]);
     }
 
+    /*
     #[test]
     #[cfg(feature = "iterator")]
     fn range_signed_integer_key_migration() {
@@ -872,6 +873,7 @@ mod test {
         // confirm new order is right
         assert_eq!(new, vec![(-1234, data), (-56, data2), (50, data3)]);
     }
+     */
 
     #[test]
     #[cfg(feature = "iterator")]
@@ -1428,7 +1430,7 @@ mod test {
         let all: StdResult<Vec<_>> = PEOPLE
             .range_raw(
                 &store,
-                Some(RawBound::Exclusive(b"jim".to_vec())),
+                Some(Bound::exclusive(b"jim" as &[u8])),
                 None,
                 Order::Ascending,
             )
@@ -1455,8 +1457,8 @@ mod test {
             .prefix(b"owner")
             .range_raw(
                 &store,
-                Some(RawBound::Exclusive(b"spender1".to_vec())),
-                Some(RawBound::Inclusive(b"spender2".to_vec())),
+                Some(Bound::exclusive(b"spender1" as &[u8])),
+                Some(Bound::inclusive(b"spender2" as &[u8])),
                 Order::Descending,
             )
             .collect();

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -116,11 +116,11 @@ where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
 {
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
         Prefix::new(self.namespace, &p.prefix())
     }
 
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
         Prefix::new(self.namespace, &p.prefix())
     }
 }
@@ -240,7 +240,7 @@ where
         self.no_prefix().keys(store, min, max, order)
     }
 
-    fn no_prefix(&self) -> Prefix<K, T> {
+    fn no_prefix(&self) -> Prefix<K, T, K> {
         Prefix::new(self.namespace, &[])
     }
 }

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -902,50 +902,6 @@ mod test {
             all,
             vec![(b"spender".to_vec(), 1000), (b"spender2".to_vec(), 3000),]
         );
-    }
-
-    #[test]
-    #[cfg(feature = "iterator")]
-    fn range2_composite_key() {
-        let mut store = MockStorage::new();
-
-        // save and load on three keys, one under different owner
-        ALLOWANCE
-            .save(&mut store, (b"owner", b"spender"), &1000)
-            .unwrap();
-        ALLOWANCE
-            .save(&mut store, (b"owner", b"spender2"), &3000)
-            .unwrap();
-        ALLOWANCE
-            .save(&mut store, (b"owner2", b"spender"), &5000)
-            .unwrap();
-
-        // let's try to iterate!
-        let all: StdResult<Vec<_>> = ALLOWANCE
-            .range(&store, None, None, Order::Ascending)
-            .collect();
-        let all = all.unwrap();
-        assert_eq!(3, all.len());
-        assert_eq!(
-            all,
-            vec![
-                ((b"owner".to_vec(), b"spender".to_vec()), 1000),
-                ((b"owner".to_vec(), b"spender2".to_vec()), 3000),
-                ((b"owner2".to_vec(), b"spender".to_vec()), 5000)
-            ]
-        );
-
-        // let's try to iterate over a prefix
-        let all: StdResult<Vec<_>> = ALLOWANCE
-            .prefix(b"owner")
-            .range(&store, None, None, Order::Ascending)
-            .collect();
-        let all = all.unwrap();
-        assert_eq!(2, all.len());
-        assert_eq!(
-            all,
-            vec![(b"spender".to_vec(), 1000), (b"spender2".to_vec(), 3000),]
-        );
 
         // let's try to iterate over a prefixed restricted inclusive range
         let all: StdResult<Vec<_>> = ALLOWANCE
@@ -1052,71 +1008,6 @@ mod test {
     #[test]
     #[cfg(feature = "iterator")]
     fn range_triple_key() {
-        let mut store = MockStorage::new();
-
-        // save and load on three keys, one under different owner
-        TRIPLE
-            .save(&mut store, (b"owner", 9u8, "recipient"), &1000)
-            .unwrap();
-        TRIPLE
-            .save(&mut store, (b"owner", 9u8, "recipient2"), &3000)
-            .unwrap();
-        TRIPLE
-            .save(&mut store, (b"owner", 10u8, "recipient3"), &3000)
-            .unwrap();
-        TRIPLE
-            .save(&mut store, (b"owner2", 9u8, "recipient"), &5000)
-            .unwrap();
-
-        // let's try to iterate!
-        let all: StdResult<Vec<_>> = TRIPLE.range(&store, None, None, Order::Ascending).collect();
-        let all = all.unwrap();
-        assert_eq!(4, all.len());
-        assert_eq!(
-            all,
-            vec![
-                ((b"owner".to_vec(), 9, "recipient".to_string()), 1000),
-                ((b"owner".to_vec(), 9, "recipient2".to_string()), 3000),
-                ((b"owner".to_vec(), 10, "recipient3".to_string()), 3000),
-                ((b"owner2".to_vec(), 9, "recipient".to_string()), 5000)
-            ]
-        );
-
-        // let's iterate over a sub_prefix
-        let all: StdResult<Vec<_>> = TRIPLE
-            .sub_prefix(b"owner")
-            .range(&store, None, None, Order::Ascending)
-            .collect();
-        let all = all.unwrap();
-        assert_eq!(3, all.len());
-        assert_eq!(
-            all,
-            vec![
-                ((9, "recipient".to_string()), 1000),
-                ((9, "recipient2".to_string()), 3000),
-                ((10, "recipient3".to_string()), 3000),
-            ]
-        );
-
-        // let's iterate over a prefix
-        let all: StdResult<Vec<_>> = TRIPLE
-            .prefix((b"owner", 9))
-            .range(&store, None, None, Order::Ascending)
-            .collect();
-        let all = all.unwrap();
-        assert_eq!(2, all.len());
-        assert_eq!(
-            all,
-            vec![
-                ("recipient".to_string(), 1000),
-                ("recipient2".to_string(), 3000),
-            ]
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "iterator")]
-    fn range2_triple_key() {
         let mut store = MockStorage::new();
 
         // save and load on three keys, one under different owner

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -477,66 +477,6 @@ mod test {
     fn range_simple_string_key() {
         let mut store = MockStorage::new();
 
-        // save and load on two keys
-        let data = Data {
-            name: "John".to_string(),
-            age: 32,
-        };
-        PEOPLE.save(&mut store, b"john", &data).unwrap();
-
-        let data2 = Data {
-            name: "Jim".to_string(),
-            age: 44,
-        };
-        PEOPLE.save(&mut store, b"jim", &data2).unwrap();
-
-        // let's try to iterate!
-        let all: StdResult<Vec<_>> = PEOPLE.range(&store, None, None, Order::Ascending).collect();
-        let all = all.unwrap();
-        assert_eq!(2, all.len());
-        assert_eq!(
-            all,
-            vec![
-                (b"jim".to_vec(), data2.clone()),
-                (b"john".to_vec(), data.clone())
-            ]
-        );
-
-        // let's try to iterate over a range
-        let all: StdResult<Vec<_>> = PEOPLE
-            .range(
-                &store,
-                Some(Bound::inclusive(b"j" as &[u8])),
-                None,
-                Order::Ascending,
-            )
-            .collect();
-        let all = all.unwrap();
-        assert_eq!(2, all.len());
-        assert_eq!(
-            all,
-            vec![(b"jim".to_vec(), data2), (b"john".to_vec(), data.clone())]
-        );
-
-        // let's try to iterate over a more restrictive range
-        let all: StdResult<Vec<_>> = PEOPLE
-            .range(
-                &store,
-                Some(Bound::inclusive(b"jo" as &[u8])),
-                None,
-                Order::Ascending,
-            )
-            .collect();
-        let all = all.unwrap();
-        assert_eq!(1, all.len());
-        assert_eq!(all, vec![(b"john".to_vec(), data)]);
-    }
-
-    #[test]
-    #[cfg(feature = "iterator")]
-    fn range2_simple_string_key() {
-        let mut store = MockStorage::new();
-
         // save and load on three keys
         let data = Data {
             name: "John".to_string(),

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -51,7 +51,7 @@ where
     }
 
     #[cfg(feature = "iterator")]
-    pub(crate) fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
+    pub(crate) fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, K> {
         Prefix::new(self.namespace, &[])
     }
 
@@ -251,6 +251,19 @@ where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a> + KeyDeserialize + Bounder<'a>,
 {
+    pub fn range2_raw<'c>(
+        &self,
+        store: &'c dyn Storage,
+        min: Option<Bound2<'a, K>>,
+        max: Option<Bound2<'a, K>>,
+        order: cosmwasm_std::Order,
+    ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::Record<T>>> + 'c>
+    where
+        T: 'c,
+    {
+        self.no_prefix_raw().range2_raw(store, min, max, order)
+    }
+
     pub fn range2<'c>(
         &self,
         store: &'c dyn Storage,

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -581,9 +581,10 @@ mod test {
         assert_eq!(1, all.len());
         assert_eq!(all, vec![(1234, data)]);
     }
+
     #[test]
     #[cfg(feature = "iterator")]
-    fn range2_simple_integer_key() {
+    fn range_simple_integer_key_with_bounder_trait() {
         let mut store = MockStorage::new();
 
         // save and load on two keys
@@ -689,7 +690,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn range2_simple_signed_integer_key() {
+    fn range_simple_signed_integer_key_with_bounder_trait() {
         let mut store = MockStorage::new();
 
         // save and load on three keys

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -62,8 +62,8 @@ impl<'a, K: Bounder<'a>> Bound2<'a, K> {
 
     pub fn to_bound(&self) -> Bound {
         match self {
-            Bound2::Exclusive((k, _)) => Bound::Exclusive(k.joined_prefix()),
-            Bound2::Inclusive((k, _)) => Bound::Inclusive(k.joined_prefix()),
+            Bound2::Exclusive((k, _)) => Bound::Exclusive(k.joined_key()),
+            Bound2::Inclusive((k, _)) => Bound::Inclusive(k.joined_key()),
         }
     }
 }

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -244,6 +244,29 @@ where
     K: KeyDeserialize,
     T: Serialize + DeserializeOwned,
 {
+    pub fn range2_raw<'a>(
+        &self,
+        store: &'a dyn Storage,
+        min: Option<Bound2<'b, B>>,
+        max: Option<Bound2<'b, B>>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = StdResult<Record<T>>> + 'a>
+    where
+        T: 'a,
+    {
+        let de_fn = self.de_fn_v;
+        let pk_name = self.pk_name.clone();
+        let mapped = range_with_prefix(
+            store,
+            &self.storage_prefix,
+            min.map(|b| b.to_bound()),
+            max.map(|b| b.to_bound()),
+            order,
+        )
+        .map(move |kv| (de_fn)(store, &pk_name, kv));
+        Box::new(mapped)
+    }
+
     pub fn range2<'a>(
         &self,
         store: &'a dyn Storage,

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -11,7 +11,7 @@ use crate::helpers::{namespaces_with_key, nested_namespaces_with_key};
 use crate::int_key::CwIntKey;
 use crate::iter_helpers::{concat, deserialize_kv, deserialize_v, trim};
 use crate::keys::{Bounder, Key};
-use crate::{Endian, Prefixer};
+use crate::{Endian, Prefixer, PrimaryKey};
 
 /// Bound is used to defines the two ends of a range, more explicit than Option<u8>
 /// None means that we don't limit that side of the range at all.
@@ -46,7 +46,7 @@ impl Bound {
 }
 
 #[derive(Clone, Debug)]
-pub enum Bound2<'a, K: Bounder<'a>> {
+pub enum Bound2<'a, K: PrimaryKey<'a>> {
     Inclusive((K, PhantomData<&'a bool>)),
     Exclusive((K, PhantomData<&'a bool>)),
 }

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -10,7 +10,7 @@ use crate::de::KeyDeserialize;
 use crate::helpers::{namespaces_with_key, nested_namespaces_with_key};
 use crate::int_key::CwIntKey;
 use crate::iter_helpers::{concat, deserialize_kv, deserialize_v, trim};
-use crate::keys::{Bounder, Key};
+use crate::keys::Key;
 use crate::{Endian, Prefixer, PrimaryKey};
 
 /// Bound is used to defines the two ends of a range, more explicit than Option<u8>
@@ -51,7 +51,7 @@ pub enum Bound2<'a, K: PrimaryKey<'a>> {
     Exclusive((K, PhantomData<&'a bool>)),
 }
 
-impl<'a, K: Bounder<'a>> Bound2<'a, K> {
+impl<'a, K: PrimaryKey<'a>> Bound2<'a, K> {
     pub fn inclusive<T: Into<K>>(k: T) -> Self {
         Self::Inclusive((k.into(), PhantomData))
     }
@@ -240,7 +240,7 @@ where
 
 impl<'b, K, T, B> Prefix<K, T, B>
 where
-    B: Bounder<'b>,
+    B: PrimaryKey<'b>,
     K: KeyDeserialize,
     T: Serialize + DeserializeOwned,
 {

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -8,10 +8,9 @@ use std::ops::Deref;
 
 use crate::de::KeyDeserialize;
 use crate::helpers::{namespaces_with_key, nested_namespaces_with_key};
-use crate::int_key::CwIntKey;
 use crate::iter_helpers::{concat, deserialize_kv, deserialize_v, trim};
 use crate::keys::Key;
-use crate::{Endian, Prefixer, PrimaryKey};
+use crate::{Prefixer, PrimaryKey};
 
 /// `RawBound` is used to define the two ends of a range, more explicit than `Option<u8>`.
 /// `None` means that we don't limit that side of the range at all.
@@ -22,28 +21,6 @@ use crate::{Endian, Prefixer, PrimaryKey};
 pub enum RawBound {
     Inclusive(Vec<u8>),
     Exclusive(Vec<u8>),
-}
-
-impl RawBound {
-    /// Turns optional binary, like Option<CanonicalAddr> into an inclusive bound
-    pub fn inclusive<T: Into<Vec<u8>>>(limit: T) -> Self {
-        RawBound::Inclusive(limit.into())
-    }
-
-    /// Turns optional binary, like Option<CanonicalAddr> into an exclusive bound
-    pub fn exclusive<T: Into<Vec<u8>>>(limit: T) -> Self {
-        RawBound::Exclusive(limit.into())
-    }
-
-    /// Turns an int, like Option<u32> into an inclusive bound
-    pub fn inclusive_int<T: CwIntKey + Endian>(limit: T) -> Self {
-        RawBound::Inclusive(limit.to_cw_bytes().into())
-    }
-
-    /// Turns an int, like Option<u64> into an exclusive bound
-    pub fn exclusive_int<T: CwIntKey + Endian>(limit: T) -> Self {
-        RawBound::Exclusive(limit.to_cw_bytes().into())
-    }
 }
 
 /// `Bound` is used to define the two ends of a range.

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -13,10 +13,11 @@ use crate::iter_helpers::{concat, deserialize_kv, deserialize_v, trim};
 use crate::keys::Key;
 use crate::{Endian, Prefixer, PrimaryKey};
 
-/// Bound is used to defines the two ends of a range, more explicit than Option<u8>
-/// None means that we don't limit that side of the range at all.
-/// Include means we use the given bytes as a limit and *include* anything at that exact key
-/// Exclude means we use the given bytes as a limit and *exclude* anything at that exact key
+/// `RawBound` is used to define the two ends of a range, more explicit than `Option<u8>`.
+/// `None` means that we don't limit that side of the range at all.
+/// `Inclusive` means we use the given bytes as a limit and *include* anything at that exact key.
+/// `Exclusive` means we use the given bytes as a limit and *exclude* anything at that exact key.
+/// See `Bound` for a type safe way to build these bounds.
 #[derive(Clone, Debug)]
 pub enum RawBound {
     Inclusive(Vec<u8>),
@@ -45,6 +46,10 @@ impl RawBound {
     }
 }
 
+/// `Bound` is used to define the two ends of a range.
+/// `None` means that we don't limit that side of the range at all.
+/// `Inclusive` means we use the given value as a limit and *include* anything at that exact key.
+/// `Exclusive` means we use the given value as a limit and *exclude* anything at that exact key.
 #[derive(Clone, Debug)]
 pub enum Bound<'a, K: PrimaryKey<'a>> {
     Inclusive((K, PhantomData<&'a bool>)),

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -54,6 +54,8 @@ impl RawBound {
 pub enum Bound<'a, K: PrimaryKey<'a>> {
     Inclusive((K, PhantomData<&'a bool>)),
     Exclusive((K, PhantomData<&'a bool>)),
+    InclusiveRaw(Vec<u8>),
+    ExclusiveRaw(Vec<u8>),
 }
 
 impl<'a, K: PrimaryKey<'a>> Bound<'a, K> {
@@ -67,8 +69,10 @@ impl<'a, K: PrimaryKey<'a>> Bound<'a, K> {
 
     pub fn to_raw_bound(&self) -> RawBound {
         match self {
-            Bound::Exclusive((k, _)) => RawBound::Exclusive(k.joined_key()),
             Bound::Inclusive((k, _)) => RawBound::Inclusive(k.joined_key()),
+            Bound::Exclusive((k, _)) => RawBound::Exclusive(k.joined_key()),
+            Bound::ExclusiveRaw(raw_k) => RawBound::Exclusive(raw_k.clone()),
+            Bound::InclusiveRaw(raw_k) => RawBound::Inclusive(raw_k.clone()),
         }
     }
 }
@@ -423,7 +427,7 @@ mod test {
         let res: StdResult<Vec<_>> = prefix
             .range_raw(
                 &store,
-                Some(RawBound::Inclusive(b"ra".to_vec())),
+                Some(Bound::inclusive(b"ra".to_vec())),
                 None,
                 Order::Ascending,
             )
@@ -433,7 +437,7 @@ mod test {
         let res: StdResult<Vec<_>> = prefix
             .range_raw(
                 &store,
-                Some(RawBound::Exclusive(b"ra".to_vec())),
+                Some(Bound::exclusive(b"ra".to_vec())),
                 None,
                 Order::Ascending,
             )
@@ -443,7 +447,7 @@ mod test {
         let res: StdResult<Vec<_>> = prefix
             .range_raw(
                 &store,
-                Some(RawBound::Exclusive(b"r".to_vec())),
+                Some(Bound::exclusive(b"r".to_vec())),
                 None,
                 Order::Ascending,
             )
@@ -455,7 +459,7 @@ mod test {
             .range_raw(
                 &store,
                 None,
-                Some(RawBound::Inclusive(b"ra".to_vec())),
+                Some(Bound::inclusive(b"ra".to_vec())),
                 Order::Descending,
             )
             .collect();
@@ -465,7 +469,7 @@ mod test {
             .range_raw(
                 &store,
                 None,
-                Some(RawBound::Exclusive(b"ra".to_vec())),
+                Some(Bound::exclusive(b"ra".to_vec())),
                 Order::Descending,
             )
             .collect();
@@ -475,7 +479,7 @@ mod test {
             .range_raw(
                 &store,
                 None,
-                Some(RawBound::Exclusive(b"rb".to_vec())),
+                Some(Bound::exclusive(b"rb".to_vec())),
                 Order::Descending,
             )
             .collect();
@@ -485,8 +489,8 @@ mod test {
         let res: StdResult<Vec<_>> = prefix
             .range_raw(
                 &store,
-                Some(RawBound::Inclusive(b"ra".to_vec())),
-                Some(RawBound::Exclusive(b"zi".to_vec())),
+                Some(Bound::inclusive(b"ra".to_vec())),
+                Some(Bound::exclusive(b"zi".to_vec())),
                 Order::Ascending,
             )
             .collect();
@@ -495,8 +499,8 @@ mod test {
         let res: StdResult<Vec<_>> = prefix
             .range_raw(
                 &store,
-                Some(RawBound::Inclusive(b"ra".to_vec())),
-                Some(RawBound::Exclusive(b"zi".to_vec())),
+                Some(Bound::inclusive(b"ra".to_vec())),
+                Some(Bound::exclusive(b"zi".to_vec())),
                 Order::Descending,
             )
             .collect();
@@ -505,8 +509,8 @@ mod test {
         let res: StdResult<Vec<_>> = prefix
             .range_raw(
                 &store,
-                Some(RawBound::Inclusive(b"ra".to_vec())),
-                Some(RawBound::Inclusive(b"zi".to_vec())),
+                Some(Bound::inclusive(b"ra".to_vec())),
+                Some(Bound::inclusive(b"zi".to_vec())),
                 Order::Descending,
             )
             .collect();
@@ -515,8 +519,8 @@ mod test {
         let res: StdResult<Vec<_>> = prefix
             .range_raw(
                 &store,
-                Some(RawBound::Exclusive(b"ra".to_vec())),
-                Some(RawBound::Exclusive(b"zi".to_vec())),
+                Some(Bound::exclusive(b"ra".to_vec())),
+                Some(Bound::exclusive(b"zi".to_vec())),
                 Order::Ascending,
             )
             .collect();

--- a/packages/storage-plus/src/prefix.rs
+++ b/packages/storage-plus/src/prefix.rs
@@ -238,16 +238,16 @@ where
     }
 }
 
-impl<'p, K, T> Prefix<K, T>
+impl<'b, K, T> Prefix<K, T>
 where
-    K: KeyDeserialize + Bounder<'p>,
+    K: KeyDeserialize + Bounder<'b>,
     T: Serialize + DeserializeOwned,
 {
     pub fn range2<'a>(
         &self,
         store: &'a dyn Storage,
-        min: Option<Bound2<'p, K>>,
-        max: Option<Bound2<'p, K>>,
+        min: Option<Bound2<'b, K>>,
+        max: Option<Bound2<'b, K>>,
         order: Order,
     ) -> Box<dyn Iterator<Item = StdResult<(K::Output, T)>> + 'a>
     where

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -132,7 +132,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prefix::Bound;
+    use crate::bound::Bound;
     use cosmwasm_std::testing::MockStorage;
 
     type TestItem = SnapshotItem<'static, u64>;

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -132,6 +132,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prefix::Bound;
     use cosmwasm_std::testing::MockStorage;
 
     type TestItem = SnapshotItem<'static, u64>;
@@ -283,7 +284,6 @@ mod tests {
     #[test]
     #[cfg(feature = "iterator")]
     fn changelog_range_works() {
-        use crate::RawBound;
         use cosmwasm_std::Order;
 
         let mut store = MockStorage::new();
@@ -316,12 +316,7 @@ mod tests {
         // let's try to iterate over a changelog range
         let all: StdResult<Vec<_>> = EVERY
             .changelog()
-            .range(
-                &store,
-                Some(RawBound::exclusive_int(3u64)),
-                None,
-                Order::Ascending,
-            )
+            .range(&store, Some(Bound::exclusive(3u64)), None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(1, all.len());

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     #[cfg(feature = "iterator")]
     fn changelog_range_works() {
-        use crate::Bound;
+        use crate::RawBound;
         use cosmwasm_std::Order;
 
         let mut store = MockStorage::new();
@@ -318,7 +318,7 @@ mod tests {
             .changelog()
             .range(
                 &store,
-                Some(Bound::exclusive_int(3u64)),
+                Some(RawBound::exclusive_int(3u64)),
                 None,
                 Order::Ascending,
             )

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -514,12 +514,7 @@ mod tests {
         let all: StdResult<Vec<_>> = EVERY
             .changelog()
             .prefix("A")
-            .range(
-                &store,
-                Some(RawBound::inclusive_int(3u64)),
-                None,
-                Order::Ascending,
-            )
+            .range(&store, Some(Bound::inclusive(3u64)), None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(1, all.len());
@@ -542,12 +537,7 @@ mod tests {
 
         // let's try to iterate over a range
         let all: StdResult<Vec<_>> = EVERY
-            .range(
-                &store,
-                Some(RawBound::Inclusive(b"C".to_vec())),
-                None,
-                Order::Ascending,
-            )
+            .range(&store, Some(Bound::inclusive("C")), None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(2, all.len());
@@ -555,12 +545,7 @@ mod tests {
 
         // let's try to iterate over a more restrictive range
         let all: StdResult<Vec<_>> = EVERY
-            .range(
-                &store,
-                Some(RawBound::Inclusive(b"D".to_vec())),
-                None,
-                Order::Ascending,
-            )
+            .range(&store, Some(Bound::inclusive("D")), None, Order::Ascending)
             .collect();
         let all = all.unwrap();
         assert_eq!(1, all.len());

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -3,14 +3,15 @@ use serde::Serialize;
 
 use cosmwasm_std::{StdError, StdResult, Storage};
 
+use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::PrimaryKey;
 use crate::map::Map;
 use crate::path::Path;
-use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, Snapshot};
-use crate::{Prefixer, Strategy};
+use crate::{Bound, Prefixer, Strategy};
 
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -10,7 +10,7 @@ use crate::map::Map;
 use crate::path::Path;
 use crate::prefix::{namespaced_prefix_range, Prefix, PrefixBound};
 use crate::snapshot::{ChangeSet, Snapshot};
-use crate::{Bound, Prefixer, Strategy};
+use crate::{Prefixer, RawBound, Strategy};
 
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.
@@ -171,8 +171,8 @@ where
     pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::Record<T>>> + 'c>
     where
@@ -184,8 +184,8 @@ where
     pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c>
     where
@@ -228,8 +228,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(K::Output, T)>> + 'c>
     where
@@ -242,8 +242,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<Bound>,
-        max: Option<Bound>,
+        min: Option<RawBound>,
+        max: Option<RawBound>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<K::Output>> + 'c>
     where
@@ -516,7 +516,7 @@ mod tests {
             .prefix("A")
             .range(
                 &store,
-                Some(Bound::inclusive_int(3u64)),
+                Some(RawBound::inclusive_int(3u64)),
                 None,
                 Order::Ascending,
             )
@@ -544,7 +544,7 @@ mod tests {
         let all: StdResult<Vec<_>> = EVERY
             .range(
                 &store,
-                Some(Bound::Inclusive(b"C".to_vec())),
+                Some(RawBound::Inclusive(b"C".to_vec())),
                 None,
                 Order::Ascending,
             )
@@ -557,7 +557,7 @@ mod tests {
         let all: StdResult<Vec<_>> = EVERY
             .range(
                 &store,
-                Some(Bound::Inclusive(b"D".to_vec())),
+                Some(RawBound::Inclusive(b"D".to_vec())),
                 None,
                 Order::Ascending,
             )

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -73,7 +73,7 @@ where
         self.primary.key(k)
     }
 
-    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T> {
+    fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, K> {
         self.primary.no_prefix_raw()
     }
 

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -8,9 +8,9 @@ use crate::iter_helpers::deserialize_kv;
 use crate::keys::PrimaryKey;
 use crate::map::Map;
 use crate::path::Path;
-use crate::prefix::{namespaced_prefix_range, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
 use crate::snapshot::{ChangeSet, Snapshot};
-use crate::{Prefixer, RawBound, Strategy};
+use crate::{Prefixer, Strategy};
 
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.
@@ -171,8 +171,8 @@ where
     pub fn range_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, K>>,
+        max: Option<Bound<'a, K>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<cosmwasm_std::Record<T>>> + 'c>
     where
@@ -184,8 +184,8 @@ where
     pub fn keys_raw<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, K>>,
+        max: Option<Bound<'a, K>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'c>
     where
@@ -228,8 +228,8 @@ where
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, K>>,
+        max: Option<Bound<'a, K>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<(K::Output, T)>> + 'c>
     where
@@ -242,8 +242,8 @@ where
     pub fn keys<'c>(
         &self,
         store: &'c dyn Storage,
-        min: Option<RawBound>,
-        max: Option<RawBound>,
+        min: Option<Bound<'a, K>>,
+        max: Option<Bound<'a, K>>,
         order: cosmwasm_std::Order,
     ) -> Box<dyn Iterator<Item = StdResult<K::Output>> + 'c>
     where
@@ -253,15 +253,15 @@ where
         self.no_prefix().keys(store, min, max, order)
     }
 
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
         Prefix::new(self.primary.namespace(), &p.prefix())
     }
 
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
         Prefix::new(self.primary.namespace(), &p.prefix())
     }
 
-    fn no_prefix(&self) -> Prefix<K, T> {
+    fn no_prefix(&self) -> Prefix<K, T, K> {
         Prefix::new(self.primary.namespace(), &[])
     }
 }

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -6,7 +6,8 @@ pub use item::SnapshotItem;
 pub use map::SnapshotMap;
 
 use crate::de::KeyDeserialize;
-use crate::{Map, Prefixer, PrimaryKey, RawBound};
+use crate::prefix::Bound;
+use crate::{Map, Prefixer, PrimaryKey};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -79,12 +80,12 @@ where
         // most recent checkpoint
         let checkpoint = self
             .checkpoints
-            .range_raw(store, None, None, Order::Descending)
+            .range(store, None, None, Order::Descending)
             .next()
             .transpose()?;
         if let Some((height, _)) = checkpoint {
             // any changelog for the given key since then?
-            let start = RawBound::inclusive(height);
+            let start = Bound::inclusive(height);
             let first = self
                 .changelog
                 .prefix(k.clone())
@@ -143,7 +144,7 @@ where
 
         // this will look for the first snapshot of height >= given height
         // If None, there is no snapshot since that time.
-        let start = RawBound::inclusive_int(height);
+        let start = Bound::inclusive(height);
         let first = self
             .changelog
             .prefix(key)

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -5,8 +5,8 @@ mod map;
 pub use item::SnapshotItem;
 pub use map::SnapshotMap;
 
+use crate::bound::Bound;
 use crate::de::KeyDeserialize;
-use crate::prefix::Bound;
 use crate::{Map, Prefixer, PrimaryKey};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -6,7 +6,7 @@ pub use item::SnapshotItem;
 pub use map::SnapshotMap;
 
 use crate::de::KeyDeserialize;
-use crate::{Bound, Map, Prefixer, PrimaryKey};
+use crate::{Map, Prefixer, PrimaryKey, RawBound};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -84,7 +84,7 @@ where
             .transpose()?;
         if let Some((height, _)) = checkpoint {
             // any changelog for the given key since then?
-            let start = Bound::inclusive(height);
+            let start = RawBound::inclusive(height);
             let first = self
                 .changelog
                 .prefix(k.clone())
@@ -143,7 +143,7 @@ where
 
         // this will look for the first snapshot of height >= given height
         // If None, there is no snapshot since that time.
-        let start = Bound::inclusive_int(height);
+        let start = RawBound::inclusive_int(height);
         let first = self
             .changelog
             .prefix(key)

--- a/packages/utils/src/pagination.rs
+++ b/packages/utils/src/pagination.rs
@@ -37,7 +37,7 @@ pub fn calc_range_start_string(start_after: Option<String>) -> Option<Vec<u8>> {
 mod test {
     use super::*;
     use cosmwasm_std::{testing::mock_dependencies, Order};
-    use cw_storage_plus::{RawBound, Map};
+    use cw_storage_plus::{Bound, Map};
 
     pub const HOLDERS: Map<&Addr, usize> = Map::new("some_data");
     const LIMIT: usize = 30;
@@ -64,7 +64,7 @@ mod test {
                 Some(addr_from_i(j * LIMIT - 1))
             };
 
-            let start = calc_range_start(start_after).map(RawBound::exclusive);
+            let start = calc_range_start(start_after).map(Bound::ExclusiveRaw);
 
             let holders = HOLDERS
                 .keys(&deps.storage, start, None, Order::Ascending)
@@ -93,7 +93,7 @@ mod test {
         for j in 0..4 {
             let end_before = Some(addr_from_i(total_elements_count - j * LIMIT));
 
-            let end = calc_range_end(end_before).map(RawBound::exclusive);
+            let end = calc_range_end(end_before).map(Bound::ExclusiveRaw);
 
             let holders = HOLDERS
                 .keys(&deps.storage, None, end, Order::Descending)

--- a/packages/utils/src/pagination.rs
+++ b/packages/utils/src/pagination.rs
@@ -37,7 +37,7 @@ pub fn calc_range_start_string(start_after: Option<String>) -> Option<Vec<u8>> {
 mod test {
     use super::*;
     use cosmwasm_std::{testing::mock_dependencies, Order};
-    use cw_storage_plus::{Bound, Map};
+    use cw_storage_plus::{RawBound, Map};
 
     pub const HOLDERS: Map<&Addr, usize> = Map::new("some_data");
     const LIMIT: usize = 30;
@@ -64,7 +64,7 @@ mod test {
                 Some(addr_from_i(j * LIMIT - 1))
             };
 
-            let start = calc_range_start(start_after).map(Bound::exclusive);
+            let start = calc_range_start(start_after).map(RawBound::exclusive);
 
             let holders = HOLDERS
                 .keys(&deps.storage, start, None, Order::Ascending)
@@ -93,7 +93,7 @@ mod test {
         for j in 0..4 {
             let end_before = Some(addr_from_i(total_elements_count - j * LIMIT));
 
-            let end = calc_range_end(end_before).map(Bound::exclusive);
+            let end = calc_range_end(end_before).map(RawBound::exclusive);
 
             let holders = HOLDERS
                 .keys(&deps.storage, None, end, Order::Descending)


### PR DESCRIPTION
Closes #462. Implements typed range bounds, following the same approach than `PrefixBound`. Also introduces a couple raw variants, for flexibility and generality.

Did all the changes in this PR, except for some refactoring, that will be published separately.
Lots of changes, but mostly cosmetic. The main impls are in keys.rs, where `Bound` was renamed to `RawBound`, and a new typed `Bound` was introduced. All this will be moved to its own `bound.rs` module for clarity (in a follow-up).

There's also a new `Bounder` trait, to build bounds from the keys (i.e. `key.inclusive_bound()` syntax), but it is mostly accessory / cosmetic.

Some small follow-ups / questions from here:

- Deprecate `prefix_range`? After this new syntax for bounds, `prefix_range` is a little redundant. It's still clearer than using composite keys with empty elements. So, I'm not sure here. 
- Deprecate / adapt raw index key helpers. We either adapt the `index_key` helpers to return typed keys, or deprecate them entirely.
- Missing `prefix_range_raw()` impls. If we don't deprecate it, let's add these for completeness in:
    - `SnapshotMap`
    - `IndexedSnapshotMap`
    - `UniqueIndex`
- Missing `sub_prefix_range/_raw()`. If we don't deprecate it, let's decide if we add these or not (only really useful for triple keys).
- Simplify / consolidate trait bound definitions. There are a lot of trait bounds over these structs, and perhaps some of those can be simplified / consolidated.

**Note**: ~~CI checks are failing due to the no-iterator variant. Solved in #629.~~ (fixed / merged)