### PR TITLE
Fix missing prefix bound types

### DIFF
--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -172,11 +172,11 @@ where
     K: PrimaryKey<'a>,
     I: IndexList<T>,
 {
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 }

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -225,11 +225,11 @@ where
     K: PrimaryKey<'a>,
     I: IndexList<T>,
 {
-    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T> {
+    pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 
-    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T> {
+    pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
         Prefix::new(self.pk_namespace, &p.prefix())
     }
 }

--- a/packages/storage-plus/src/indexes/multi.rs
+++ b/packages/storage-plus/src/indexes/multi.rs
@@ -250,7 +250,7 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a> + Prefixer<'a>,
 {
-    pub fn prefix(&self, p: IK) -> Prefix<PK, T> {
+    pub fn prefix(&self, p: IK) -> Prefix<PK, T, PK> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),
@@ -260,7 +260,7 @@ where
         )
     }
 
-    pub fn sub_prefix(&self, p: IK::Prefix) -> Prefix<PK, T> {
+    pub fn sub_prefix(&self, p: IK::Prefix) -> Prefix<PK, T, (IK::Suffix, PK)> {
         Prefix::with_deserialization_functions(
             self.idx_namespace,
             &p.prefix(),


### PR DESCRIPTION
Fixes a couple of errors with missing bound annotations for `IndexedMap`s and `MultiIndex`.