### PR TITLE
Forward original errors in multitest `instantiate`, `execute` and `query`

### DIFF
--- a/packages/multi-test/src/app.rs
+++ b/packages/multi-test/src/app.rs
@@ -2604,9 +2604,9 @@ mod test {
                 panic!("wrong StdError variant");
             }
 
-            // we're expecting exactly 3 nested error types
-            // (the original error, initiate msg context, WasmMsg context)
-            assert_eq!(err.chain().count(), 3);
+            // We're expecting exactly 2 nested error types
+            // (the original error, WasmMsg context)
+            assert_eq!(err.chain().count(), 2);
         }
 
         #[test]
@@ -2634,9 +2634,9 @@ mod test {
                 panic!("wrong StdError variant");
             }
 
-            // we're expecting exactly 3 nested error types
-            // (the original error, execute msg context, WasmMsg context)
-            assert_eq!(err.chain().count(), 3);
+            // We're expecting exactly 2 nested error types
+            // (the original error, WasmMsg context)
+            assert_eq!(err.chain().count(), 2);
         }
 
         #[test]
@@ -2674,9 +2674,9 @@ mod test {
                 panic!("wrong StdError variant");
             }
 
-            // we're expecting exactly 4 nested error types
-            // (the original error, execute msg context, 2 WasmMsg contexts)
-            assert_eq!(err.chain().count(), 4);
+            // We're expecting exactly 3 nested error types
+            // (the original error, 2 WasmMsg contexts)
+            assert_eq!(err.chain().count(), 3);
         }
 
         #[test]
@@ -2725,9 +2725,9 @@ mod test {
                 panic!("wrong StdError variant");
             }
 
-            // we're expecting exactly 5 nested error types
-            // (the original error, execute msg context, 3 WasmMsg contexts)
-            assert_eq!(err.chain().count(), 5);
+            // We're expecting exactly 4 nested error types
+            // (the original error, 3 WasmMsg contexts)
+            assert_eq!(err.chain().count(), 4);
         }
     }
 }

--- a/packages/multi-test/src/contracts.rs
+++ b/packages/multi-test/src/contracts.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
     Response, SubMsg,
 };
 
-use anyhow::{anyhow, bail, Context, Result as AnyResult};
+use anyhow::{anyhow, bail, Result as AnyResult};
 
 /// Interface to call into a Contract
 pub trait Contract<T, Q = Empty>
@@ -349,12 +349,7 @@ where
         msg: Vec<u8>,
     ) -> AnyResult<Response<C>> {
         let msg: T1 = from_slice(&msg)?;
-        (self.execute_fn)(deps, env, info, msg.clone())
-            .map_err(anyhow::Error::from)
-            .context(format!(
-                "Contract returned an error on execute msg:\n{:?}",
-                msg,
-            ))
+        (self.execute_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
     }
 
     fn instantiate(
@@ -365,22 +360,12 @@ where
         msg: Vec<u8>,
     ) -> AnyResult<Response<C>> {
         let msg: T2 = from_slice(&msg)?;
-        (self.instantiate_fn)(deps, env, info, msg.clone())
-            .map_err(anyhow::Error::from)
-            .context(format!(
-                "Contract returned an error on instantiate msg:\n{:?}",
-                msg,
-            ))
+        (self.instantiate_fn)(deps, env, info, msg).map_err(|err| anyhow!(err))
     }
 
     fn query(&self, deps: Deps<Q>, env: Env, msg: Vec<u8>) -> AnyResult<Binary> {
         let msg: T3 = from_slice(&msg)?;
-        (self.query_fn)(deps, env, msg.clone())
-            .map_err(anyhow::Error::from)
-            .context(format!(
-                "Contract returned an error on query msg:\n{:?}",
-                msg,
-            ))
+        (self.query_fn)(deps, env, msg).map_err(|err| anyhow!(err))
     }
 
     // this returns an error if the contract doesn't implement sudo


### PR DESCRIPTION
Instead of rewriting errors, just forward them so that they can be used for error matching / patterns.