### PR TITLE
Set version: 0.12.0-alpha2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "criterion",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "cw1"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-subkeys"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist-ng"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cw1155"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "cw1155-base"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-ics20"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "cw3"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-fixed-multisig"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-flex-multisig"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "cw4"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-group"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-stake"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-subkeys"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement subkeys for authorizing native tokens as a cw1 proxy contract"
@@ -19,12 +19,12 @@ library = []
 test-utils = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw1 = { path = "../../packages/cw1", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.11.1", features = ["library"] }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw1 = { path = "../../packages/cw1", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.12.0-alpha2", features = ["library"] }
 cosmwasm-std = { version = "1.0.0-beta3", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.23"
@@ -32,4 +32,4 @@ semver = "1"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta3" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.11.1", features = ["library", "test-utils"] }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.12.0-alpha2", features = ["library", "test-utils"] }

--- a/contracts/cw1-whitelist-ng/Cargo.toml
+++ b/contracts/cw1-whitelist-ng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist-ng"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Bartłomiej Kuras <bartk@confio.gmbh>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -22,20 +22,20 @@ querier = ["library"]
 multitest = ["cw-multi-test", "anyhow"]
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw1 = { path = "../../packages/cw1", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw1 = { path = "../../packages/cw1", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.11.1", optional = true }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.12.0-alpha2", optional = true }
 anyhow = { version = "1", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1"
 cosmwasm-schema = { version = "1.0.0-beta3" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.11.1" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.12.0-alpha2" }
 derivative = "2"

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -19,11 +19,11 @@ library = []
 test-utils = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw1 = { path = "../../packages/cw1", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw1 = { path = "../../packages/cw1", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
@@ -32,5 +32,5 @@ thiserror = { version = "1.0.23" }
 anyhow = "1"
 assert_matches = "1"
 cosmwasm-schema = { version = "1.0.0-beta3" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.11.1" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.12.0-alpha2" }
 derivative = "2"

--- a/contracts/cw1155-base/Cargo.toml
+++ b/contracts/cw1155-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155-base"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-1155 compliant token"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
-cw1155 = { path = "../../packages/cw1155", version = "0.11.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
+cw1155 = { path = "../../packages/cw1155", version = "0.12.0-alpha2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-base"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-20 compliant token"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
-cw20 = { path = "../../packages/cw20", version = "0.11.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
+cw20 = { path = "../../packages/cw20", version = "0.12.0-alpha2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-ics20/Cargo.toml
+++ b/contracts/cw20-ics20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-ics20"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "IBC Enabled contracts that receives CW20 tokens and sends them over ICS20 to a remote chain"
@@ -18,11 +18,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
-cw20 = { path = "../../packages/cw20", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
+cw20 = { path = "../../packages/cw20", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3", features = ["stargate"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-fixed-multisig"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with an fixed group multisig"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
-cw3 = { path = "../../packages/cw3", version = "0.11.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
+cw3 = { path = "../../packages/cw3", version = "0.12.0-alpha2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -29,6 +29,6 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta3" }
-cw20 = { path = "../../packages/cw20", version = "0.11.1" }
-cw20-base = { path = "../cw20-base", version = "0.11.1", features = ["library"] }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.11.1" }
+cw20 = { path = "../../packages/cw20", version = "0.12.0-alpha2" }
+cw20-base = { path = "../cw20-base", version = "0.12.0-alpha2", features = ["library"] }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.12.0-alpha2" }

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-flex-multisig"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with multiple voting patterns and dynamic groups"
@@ -18,12 +18,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
-cw3 = { path = "../../packages/cw3", version = "0.11.1" }
-cw3-fixed-multisig = { path = "../cw3-fixed-multisig", version = "0.11.1", features = ["library"] }
-cw4 = { path = "../../packages/cw4", version = "0.11.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
+cw3 = { path = "../../packages/cw3", version = "0.12.0-alpha2" }
+cw3-fixed-multisig = { path = "../cw3-fixed-multisig", version = "0.12.0-alpha2", features = ["library"] }
+cw4 = { path = "../../packages/cw4", version = "0.12.0-alpha2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -31,5 +31,5 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta3" }
-cw4-group = { path = "../cw4-group", version = "0.11.1" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.11.1" }
+cw4-group = { path = "../cw4-group", version = "0.12.0-alpha2" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.12.0-alpha2" }

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-group"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple cw4 implementation of group membership controlled by admin "
@@ -26,11 +26,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
-cw4 = { path = "../../packages/cw4", version = "0.11.1" }
-cw-controllers = { path = "../../packages/controllers", version = "0.11.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
+cw4 = { path = "../../packages/cw4", version = "0.12.0-alpha2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.12.0-alpha2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-stake"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CW4 implementation of group based on staked tokens"
@@ -26,12 +26,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw2 = { path = "../../packages/cw2", version = "0.11.1" }
-cw4 = { path = "../../packages/cw4", version = "0.11.1" }
-cw20 = { path = "../../packages/cw20", version = "0.11.1" }
-cw-controllers = { path = "../../packages/controllers", version = "0.11.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw2 = { path = "../../packages/cw2", version = "0.12.0-alpha2" }
+cw4 = { path = "../../packages/cw4", version = "0.12.0-alpha2" }
+cw20 = { path = "../../packages/cw20", version = "0.12.0-alpha2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.12.0-alpha2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/controllers/Cargo.toml
+++ b/packages/controllers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-controllers"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common controllers we can reuse in many contracts"
@@ -13,8 +13,8 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta3" }
-cw-utils = { path = "../utils", version = "0.11.1" }
-cw-storage-plus = { path = "../storage-plus", version = "0.11.1" }
+cw-utils = { path = "../utils", version = "0.12.0-alpha2" }
+cw-storage-plus = { path = "../storage-plus", version = "0.12.0-alpha2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }

--- a/packages/cw1/Cargo.toml
+++ b/packages/cw1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1 interface"

--- a/packages/cw1155/Cargo.toml
+++ b/packages/cw1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1155 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw2"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-2 interface"
@@ -11,6 +11,6 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta3", default-features = false }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw20/Cargo.toml
+++ b/packages/cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-20 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw3/Cargo.toml
+++ b/packages/cw3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw4/Cargo.toml
+++ b/packages/cw4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-4 Interface: Groups Members"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-storage-plus = { path = "../storage-plus", version = "0.11.1" }
+cw-storage-plus = { path = "../storage-plus", version = "0.12.0-alpha2" }
 cosmwasm-std = { version = "1.0.0-beta3" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-multi-test"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Test helpers for multi-contract interactions"
@@ -18,8 +18,8 @@ staking = ["cosmwasm-std/staking"]
 backtrace = ["anyhow/backtrace"]
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.11.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1"}
+cw-utils = { path = "../../packages/utils", version = "0.12.0-alpha2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2"}
 cosmwasm-std = { version = "1.0.0-beta3", features = ["staking"] }
 cosmwasm-storage = { version = "1.0.0-beta3" }
 itertools = "0.10.1"

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-storage-plus"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Enhanced/experimental storage engines"

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-utils"
-version = "0.11.1"
+version = "0.12.0-alpha2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common helpers for other cw specs"
@@ -18,5 +18,5 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
 [dev-dependencies]
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.11.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.12.0-alpha2" }
 prost = "0.9"


### PR DESCRIPTION
Using these alphas for the ics20 contract. But also, this exposes the new Bounds type if we want to ensure other repos can update well before making a final tag