### PR TITLE
cw20-base: validate addresses are unique in initial balances

### DIFF
--- a/contracts/cw20-base/src/error.rs
+++ b/contracts/cw20-base/src/error.rs
@@ -32,4 +32,7 @@ pub enum ContractError {
 
     #[error("Invalid png header")]
     InvalidPngHeader {},
+
+    #[error("Duplicate initial balance addresses")]
+    DuplicateInitialBalanceAddresses {},
 }


### PR DESCRIPTION
Fixes #626 