### PR TITLE
packages: support custom queries

### DIFF
--- a/packages/controllers/src/admin.rs
+++ b/packages/controllers/src/admin.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
 
-use cosmwasm_std::{attr, Addr, Deps, DepsMut, MessageInfo, Response, StdError, StdResult};
+use cosmwasm_std::{
+    attr, Addr, CustomQuery, Deps, DepsMut, MessageInfo, Response, StdError, StdResult,
+};
 use cw_storage_plus::Item;
 
 // TODO: should the return values end up in utils, so eg. cw4 can import them as well as this module?
@@ -32,17 +34,17 @@ impl<'a> Admin<'a> {
         Admin(Item::new(namespace))
     }
 
-    pub fn set(&self, deps: DepsMut, admin: Option<Addr>) -> StdResult<()> {
+    pub fn set<Q: CustomQuery>(&self, deps: DepsMut<Q>, admin: Option<Addr>) -> StdResult<()> {
         self.0.save(deps.storage, &admin)
     }
 
-    pub fn get(&self, deps: Deps) -> StdResult<Option<Addr>> {
+    pub fn get<Q: CustomQuery>(&self, deps: Deps<Q>) -> StdResult<Option<Addr>> {
         self.0.load(deps.storage)
     }
 
     /// Returns Ok(true) if this is an admin, Ok(false) if not and an Error if
     /// we hit an error with Api or Storage usage
-    pub fn is_admin(&self, deps: Deps, caller: &Addr) -> StdResult<bool> {
+    pub fn is_admin<Q: CustomQuery>(&self, deps: Deps<Q>, caller: &Addr) -> StdResult<bool> {
         match self.0.load(deps.storage)? {
             Some(owner) => Ok(caller == &owner),
             None => Ok(false),
@@ -51,7 +53,11 @@ impl<'a> Admin<'a> {
 
     /// Like is_admin but returns AdminError::NotAdmin if not admin.
     /// Helper for a nice one-line auth check.
-    pub fn assert_admin(&self, deps: Deps, caller: &Addr) -> Result<(), AdminError> {
+    pub fn assert_admin<Q: CustomQuery>(
+        &self,
+        deps: Deps<Q>,
+        caller: &Addr,
+    ) -> Result<(), AdminError> {
         if !self.is_admin(deps, caller)? {
             Err(AdminError::NotAdmin {})
         } else {
@@ -59,9 +65,9 @@ impl<'a> Admin<'a> {
         }
     }
 
-    pub fn execute_update_admin<C>(
+    pub fn execute_update_admin<C, Q: CustomQuery>(
         &self,
-        deps: DepsMut,
+        deps: DepsMut<Q>,
         info: MessageInfo,
         new_admin: Option<Addr>,
     ) -> Result<Response<C>, AdminError>
@@ -160,14 +166,14 @@ mod tests {
         let info = mock_info(imposter.as_ref(), &[]);
         let new_admin = Some(friend.clone());
         let err = control
-            .execute_update_admin::<Empty>(deps.as_mut(), info, new_admin.clone())
+            .execute_update_admin::<Empty, Empty>(deps.as_mut(), info, new_admin.clone())
             .unwrap_err();
         assert_eq!(AdminError::NotAdmin {}, err);
 
         // owner can update
         let info = mock_info(owner.as_ref(), &[]);
         let res = control
-            .execute_update_admin::<Empty>(deps.as_mut(), info, new_admin)
+            .execute_update_admin::<Empty, Empty>(deps.as_mut(), info, new_admin)
             .unwrap();
         assert_eq!(0, res.messages.len());
 

--- a/packages/controllers/src/claim.rs
+++ b/packages/controllers/src/claim.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, BlockInfo, Deps, StdResult, Storage, Uint128};
+use cosmwasm_std::{Addr, BlockInfo, CustomQuery, Deps, StdResult, Storage, Uint128};
 use cw_storage_plus::Map;
 use cw_utils::Expiration;
 
@@ -86,7 +86,11 @@ impl<'a> Claims<'a> {
         Ok(to_send)
     }
 
-    pub fn query_claims(&self, deps: Deps, address: &Addr) -> StdResult<ClaimsResponse> {
+    pub fn query_claims<Q: CustomQuery>(
+        &self,
+        deps: Deps<Q>,
+        address: &Addr,
+    ) -> StdResult<ClaimsResponse> {
         let claims = self.0.may_load(deps.storage, address)?.unwrap_or_default();
         Ok(ClaimsResponse { claims })
     }

--- a/packages/controllers/src/hooks.rs
+++ b/packages/controllers/src/hooks.rs
@@ -4,7 +4,8 @@ use std::fmt;
 use thiserror::Error;
 
 use cosmwasm_std::{
-    attr, Addr, Deps, DepsMut, MessageInfo, Response, StdError, StdResult, Storage, SubMsg,
+    attr, Addr, CustomQuery, Deps, DepsMut, MessageInfo, Response, StdError, StdResult, Storage,
+    SubMsg,
 };
 use cw_storage_plus::Item;
 
@@ -73,10 +74,10 @@ impl<'a> Hooks<'a> {
             .collect()
     }
 
-    pub fn execute_add_hook<C>(
+    pub fn execute_add_hook<C, Q: CustomQuery>(
         &self,
         admin: &Admin,
-        deps: DepsMut,
+        deps: DepsMut<Q>,
         info: MessageInfo,
         addr: Addr,
     ) -> Result<Response<C>, HookError>
@@ -94,10 +95,10 @@ impl<'a> Hooks<'a> {
         Ok(Response::new().add_attributes(attributes))
     }
 
-    pub fn execute_remove_hook<C>(
+    pub fn execute_remove_hook<C, Q: CustomQuery>(
         &self,
         admin: &Admin,
-        deps: DepsMut,
+        deps: DepsMut<Q>,
         info: MessageInfo,
         addr: Addr,
     ) -> Result<Response<C>, HookError>
@@ -115,7 +116,7 @@ impl<'a> Hooks<'a> {
         Ok(Response::new().add_attributes(attributes))
     }
 
-    pub fn query_hooks(&self, deps: Deps) -> StdResult<HooksResponse> {
+    pub fn query_hooks<Q: CustomQuery>(&self, deps: Deps<Q>) -> StdResult<HooksResponse> {
         let hooks = self.0.may_load(deps.storage)?.unwrap_or_default();
         let hooks = hooks.into_iter().map(String::from).collect();
         Ok(HooksResponse { hooks })

--- a/packages/cw20/src/helpers.rs
+++ b/packages/cw20/src/helpers.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    to_binary, Addr, CosmosMsg, Empty, Querier, QuerierWrapper, StdResult, Uint128, WasmMsg,
+    to_binary, Addr, CosmosMsg, CustomQuery, Querier, QuerierWrapper, StdResult, Uint128, WasmMsg,
     WasmQuery,
 };
 
@@ -34,11 +34,12 @@ impl Cw20Contract {
     }
 
     /// Get token balance for the given address
-    pub fn balance<Q: Querier, T: Into<String>>(
-        &self,
-        querier: &Q,
-        address: T,
-    ) -> StdResult<Uint128> {
+    pub fn balance<Q, T, CQ>(&self, querier: &Q, address: T) -> StdResult<Uint128>
+    where
+        Q: Querier,
+        T: Into<String>,
+        CQ: CustomQuery,
+    {
         let msg = Cw20QueryMsg::Balance {
             address: address.into(),
         };
@@ -47,29 +48,39 @@ impl Cw20Contract {
             msg: to_binary(&msg)?,
         }
         .into();
-        let res: BalanceResponse = QuerierWrapper::<Empty>::new(querier).query(&query)?;
+        let res: BalanceResponse = QuerierWrapper::<CQ>::new(querier).query(&query)?;
         Ok(res.balance)
     }
 
     /// Get metadata from the contract. This is a good check that the address
     /// is a valid Cw20 contract.
-    pub fn meta<Q: Querier>(&self, querier: &Q) -> StdResult<TokenInfoResponse> {
+    pub fn meta<Q, CQ>(&self, querier: &Q) -> StdResult<TokenInfoResponse>
+    where
+        Q: Querier,
+        CQ: CustomQuery,
+    {
         let msg = Cw20QueryMsg::TokenInfo {};
         let query = WasmQuery::Smart {
             contract_addr: self.addr().into(),
             msg: to_binary(&msg)?,
         }
         .into();
-        QuerierWrapper::<Empty>::new(querier).query(&query)
+        QuerierWrapper::<CQ>::new(querier).query(&query)
     }
 
     /// Get allowance of spender to use owner's account
-    pub fn allowance<Q: Querier, T: Into<String>, U: Into<String>>(
+    pub fn allowance<Q, T, U, CQ>(
         &self,
         querier: &Q,
         owner: T,
         spender: U,
-    ) -> StdResult<AllowanceResponse> {
+    ) -> StdResult<AllowanceResponse>
+    where
+        Q: Querier,
+        T: Into<String>,
+        U: Into<String>,
+        CQ: CustomQuery,
+    {
         let msg = Cw20QueryMsg::Allowance {
             owner: owner.into(),
             spender: spender.into(),
@@ -79,27 +90,32 @@ impl Cw20Contract {
             msg: to_binary(&msg)?,
         }
         .into();
-        QuerierWrapper::<Empty>::new(querier).query(&query)
+        QuerierWrapper::<CQ>::new(querier).query(&query)
     }
 
     /// Find info on who can mint, and how much
-    pub fn minter<Q: Querier>(&self, querier: &Q) -> StdResult<Option<MinterResponse>> {
+    pub fn minter<Q, CQ>(&self, querier: &Q) -> StdResult<Option<MinterResponse>>
+    where
+        Q: Querier,
+        CQ: CustomQuery,
+    {
         let msg = Cw20QueryMsg::Minter {};
         let query = WasmQuery::Smart {
             contract_addr: self.addr().into(),
             msg: to_binary(&msg)?,
         }
         .into();
-        QuerierWrapper::<Empty>::new(querier).query(&query)
+        QuerierWrapper::<CQ>::new(querier).query(&query)
     }
 
     /// returns true if the contract supports the allowance extension
-    pub fn has_allowance<Q: Querier>(&self, querier: &Q) -> bool {
-        self.allowance(querier, self.addr(), self.addr()).is_ok()
+    pub fn has_allowance<Q: Querier, CQ: CustomQuery>(&self, querier: &Q) -> bool {
+        self.allowance::<_, _, _, CQ>(querier, self.addr(), self.addr())
+            .is_ok()
     }
 
     /// returns true if the contract supports the mintable extension
-    pub fn is_mintable<Q: Querier>(&self, querier: &Q) -> bool {
-        self.minter(querier).is_ok()
+    pub fn is_mintable<Q: Querier, CQ: CustomQuery>(&self, querier: &Q) -> bool {
+        self.minter::<_, CQ>(querier).is_ok()
     }
 }

--- a/packages/cw4/src/helpers.rs
+++ b/packages/cw4/src/helpers.rs
@@ -2,7 +2,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    to_binary, Addr, CosmosMsg, Empty, QuerierWrapper, QueryRequest, StdResult, WasmMsg, WasmQuery,
+    to_binary, Addr, CosmosMsg, CustomQuery, QuerierWrapper, QueryRequest, StdResult, WasmMsg,
+    WasmQuery,
 };
 
 use crate::msg::Cw4ExecuteMsg;
@@ -54,7 +55,7 @@ impl Cw4Contract {
         self.encode_msg(msg)
     }
 
-    fn encode_smart_query(&self, msg: Cw4QueryMsg) -> StdResult<QueryRequest<Empty>> {
+    fn encode_smart_query<Q: CustomQuery>(&self, msg: Cw4QueryMsg) -> StdResult<QueryRequest<Q>> {
         Ok(WasmQuery::Smart {
             contract_addr: self.addr().into(),
             msg: to_binary(&msg)?,
@@ -63,7 +64,7 @@ impl Cw4Contract {
     }
 
     /// Show the hooks
-    pub fn hooks(&self, querier: &QuerierWrapper) -> StdResult<Vec<String>> {
+    pub fn hooks<Q: CustomQuery>(&self, querier: &QuerierWrapper<Q>) -> StdResult<Vec<String>> {
         let query = self.encode_smart_query(Cw4QueryMsg::Hooks {})?;
         let res: HooksResponse = querier.query(&query)?;
         Ok(res.hooks)

--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -557,7 +557,7 @@ where
 {
     /// This registers contract code (like uploading wasm bytecode on a chain),
     /// so it can later be used to instantiate a contract.
-    pub fn store_code(&mut self, code: Box<dyn Contract<CustomT::ExecT>>) -> u64 {
+    pub fn store_code(&mut self, code: Box<dyn Contract<CustomT::ExecT, CustomT::QueryT>>) -> u64 {
         self.init_modules(|router, _, _| router.wasm.store_code(code) as u64)
     }
 

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -6,10 +6,9 @@
 //!
 //! To understand the design of this module, please refer to `../DESIGN.md`
 
-#![allow(clippy::type_complexity)]
-
 mod app;
 mod bank;
+#[allow(clippy::type_complexity)]
 mod contracts;
 pub mod custom_handler;
 pub mod error;

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! To understand the design of this module, please refer to `../DESIGN.md`
 
+#![allow(clippy::type_complexity)]
+
 mod app;
 mod bank;
 mod contracts;

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -99,7 +99,7 @@ pub trait Wasm<ExecC, QueryC> {
 pub struct WasmKeeper<ExecC, QueryC> {
     /// code is in-memory lookup that stands in for wasm code
     /// this can only be edited on the WasmRouter, and just read in caches
-    codes: HashMap<usize, Box<dyn Contract<ExecC>>>,
+    codes: HashMap<usize, Box<dyn Contract<ExecC, QueryC>>>,
     /// Just markers to make type elision fork when using it as `Wasm` trait
     _p: std::marker::PhantomData<QueryC>,
 }
@@ -180,7 +180,7 @@ where
 }
 
 impl<ExecC, QueryC> WasmKeeper<ExecC, QueryC> {
-    pub fn store_code(&mut self, code: Box<dyn Contract<ExecC>>) -> usize {
+    pub fn store_code(&mut self, code: Box<dyn Contract<ExecC, QueryC>>) -> usize {
         let idx = self.codes.len() + 1;
         self.codes.insert(idx, code);
         idx
@@ -706,7 +706,7 @@ where
         action: F,
     ) -> AnyResult<T>
     where
-        F: FnOnce(&Box<dyn Contract<ExecC>>, Deps, Env) -> AnyResult<T>,
+        F: FnOnce(&Box<dyn Contract<ExecC, QueryC>>, Deps<QueryC>, Env) -> AnyResult<T>,
     {
         let contract = self.load_contract(storage, &address)?;
         let handler = self
@@ -734,7 +734,7 @@ where
         action: F,
     ) -> AnyResult<T>
     where
-        F: FnOnce(&Box<dyn Contract<ExecC>>, DepsMut, Env) -> AnyResult<T>,
+        F: FnOnce(&Box<dyn Contract<ExecC, QueryC>>, DepsMut<QueryC>, Env) -> AnyResult<T>,
         ExecC: DeserializeOwned,
     {
         let contract = self.load_contract(storage, &address)?;

--- a/packages/storage-plus/src/helpers.rs
+++ b/packages/storage-plus/src/helpers.rs
@@ -10,7 +10,7 @@ use std::any::type_name;
 use crate::keys::Key;
 
 use cosmwasm_std::{
-    from_slice, to_vec, Addr, Binary, ContractResult, Empty, QuerierWrapper, QueryRequest,
+    from_slice, to_vec, Addr, Binary, ContractResult, CustomQuery, QuerierWrapper, QueryRequest,
     StdError, StdResult, SystemResult, WasmQuery,
 };
 
@@ -93,12 +93,12 @@ pub(crate) fn encode_length(namespace: &[u8]) -> [u8; 2] {
 /// This is similar to querier.query(WasmQuery::Raw{}), except it does NOT parse the
 /// result, but return a possibly empty Binary to be handled by the calling code.
 /// That is essential to handle b"" as None.
-pub(crate) fn query_raw(
-    querier: &QuerierWrapper,
+pub(crate) fn query_raw<Q: CustomQuery>(
+    querier: &QuerierWrapper<Q>,
     contract_addr: Addr,
     key: Binary,
 ) -> StdResult<Binary> {
-    let request: QueryRequest<Empty> = WasmQuery::Raw {
+    let request: QueryRequest<Q> = WasmQuery::Raw {
         contract_addr: contract_addr.into(),
         key,
     }

--- a/packages/storage-plus/src/item.rs
+++ b/packages/storage-plus/src/item.rs
@@ -2,7 +2,9 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::marker::PhantomData;
 
-use cosmwasm_std::{to_vec, Addr, QuerierWrapper, StdError, StdResult, Storage, WasmQuery};
+use cosmwasm_std::{
+    to_vec, Addr, CustomQuery, QuerierWrapper, StdError, StdResult, Storage, WasmQuery,
+};
 
 use crate::helpers::{may_deserialize, must_deserialize};
 
@@ -77,7 +79,11 @@ where
     /// from a remote contract in a type-safe way using WasmQuery::RawQuery.
     ///
     /// Note that we expect an Item to be set, and error if there is no data there
-    pub fn query(&self, querier: &QuerierWrapper, remote_contract: Addr) -> StdResult<T> {
+    pub fn query<Q: CustomQuery>(
+        &self,
+        querier: &QuerierWrapper<Q>,
+        remote_contract: Addr,
+    ) -> StdResult<T> {
         let request = WasmQuery::Raw {
             contract_addr: remote_contract.into(),
             key: self.storage_key.into(),

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -15,7 +15,7 @@ use crate::keys::{Key, PrimaryKey};
 use crate::path::Path;
 #[cfg(feature = "iterator")]
 use crate::prefix::{namespaced_prefix_range, Prefix};
-use cosmwasm_std::{from_slice, Addr, QuerierWrapper, StdError, StdResult, Storage};
+use cosmwasm_std::{from_slice, Addr, CustomQuery, QuerierWrapper, StdError, StdResult, Storage};
 
 #[derive(Debug, Clone)]
 pub struct Map<'a, K, T> {
@@ -95,9 +95,9 @@ where
 
     /// If you import the proper Map from the remote contract, this will let you read the data
     /// from a remote contract in a type-safe way using WasmQuery::RawQuery
-    pub fn query(
+    pub fn query<Q: CustomQuery>(
         &self,
-        querier: &QuerierWrapper,
+        querier: &QuerierWrapper<Q>,
         remote_contract: Addr,
         k: K,
     ) -> StdResult<Option<T>> {


### PR DESCRIPTION
In order to resolve https://github.com/confio/poe-contracts/issues/36, it looks like we need the `tgrade-valset` contract to use `TgradeQuery` as the custom query type for `Deps` and `DepsMut` (currently it's `Empty`).

In order to do that, `Admin` needs to support custom query types that are not `Empty` in `Deps`/`DepsMut`.