### PR TITLE
Update ics20 contract

### DIFF
--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -122,7 +122,7 @@ pub fn execute_transfer(
     );
     packet.validate()?;
 
-    // prepare message and set proper gas limit
+    // prepare ibc message
     let msg = IbcMsg::SendPacket {
         channel_id: msg.channel,
         data: to_binary(&packet)?,

--- a/contracts/cw20-ics20/src/error.rs
+++ b/contracts/cw20-ics20/src/error.rs
@@ -49,6 +49,12 @@ pub enum ContractError {
 
     #[error("Got a submessage reply with unknown id: {id}")]
     UnknownReplyId { id: u64 },
+
+    #[error("You cannot lower the gas limit for a contract on the allow list")]
+    CannotLowerGas,
+
+    #[error("Only the governance contract can do this")]
+    Unauthorized,
 }
 
 impl From<FromUtf8Error> for ContractError {

--- a/contracts/cw20-ics20/src/error.rs
+++ b/contracts/cw20-ics20/src/error.rs
@@ -55,6 +55,9 @@ pub enum ContractError {
 
     #[error("Only the governance contract can do this")]
     Unauthorized,
+
+    #[error("You can only send cw20 tokens that have been explicitly allowed by governance")]
+    NotOnAllowList,
 }
 
 impl From<FromUtf8Error> for ContractError {

--- a/contracts/cw20-ics20/src/ibc.rs
+++ b/contracts/cw20-ics20/src/ibc.rs
@@ -181,6 +181,18 @@ pub fn ibc_packet_receive(
                 attr("success", "true"),
             ];
             let to_send = Amount::from_parts(denom.into(), msg.amount);
+
+            // TODO: add check..
+            // if cw20 token, ensure it is whitelisted, and use the registered gas limit
+            //     let gas_limit = if let Amount::Cw20(coin) = &amount {
+            //         let addr = deps.api.addr_validate(&coin.address)?;
+            //         let allow = ALLOW_LIST
+            //             .may_load(deps.storage, &addr)?
+            //             .ok_or(ContractError::NotOnAllowList)?;
+            //         allow.gas_limit
+            //     } else {
+            //         None
+            //     };
             let msg = send_amount(to_send, msg.receiver);
             IbcReceiveResponse::new()
                 .set_ack(ack_success())

--- a/contracts/cw20-ics20/src/ibc.rs
+++ b/contracts/cw20-ics20/src/ibc.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    attr, entry_point, from_binary, to_binary, BankMsg, Binary, ContractResult, DepsMut, Env,
+    attr, entry_point, from_binary, to_binary, BankMsg, Binary, ContractResult, Deps, DepsMut, Env,
     IbcBasicResponse, IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg, IbcChannelOpenMsg,
     IbcEndpoint, IbcOrder, IbcPacket, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
     IbcReceiveResponse, Reply, Response, StdResult, SubMsg, Uint128, WasmMsg,
@@ -10,7 +10,7 @@ use cosmwasm_std::{
 
 use crate::amount::Amount;
 use crate::error::{ContractError, Never};
-use crate::state::{ChannelInfo, CHANNEL_INFO, CHANNEL_STATE};
+use crate::state::{ChannelInfo, ALLOW_LIST, CHANNEL_INFO, CHANNEL_STATE};
 use cw20::Cw20ExecuteMsg;
 
 pub const ICS20_VERSION: &str = "ics20-1";
@@ -164,52 +164,15 @@ pub fn ibc_packet_receive(
 ) -> Result<IbcReceiveResponse, Never> {
     let packet = msg.packet;
 
-    let res = match do_ibc_packet_receive(deps, &packet) {
-        Ok(msg) => {
-            // build attributes first so we don't have to clone msg below
-            // similar event messages like ibctransfer module
-
-            // This cannot fail as we parse it in do_ibc_packet_receive. Best to pass the data somehow?
-            let denom = parse_voucher_denom(&msg.denom, &packet.src).unwrap();
-
-            let attributes = vec![
-                attr("action", "receive"),
-                attr("sender", &msg.sender),
-                attr("receiver", &msg.receiver),
-                attr("denom", denom),
-                attr("amount", msg.amount),
-                attr("success", "true"),
-            ];
-            let to_send = Amount::from_parts(denom.into(), msg.amount);
-
-            // TODO: add check..
-            // if cw20 token, ensure it is whitelisted, and use the registered gas limit
-            //     let gas_limit = if let Amount::Cw20(coin) = &amount {
-            //         let addr = deps.api.addr_validate(&coin.address)?;
-            //         let allow = ALLOW_LIST
-            //             .may_load(deps.storage, &addr)?
-            //             .ok_or(ContractError::NotOnAllowList)?;
-            //         allow.gas_limit
-            //     } else {
-            //         None
-            //     };
-            let msg = send_amount(to_send, msg.receiver);
-            IbcReceiveResponse::new()
-                .set_ack(ack_success())
-                .add_submessage(msg)
-                .add_attributes(attributes)
-        }
-        Err(err) => IbcReceiveResponse::new()
+    do_ibc_packet_receive(deps, &packet).or_else(|err| {
+        Ok(IbcReceiveResponse::new()
             .set_ack(ack_fail(err.to_string()))
             .add_attributes(vec![
                 attr("action", "receive"),
                 attr("success", "false"),
                 attr("error", err.to_string()),
-            ]),
-    };
-
-    // if we have funds, now send the tokens to the requested recipient
-    Ok(res)
+            ]))
+    })
 }
 
 // Returns local denom if the denom is an encoded voucher from the expected endpoint
@@ -238,7 +201,10 @@ fn parse_voucher_denom<'a>(
 }
 
 // this does the work of ibc_packet_receive, we wrap it to turn errors into acknowledgements
-fn do_ibc_packet_receive(deps: DepsMut, packet: &IbcPacket) -> Result<Ics20Packet, ContractError> {
+fn do_ibc_packet_receive(
+    deps: DepsMut,
+    packet: &IbcPacket,
+) -> Result<IbcReceiveResponse, ContractError> {
     let msg: Ics20Packet = from_binary(&packet.data)?;
     let channel = packet.dest.channel_id.clone();
 
@@ -246,7 +212,6 @@ fn do_ibc_packet_receive(deps: DepsMut, packet: &IbcPacket) -> Result<Ics20Packe
     // If it originated on our chain, it looks like "port/channel/ucosm".
     let denom = parse_voucher_denom(&msg.denom, &packet.src)?;
 
-    let amount = msg.amount;
     CHANNEL_STATE.update(
         deps.storage,
         (&channel, denom),
@@ -255,12 +220,48 @@ fn do_ibc_packet_receive(deps: DepsMut, packet: &IbcPacket) -> Result<Ics20Packe
             let mut cur = orig.ok_or(ContractError::InsufficientFunds {})?;
             cur.outstanding = cur
                 .outstanding
-                .checked_sub(amount)
+                .checked_sub(msg.amount)
                 .or(Err(ContractError::InsufficientFunds {}))?;
             Ok(cur)
         },
     )?;
-    Ok(msg)
+
+    let to_send = Amount::from_parts(denom.to_string(), msg.amount);
+    let gas_limit = check_gas_limit(deps.as_ref(), &to_send)?;
+
+    // build attributes first so we don't have to clone msg below
+    // similar event messages like ibctransfer module
+
+    let attributes = vec![
+        attr("action", "receive"),
+        attr("sender", &msg.sender),
+        attr("receiver", &msg.receiver),
+        attr("denom", denom),
+        attr("amount", msg.amount),
+        attr("success", "true"),
+    ];
+
+    let msg = send_amount(to_send, msg.receiver, gas_limit);
+    let res = IbcReceiveResponse::new()
+        .set_ack(ack_success())
+        .add_submessage(msg)
+        .add_attributes(attributes);
+
+    Ok(res)
+}
+
+fn check_gas_limit(deps: Deps, amount: &Amount) -> Result<Option<u64>, ContractError> {
+    match amount {
+        Amount::Cw20(coin) => {
+            // if cw20 token, use the registered gas limit, or error if not whitelisted
+            let addr = deps.api.addr_validate(&coin.address)?;
+            Ok(ALLOW_LIST
+                .may_load(deps.storage, &addr)?
+                .ok_or(ContractError::NotOnAllowList)?
+                .gas_limit)
+        }
+        _ => Ok(None),
+    }
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -318,7 +319,7 @@ fn on_packet_success(deps: DepsMut, packet: IbcPacket) -> Result<IbcBasicRespons
 
 // return the tokens to sender
 fn on_packet_failure(
-    _deps: DepsMut,
+    deps: DepsMut,
     packet: IbcPacket,
     err: String,
 ) -> Result<IbcBasicResponse, ContractError> {
@@ -335,13 +336,14 @@ fn on_packet_failure(
     ];
 
     let amount = Amount::from_parts(msg.denom, msg.amount);
-    let msg = send_amount(amount, msg.sender);
+    let gas_limit = check_gas_limit(deps.as_ref(), &amount)?;
+    let msg = send_amount(amount, msg.sender, gas_limit);
     Ok(IbcBasicResponse::new()
         .add_attributes(attributes)
         .add_submessage(msg))
 }
 
-fn send_amount(amount: Amount, recipient: String) -> SubMsg {
+fn send_amount(amount: Amount, recipient: String, gas_limit: Option<u64>) -> SubMsg {
     match amount {
         Amount::Native(coin) => SubMsg::reply_on_error(
             BankMsg::Send {
@@ -360,7 +362,9 @@ fn send_amount(amount: Amount, recipient: String) -> SubMsg {
                 msg: to_binary(&msg).unwrap(),
                 funds: vec![],
             };
-            SubMsg::reply_on_error(exec, SEND_TOKEN_ID)
+            let mut sub = SubMsg::reply_on_error(exec, SEND_TOKEN_ID);
+            sub.gas_limit = gas_limit;
+            sub
         }
     }
 }
@@ -401,7 +405,12 @@ mod test {
         assert_eq!(expected, encdoded.as_str());
     }
 
-    fn cw20_payment(amount: u128, address: &str, recipient: &str) -> SubMsg {
+    fn cw20_payment(
+        amount: u128,
+        address: &str,
+        recipient: &str,
+        gas_limit: Option<u64>,
+    ) -> SubMsg {
         let msg = Cw20ExecuteMsg::Transfer {
             recipient: recipient.into(),
             amount: Uint128::new(amount),
@@ -411,7 +420,9 @@ mod test {
             msg: to_binary(&msg).unwrap(),
             funds: vec![],
         };
-        SubMsg::reply_on_error(exec, SEND_TOKEN_ID)
+        let mut msg = SubMsg::reply_on_error(exec, SEND_TOKEN_ID);
+        msg.gas_limit = gas_limit;
+        msg
     }
 
     fn native_payment(amount: u128, denom: &str, recipient: &str) -> SubMsg {
@@ -479,9 +490,10 @@ mod test {
         let send_channel = "channel-9";
         let cw20_addr = "token-addr";
         let cw20_denom = "cw20:token-addr";
+        let gas_limit = 1234567;
         let mut deps = setup(
             &["channel-1", "channel-7", send_channel],
-            &[(cw20_addr, 1234567)],
+            &[(cw20_addr, gas_limit)],
         );
 
         // prepare some mock packets
@@ -520,7 +532,7 @@ mod test {
         let res = ibc_packet_receive(deps.as_mut(), mock_env(), msg).unwrap();
         assert_eq!(1, res.messages.len());
         assert_eq!(
-            cw20_payment(876543210, cw20_addr, "local-rcpt"),
+            cw20_payment(876543210, cw20_addr, "local-rcpt", Some(gas_limit)),
             res.messages[0]
         );
         let ack: Ics20Ack = from_binary(&res.acknowledgement).unwrap();

--- a/contracts/cw20-ics20/src/ibc.rs
+++ b/contracts/cw20-ics20/src/ibc.rs
@@ -465,10 +465,12 @@ mod test {
     #[test]
     fn send_receive_cw20() {
         let send_channel = "channel-9";
-        let mut deps = setup(&["channel-1", "channel-7", send_channel]);
-
         let cw20_addr = "token-addr";
         let cw20_denom = "cw20:token-addr";
+        let mut deps = setup(
+            &["channel-1", "channel-7", send_channel],
+            &[(cw20_addr, 1234567)],
+        );
 
         // prepare some mock packets
         let sent_packet = mock_sent_packet(send_channel, 987654321, cw20_denom, "local-sender");
@@ -521,7 +523,7 @@ mod test {
     #[test]
     fn send_receive_native() {
         let send_channel = "channel-9";
-        let mut deps = setup(&["channel-1", "channel-7", send_channel]);
+        let mut deps = setup(&["channel-1", "channel-7", send_channel], &[]);
 
         let denom = "uatom";
 

--- a/contracts/cw20-ics20/src/msg.rs
+++ b/contracts/cw20-ics20/src/msg.rs
@@ -49,6 +49,7 @@ pub struct TransferMsg {
     pub timeout: Option<u64>,
 }
 
+// TODO: query config, query allow list
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
@@ -59,6 +60,15 @@ pub enum QueryMsg {
     /// Returns the details of the name channel, error if not created.
     /// Return type: ChannelResponse.
     Channel { id: String },
+    /// Show the Config. Returns ConfigResponse
+    Config {},
+    /// Query if a given cw20 contract is allowed. Returns AllowedResponse
+    Allowed { contract: String },
+    /// List all allowed cw20 contracts. Returns ListAllowedResponse
+    ListAllowed {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -80,4 +90,27 @@ pub struct ChannelResponse {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct PortResponse {
     pub port_id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct ConfigResponse {
+    pub default_timeout: u64,
+    pub gov_contract: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct AllowedResponse {
+    pub is_allowed: bool,
+    pub gas_limit: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct ListAllowedResponse {
+    pub allow: Vec<AllowedInfo>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct AllowedInfo {
+    pub contract: String,
+    pub gas_limit: Option<u64>,
 }

--- a/contracts/cw20-ics20/src/msg.rs
+++ b/contracts/cw20-ics20/src/msg.rs
@@ -49,7 +49,6 @@ pub struct TransferMsg {
     pub timeout: Option<u64>,
 }
 
-// TODO: query config, query allow list
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {

--- a/contracts/cw20-ics20/src/msg.rs
+++ b/contracts/cw20-ics20/src/msg.rs
@@ -10,6 +10,16 @@ use crate::state::ChannelInfo;
 pub struct InitMsg {
     /// Default timeout for ics20 packets, specified in seconds
     pub default_timeout: u64,
+    /// who can allow more contracts
+    pub gov_contract: String,
+    /// initial allowlist - all cw20 tokens we will send must be previously allowed by governance
+    pub allowlist: Vec<AllowMsg>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct AllowMsg {
+    pub contract: String,
+    pub gas_limit: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -22,6 +32,8 @@ pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     /// This allows us to transfer *exactly one* native token
     Transfer(TransferMsg),
+    /// This must be called by gov_contract, will allow a new cw20 token to be sent
+    Allow(AllowMsg),
 }
 
 /// This is the message we accept via Receive

--- a/contracts/cw20-ics20/src/state.rs
+++ b/contracts/cw20-ics20/src/state.rs
@@ -1,16 +1,19 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{IbcEndpoint, Uint128};
+use cosmwasm_std::{Addr, IbcEndpoint, Uint128};
 use cw_storage_plus::{Item, Map};
 
 pub const CONFIG: Item<Config> = Item::new("ics20_config");
 
-// static info on one channel that doesn't change
+/// static info on one channel that doesn't change
 pub const CHANNEL_INFO: Map<&str, ChannelInfo> = Map::new("channel_info");
 
-// indexed by (channel_id, denom) maintaining the balance of the channel in that currency
+/// indexed by (channel_id, denom) maintaining the balance of the channel in that currency
 pub const CHANNEL_STATE: Map<(&str, &str), ChannelState> = Map::new("channel_state");
+
+/// Every cw20 contract we allow to be sent is stored here, possibly with a gas_limit
+pub const ALLOW_LIST: Map<&Addr, AllowInfo> = Map::new("allow_list");
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
 pub struct ChannelState {
@@ -18,9 +21,10 @@ pub struct ChannelState {
     pub total_sent: Uint128,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Config {
     pub default_timeout: u64,
+    pub gov_contract: Addr,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -31,4 +35,9 @@ pub struct ChannelInfo {
     pub counterparty_endpoint: IbcEndpoint,
     /// the connection this exists on (you can use to query client/consensus info)
     pub connection_id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct AllowInfo {
+    pub gas_limit: Option<u64>,
 }

--- a/contracts/cw20-ics20/src/test_helpers.rs
+++ b/contracts/cw20-ics20/src/test_helpers.rs
@@ -60,6 +60,8 @@ pub fn setup(channels: &[&str]) -> OwnedDeps<MockStorage, MockApi, MockQuerier> 
     // instantiate an empty contract
     let instantiate_msg = InitMsg {
         default_timeout: DEFAULT_TIMEOUT,
+        gov_contract: "gov".to_string(),
+        allowlist: vec![],
     };
     let info = mock_info(&String::from("anyone"), &[]);
     let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();


### PR DESCRIPTION
Freshen up the contract a bit and add an important improvement to bring it closer to production:

-> Only allowed cw20 tokens can be sent, and they may have a gas limit set to use when transferring them.

As it currently stands, you could send a token from a malicious cw20 contract and when someone sent it back from the destination chain, it would run an infinite loop (or just error). This would kill any relayer trying to send this in a batch with other packets and could (temporarily) make a channel useless until the timeout arrived.

If the cw20 contract is not malicious, the existing code works fine. This allows a gov_contract that can only add new tokens there. This gov_contract cannot disable existing token sends. (Design for minimally intrusive governance that can manage this) 