### PR TITLE
Update rust version in CI to current stable (1.58.1)

### DIFF
--- a/packages/storage-plus/benches/main.rs
+++ b/packages/storage-plus/benches/main.rs
@@ -27,12 +27,15 @@ fn bench_signed_int_key(c: &mut Criterion) {
 
         assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
         assert_eq!(to_cw_bytes(&k_check), i32::to_cw_bytes(&k_check));
-        assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
+        assert_eq!(
+            to_cw_bytes(&k_check.wrapping_neg()),
+            i32::to_cw_bytes(&k_check.wrapping_neg())
+        );
 
         b.iter(|| {
             let k = k();
             black_box(to_cw_bytes(&k));
-            black_box(to_cw_bytes(&-k));
+            black_box(to_cw_bytes(&k.wrapping_neg()));
         });
     });
 
@@ -44,12 +47,15 @@ fn bench_signed_int_key(c: &mut Criterion) {
 
         assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
         assert_eq!(to_cw_bytes(&k_check), i32::to_cw_bytes(&k_check));
-        assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
+        assert_eq!(
+            to_cw_bytes(&k_check.wrapping_neg()),
+            i32::to_cw_bytes(&k_check.wrapping_neg())
+        );
 
         b.iter(|| {
             let k = k();
             black_box(to_cw_bytes(&k));
-            black_box(to_cw_bytes(&-k));
+            black_box(to_cw_bytes(&k.wrapping_neg()));
         });
     });
 
@@ -63,12 +69,15 @@ fn bench_signed_int_key(c: &mut Criterion) {
 
         assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
         assert_eq!(to_cw_bytes(&k_check), i32::to_cw_bytes(&k_check));
-        assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
+        assert_eq!(
+            to_cw_bytes(&k_check.wrapping_neg()),
+            i32::to_cw_bytes(&k_check.wrapping_neg())
+        );
 
         b.iter(|| {
             let k = k();
             black_box(to_cw_bytes(&k));
-            black_box(to_cw_bytes(&-k));
+            black_box(to_cw_bytes(&k.wrapping_neg()));
         });
     });
 
@@ -76,20 +85,23 @@ fn bench_signed_int_key(c: &mut Criterion) {
         #[inline]
         fn to_cw_bytes(value: &i32) -> Buf {
             if value >= &0i32 {
-                (*value as u32 - i32::MIN as u32).to_be_bytes()
+                ((*value as u32).wrapping_sub(i32::MIN as u32)).to_be_bytes()
             } else {
-                (*value as u32 + i32::MIN as u32).to_be_bytes()
+                ((*value as u32).wrapping_add(i32::MIN as u32)).to_be_bytes()
             }
         }
 
         assert_eq!(to_cw_bytes(&0), i32::to_cw_bytes(&0));
         assert_eq!(to_cw_bytes(&k_check), i32::to_cw_bytes(&k_check));
-        assert_eq!(to_cw_bytes(&-k_check), i32::to_cw_bytes(&-k_check));
+        assert_eq!(
+            to_cw_bytes(&k_check.wrapping_neg()),
+            i32::to_cw_bytes(&k_check.wrapping_neg())
+        );
 
         b.iter(|| {
             let k = k();
             black_box(to_cw_bytes(&k));
-            black_box(to_cw_bytes(&-k));
+            black_box(to_cw_bytes(&k.wrapping_neg()));
         });
     });
 


### PR DESCRIPTION
Required for `edition2021` feature. I'm now getting the following error in CI:
```
  ...
  Downloaded uint v0.9.2
error: failed to compile `cosmwasm-vm v1.0.0-beta4`, intermediate artifacts can be found at `/tmp/cargo-installFy1UUa`

Caused by:
  failed to parse manifest at `/usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/uint-0.9.2/Cargo.toml`

Caused by:
  feature `edition2021` is required

  this Cargo does not support nightly features, but if you
  switch to nightly channel you can add
  `cargo-features = ["edition2021"]` to enable this feature
  ...
```

Swtching to current `stable` seems to be the simplest / stablest way to solve this.