### PR TITLE
Type safe bounds refactor

### DIFF
--- a/packages/storage-plus/src/bound.rs
+++ b/packages/storage-plus/src/bound.rs
@@ -1,0 +1,184 @@
+#![cfg(feature = "iterator")]
+
+use cosmwasm_std::Addr;
+use std::marker::PhantomData;
+
+use crate::de::KeyDeserialize;
+use crate::{Prefixer, PrimaryKey};
+
+/// `RawBound` is used to define the two ends of a range, more explicit than `Option<u8>`.
+/// `None` means that we don't limit that side of the range at all.
+/// `Inclusive` means we use the given bytes as a limit and *include* anything at that exact key.
+/// `Exclusive` means we use the given bytes as a limit and *exclude* anything at that exact key.
+/// See `Bound` for a type safe way to build these bounds.
+#[derive(Clone, Debug)]
+pub enum RawBound {
+    Inclusive(Vec<u8>),
+    Exclusive(Vec<u8>),
+}
+
+/// `Bound` is used to define the two ends of a range.
+/// `None` means that we don't limit that side of the range at all.
+/// `Inclusive` means we use the given value as a limit and *include* anything at that exact key.
+/// `Exclusive` means we use the given value as a limit and *exclude* anything at that exact key.
+#[derive(Clone, Debug)]
+pub enum Bound<'a, K: PrimaryKey<'a>> {
+    Inclusive((K, PhantomData<&'a bool>)),
+    Exclusive((K, PhantomData<&'a bool>)),
+    InclusiveRaw(Vec<u8>),
+    ExclusiveRaw(Vec<u8>),
+}
+
+impl<'a, K: PrimaryKey<'a>> Bound<'a, K> {
+    pub fn inclusive<T: Into<K>>(k: T) -> Self {
+        Self::Inclusive((k.into(), PhantomData))
+    }
+
+    pub fn exclusive<T: Into<K>>(k: T) -> Self {
+        Self::Exclusive((k.into(), PhantomData))
+    }
+
+    pub fn to_raw_bound(&self) -> RawBound {
+        match self {
+            Bound::Inclusive((k, _)) => RawBound::Inclusive(k.joined_key()),
+            Bound::Exclusive((k, _)) => RawBound::Exclusive(k.joined_key()),
+            Bound::ExclusiveRaw(raw_k) => RawBound::Exclusive(raw_k.clone()),
+            Bound::InclusiveRaw(raw_k) => RawBound::Inclusive(raw_k.clone()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum PrefixBound<'a, K: Prefixer<'a>> {
+    Inclusive((K, PhantomData<&'a bool>)),
+    Exclusive((K, PhantomData<&'a bool>)),
+}
+
+impl<'a, K: Prefixer<'a>> PrefixBound<'a, K> {
+    pub fn inclusive<T: Into<K>>(k: T) -> Self {
+        Self::Inclusive((k.into(), PhantomData))
+    }
+
+    pub fn exclusive<T: Into<K>>(k: T) -> Self {
+        Self::Exclusive((k.into(), PhantomData))
+    }
+
+    pub fn to_raw_bound(&self) -> RawBound {
+        match self {
+            PrefixBound::Exclusive((k, _)) => RawBound::Exclusive(k.joined_prefix()),
+            PrefixBound::Inclusive((k, _)) => RawBound::Inclusive(k.joined_prefix()),
+        }
+    }
+}
+
+pub trait Bounder<'a>: PrimaryKey<'a> + Sized {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>>;
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>>;
+}
+
+impl<'a> Bounder<'a> for () {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        None
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        None
+    }
+}
+
+impl<'a> Bounder<'a> for &'a [u8] {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<
+        'a,
+        T: PrimaryKey<'a> + KeyDeserialize + Prefixer<'a> + Clone,
+        U: PrimaryKey<'a> + KeyDeserialize + Clone,
+    > Bounder<'a> for (T, U)
+{
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<
+        'a,
+        T: PrimaryKey<'a> + Prefixer<'a> + Clone,
+        U: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize + Clone,
+        V: PrimaryKey<'a> + KeyDeserialize + Clone,
+    > Bounder<'a> for (T, U, V)
+{
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for &'a str {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for String {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for Vec<u8> {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for &'a Addr {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+impl<'a> Bounder<'a> for Addr {
+    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::inclusive(self))
+    }
+    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+        Some(Bound::exclusive(self))
+    }
+}
+
+macro_rules! integer_bound {
+    (for $($t:ty),+) => {
+        $(impl<'a> Bounder<'a> for $t {
+            fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
+                Some(Bound::inclusive(self))
+            }
+            fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
+                Some(Bound::exclusive(self))
+            }
+        })*
+    }
+}
+
+integer_bound!(for i8, u8, i16, u16, i32, u32, i64, u64);

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1,6 +1,7 @@
 // this module requires iterator to be useful at all
 #![cfg(feature = "iterator")]
 
+use crate::PrefixBound;
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -10,8 +11,8 @@ use crate::indexes::Index;
 use crate::iter_helpers::{deserialize_kv, deserialize_v};
 use crate::keys::{Prefixer, PrimaryKey};
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
-use crate::Path;
+use crate::prefix::{namespaced_prefix_range, Prefix};
+use crate::{Bound, Path};
 
 pub trait IndexList<T> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<T>> + '_>;

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -8,9 +8,10 @@ use serde::Serialize;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::{Prefixer, PrimaryKey};
-use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, SnapshotMap};
-use crate::{IndexList, Map, Path, Strategy};
+use crate::PrefixBound;
+use crate::{Bound, IndexList, Map, Path, Strategy};
 
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
 pub struct IndexedSnapshotMap<'a, K, T, I> {

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -6,12 +6,13 @@ use serde::Serialize;
 
 use cosmwasm_std::{from_slice, Order, Record, StdError, StdResult, Storage};
 
+use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
 use crate::helpers::namespaces_with_key;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, Bound, PrefixBound};
-use crate::{Index, Prefix, Prefixer, PrimaryKey};
+use crate::prefix::namespaced_prefix_range;
+use crate::{Bound, Index, Prefix, Prefixer, PrimaryKey};
 use std::marker::PhantomData;
 
 /// MultiIndex stores (namespace, index_name, idx_value, pk) -> b"pk_len".

--- a/packages/storage-plus/src/indexes/unique.rs
+++ b/packages/storage-plus/src/indexes/unique.rs
@@ -8,11 +8,12 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{from_slice, Binary, Order, Record, StdError, StdResult, Storage};
 
+use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
-use crate::prefix::{namespaced_prefix_range, Bound, PrefixBound};
-use crate::{Index, Prefix, Prefixer, PrimaryKey};
+use crate::prefix::namespaced_prefix_range;
+use crate::{Bound, Index, Prefix, Prefixer, PrimaryKey};
 
 /// UniqueRef stores Binary(Vec[u8]) representation of private key and index value
 #[derive(Deserialize, Serialize)]

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -3,7 +3,6 @@ use cosmwasm_std::Addr;
 use crate::de::KeyDeserialize;
 use crate::helpers::namespaces_with_key;
 use crate::int_key::CwIntKey;
-use crate::prefix::Bound;
 
 #[derive(Debug)]
 pub enum Key<'a> {
@@ -300,118 +299,6 @@ macro_rules! integer_prefix {
 }
 
 integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64);
-
-pub trait Bounder<'a>: PrimaryKey<'a> + Sized {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>>;
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>>;
-}
-
-impl<'a> Bounder<'a> for () {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        None
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        None
-    }
-}
-
-impl<'a> Bounder<'a> for &'a [u8] {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<
-        'a,
-        T: PrimaryKey<'a> + KeyDeserialize + Prefixer<'a> + Clone,
-        U: PrimaryKey<'a> + KeyDeserialize + Clone,
-    > Bounder<'a> for (T, U)
-{
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<
-        'a,
-        T: PrimaryKey<'a> + Prefixer<'a> + Clone,
-        U: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize + Clone,
-        V: PrimaryKey<'a> + KeyDeserialize + Clone,
-    > Bounder<'a> for (T, U, V)
-{
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for &'a str {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for String {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for Vec<u8> {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for &'a Addr {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-impl<'a> Bounder<'a> for Addr {
-    fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::inclusive(self))
-    }
-    fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-        Some(Bound::exclusive(self))
-    }
-}
-
-macro_rules! integer_bound {
-    (for $($t:ty),+) => {
-        $(impl<'a> Bounder<'a> for $t {
-            fn inclusive_bound(self) -> Option<Bound<'a, Self>> {
-                Some(Bound::inclusive(self))
-            }
-            fn exclusive_bound(self) -> Option<Bound<'a, Self>> {
-                Some(Bound::exclusive(self))
-            }
-        })*
-    }
-}
-
-integer_bound!(for i8, u8, i16, u16, i32, u32, i64, u64);
 
 #[cfg(test)]
 mod test {

--- a/packages/storage-plus/src/keys_old.rs
+++ b/packages/storage-plus/src/keys_old.rs
@@ -1,6 +1,8 @@
 use crate::de::KeyDeserialize;
 use crate::keys::Key;
-use crate::{Bound, Bounder, Endian, Prefixer, PrimaryKey};
+#[cfg(feature = "iterator")]
+use crate::{Bound, Bounder};
+use crate::{Endian, Prefixer, PrimaryKey};
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -62,6 +64,7 @@ impl<'a, T: Endian> Prefixer<'a> for IntKeyOld<T> {
 }
 
 // this auto-implements Bounder for all the IntKey types
+#[cfg(feature = "iterator")]
 impl<'a, T: Endian> Bounder<'a> for IntKeyOld<T>
 where
     IntKeyOld<T>: KeyDeserialize,

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -1,3 +1,4 @@
+mod bound;
 mod de;
 mod de_old;
 mod endian;
@@ -15,6 +16,8 @@ mod path;
 mod prefix;
 mod snapshot;
 
+#[cfg(feature = "iterator")]
+pub use bound::{Bound, Bounder, PrefixBound, RawBound};
 pub use endian::Endian;
 #[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};
@@ -28,11 +31,11 @@ pub use indexes::UniqueIndex;
 pub use indexes::{index_string, index_string_tuple, index_triple, index_tuple, Index};
 pub use int_key::CwIntKey;
 pub use item::Item;
-pub use keys::{Bounder, Key, Prefixer, PrimaryKey};
+pub use keys::{Key, Prefixer, PrimaryKey};
 pub use keys_old::IntKeyOld;
 pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
-pub use prefix::{range_with_prefix, Bound, Prefix, PrefixBound, RawBound};
+pub use prefix::{range_with_prefix, Prefix};
 #[cfg(feature = "iterator")]
 pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -3,17 +3,18 @@ use serde::Serialize;
 use std::marker::PhantomData;
 
 #[cfg(feature = "iterator")]
+use crate::bound::{Bound, Bounder, PrefixBound};
+#[cfg(feature = "iterator")]
 use crate::de::KeyDeserialize;
 use crate::helpers::query_raw;
 #[cfg(feature = "iterator")]
 use crate::iter_helpers::{deserialize_kv, deserialize_v};
 #[cfg(feature = "iterator")]
 use crate::keys::Prefixer;
-use crate::keys::{Bounder, Key, PrimaryKey};
+use crate::keys::{Key, PrimaryKey};
 use crate::path::Path;
-use crate::prefix::Bound;
 #[cfg(feature = "iterator")]
-use crate::prefix::{namespaced_prefix_range, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Prefix};
 use cosmwasm_std::{from_slice, Addr, QuerierWrapper, StdError, StdResult, Storage};
 
 #[derive(Debug, Clone)]
@@ -263,6 +264,7 @@ mod test {
     use cosmwasm_std::{Order, StdResult};
 
     use crate::int_key::CwIntKey;
+    #[cfg(feature = "iterator")]
     use crate::IntKeyOld;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]

--- a/packages/storage-plus/src/snapshot/item.rs
+++ b/packages/storage-plus/src/snapshot/item.rs
@@ -132,7 +132,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prefix::Bound;
+    use crate::bound::Bound;
     use cosmwasm_std::testing::MockStorage;
 
     type TestItem = SnapshotItem<'static, u64>;

--- a/packages/storage-plus/src/snapshot/map.rs
+++ b/packages/storage-plus/src/snapshot/map.rs
@@ -3,14 +3,15 @@ use serde::Serialize;
 
 use cosmwasm_std::{StdError, StdResult, Storage};
 
+use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::PrimaryKey;
 use crate::map::Map;
 use crate::path::Path;
-use crate::prefix::{namespaced_prefix_range, Bound, Prefix, PrefixBound};
+use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, Snapshot};
-use crate::{Prefixer, Strategy};
+use crate::{Bound, Prefixer, Strategy};
 
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.

--- a/packages/storage-plus/src/snapshot/mod.rs
+++ b/packages/storage-plus/src/snapshot/mod.rs
@@ -5,8 +5,8 @@ mod map;
 pub use item::SnapshotItem;
 pub use map::SnapshotMap;
 
+use crate::bound::Bound;
 use crate::de::KeyDeserialize;
-use crate::prefix::Bound;
 use crate::{Map, Prefixer, PrimaryKey};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;


### PR DESCRIPTION
#627 follow-up. Refactored bounds-related stuff into its own module. This helps fix features, and so the no-iterator variant builds properly here.