### PR TITLE
`MIGRATING.md` update / examples for type safe bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,48 @@
 # Changelog
 
-# Changelog
-
 ## [Unreleased](https://github.com/CosmWasm/cw-plus/tree/HEAD)
 
-[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.11.1...HEAD)
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.12.0-alpha1...HEAD)
+
+**Closed issues:**
+
+- Incorrect Cw4ExecuteMsg used during remove\_hook [\#637](https://github.com/CosmWasm/cw-plus/issues/637)
+- Make `Bound`s type safe [\#462](https://github.com/CosmWasm/cw-plus/issues/462)
+
+**Merged pull requests:**
+
+- Fix benchmarks \(after 1.58.1 update\) [\#639](https://github.com/CosmWasm/cw-plus/pull/639) ([maurolacy](https://github.com/maurolacy))
+- Fix `remove_hook` helper [\#638](https://github.com/CosmWasm/cw-plus/pull/638) ([maurolacy](https://github.com/maurolacy))
+- Type safe bounds [\#627](https://github.com/CosmWasm/cw-plus/pull/627) ([maurolacy](https://github.com/maurolacy))
+
+## [v0.12.0-alpha1](https://github.com/CosmWasm/cw-plus/tree/v0.12.0-alpha1) (2022-01-27)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.11.1...v0.12.0-alpha1)
+
+**Deprecated:**
+
+- Remove `IntKey` with surrounding implementation [\#570](https://github.com/CosmWasm/cw-plus/issues/570)
+
+**Closed issues:**
+
+- Move all cw20 examples to new repo [\#578](https://github.com/CosmWasm/cw-plus/issues/578)
+- Add more debug output from multi-test [\#575](https://github.com/CosmWasm/cw-plus/issues/575)
+
+**Merged pull requests:**
+
+- Update Rust to v1.54.0 in CI [\#636](https://github.com/CosmWasm/cw-plus/pull/636) ([maurolacy](https://github.com/maurolacy))
+- Refactor cw2 spec readme [\#635](https://github.com/CosmWasm/cw-plus/pull/635) ([orkunkl](https://github.com/orkunkl))
+- Fix tag consolidation for matching CHANGELOG entries [\#634](https://github.com/CosmWasm/cw-plus/pull/634) ([maurolacy](https://github.com/maurolacy))
+- Ics20 contract rollback [\#633](https://github.com/CosmWasm/cw-plus/pull/633) ([ethanfrey](https://github.com/ethanfrey))
+- Fix typo in README.md [\#632](https://github.com/CosmWasm/cw-plus/pull/632) ([josefrichter](https://github.com/josefrichter))
+- Update ics20 contract [\#631](https://github.com/CosmWasm/cw-plus/pull/631) ([ethanfrey](https://github.com/ethanfrey))
+- Publish snapshot map changelog [\#622](https://github.com/CosmWasm/cw-plus/pull/622) ([maurolacy](https://github.com/maurolacy))
+- Remove `IntKey` and `TimestampKey` [\#620](https://github.com/CosmWasm/cw-plus/pull/620) ([ueco-jb](https://github.com/ueco-jb))
+- Signed int key benchmarks [\#619](https://github.com/CosmWasm/cw-plus/pull/619) ([maurolacy](https://github.com/maurolacy))
+- fix readme update coralnet to sandynet-1 [\#617](https://github.com/CosmWasm/cw-plus/pull/617) ([yubrew](https://github.com/yubrew))
+- Publish `PrefixBound` [\#616](https://github.com/CosmWasm/cw-plus/pull/616) ([maurolacy](https://github.com/maurolacy))
+- Move contracts to cw-tokens [\#613](https://github.com/CosmWasm/cw-plus/pull/613) ([ethanfrey](https://github.com/ethanfrey))
+- Add context to multitest execution errors [\#597](https://github.com/CosmWasm/cw-plus/pull/597) ([uint](https://github.com/uint))
 
 ## [v0.11.1](https://github.com/CosmWasm/cw-plus/tree/v0.11.1) (2021-12-28)
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -52,6 +52,8 @@ pub fn query_all_allowances(
 ```
 Notice that here we build a bound for an address, and using a raw bound allows us to skip address validation / build up.
 
+See storage-plus [README.md](./packages/storage-plus/README.md#Bound) for more information on `Bound`.
+
 ## v0.10.3 -> v0.11.0
 
 ### Breaking Issues / PRs

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,6 +2,50 @@
 
 This guide lists API changes between *cw-plus* major releases.
 
+## v0.11.0 -> v0.12.0
+
+### Breaking Issues / PRs
+
+- Type safe `Bound`s [\#462](https://github.com/CosmWasm/cw-plus/issues/462)
+
+Bounds are now type-safe. That means the bound type must match the key / sub-key you are ranging over.
+
+Migration code example:
+
+```diff
+fn list_allowed(
+     limit: Option<u32>,
+ ) -> StdResult<ListAllowedResponse> {
+     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+-    let start = match start_after {
+-        Some(x) => Some(Bound::exclusive(deps.api.addr_validate(&x)?.into_string())),
+-        None => None,
+-    };
++    let addr = maybe_addr(deps.api, start_after)?;
++    let start = addr.as_ref().map(Bound::exclusive);
+
+     let allow = ALLOW_LIST
+         .range(deps.storage, start, None, Order::Ascending)
+```
+Here the `ALLOW_LIST` key is of type `&Addr`. That's why we use `as_ref()` before the `map()` that builds the bound.
+Notice also that this "forces" you to use `addr_validate()`, in order to build a bound over the proper type.
+
+You can still use untyped bounds, with the `ExclusiveRaw` and `InclusiveRaw` enum types.
+Migration code example, in case you want to keep your raw bounds:
+
+```diff
+pub fn query_all_allowances(
+ ) -> StdResult<AllAllowancesResponse> {
+     let limit = calc_limit(limit);
+     // we use raw addresses here....
+-    let start = start_after.map(Bound::exclusive);
++    let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
+
+     let allowances = ALLOWANCES
+         .range(deps.storage, start, None, Order::Ascending)
+```
+Notice that here we build a bound for an address, and using a raw bound allows us to skip address validation / build up.
+
 ## v0.10.3 -> v0.11.0
 
 ### Breaking Issues / PRs

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -14,8 +14,10 @@ Migration code example:
 
 ```diff
 fn list_allowed(
-     limit: Option<u32>,
- ) -> StdResult<ListAllowedResponse> {
+    deps: Deps,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> StdResult<ListAllowedResponse> {
      let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
 -    let start = match start_after {
 -        Some(x) => Some(Bound::exclusive(deps.api.addr_validate(&x)?.into_string())),
@@ -35,7 +37,11 @@ Migration code example, in case you want to keep your raw bounds:
 
 ```diff
 pub fn query_all_allowances(
- ) -> StdResult<AllAllowancesResponse> {
+    deps: Deps,
+    env: Env,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> StdResult<AllAllowancesResponse> {
      let limit = calc_limit(limit);
      // we use raw addresses here....
 -    let start = start_after.map(Bound::exclusive);

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -16,7 +16,7 @@ pub fn query_all_allowances(
 ) -> StdResult<AllAllowancesResponse> {
     let owner_addr = deps.api.addr_validate(&owner)?;
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(|s| Bound::ExclusiveRaw(s.as_bytes().into()));
+    let start = start_after.map(|s| Bound::ExclusiveRaw(s.into_bytes()));
 
     let allowances = ALLOWANCES
         .prefix(&owner_addr)


### PR DESCRIPTION
Adds entry for migrating to type-safe bounds.