### PR TITLE
Fix cw20 ics20 packets

### DIFF
--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -365,9 +365,10 @@ mod test {
     use super::*;
     use crate::test_helpers::*;
 
-    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
     use cosmwasm_std::{coin, coins, CosmosMsg, IbcMsg, StdError, Uint128};
 
+    use crate::state::ChannelState;
     use cw_utils::PaymentError;
 
     #[test]
@@ -531,5 +532,37 @@ mod test {
         let info = mock_info(cw20_addr, &[]);
         let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
         assert_eq!(err, ContractError::NotOnAllowList);
+    }
+
+    #[test]
+    fn v3_migration_works() {
+        // basic state with one channel
+        let send_channel = "channel-15";
+        let cw20_addr = "my-token";
+        let native = "ucosm";
+        let mut deps = setup(&[send_channel], &[(cw20_addr, 123456)]);
+
+        // mock that we sent some tokens in both native and cw20 (TODO: cw20)
+        // balances set high
+        deps.querier
+            .update_balance(MOCK_CONTRACT_ADDR, coins(50000, native));
+
+        // channel state a bit lower (some in-flight acks)
+        let state = ChannelState {
+            // 14000 not accounted for (in-flight)
+            outstanding: Uint128::new(36000),
+            total_sent: Uint128::new(100000),
+        };
+        CHANNEL_STATE
+            .save(deps.as_mut().storage, (send_channel, native), &state)
+            .unwrap();
+
+        // run migration
+        migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+
+        // check new channel state
+        let chan = query_channel(deps.as_ref(), send_channel.into()).unwrap();
+        assert_eq!(chan.balances, vec![Amount::native(50000, native)]);
+        assert_eq!(chan.total_sent, vec![Amount::native(114000, native)]);
     }
 }

--- a/contracts/cw20-ics20/src/ibc.rs
+++ b/contracts/cw20-ics20/src/ibc.rs
@@ -11,8 +11,8 @@ use cosmwasm_std::{
 use crate::amount::Amount;
 use crate::error::{ContractError, Never};
 use crate::state::{
-    increase_channel_balance, reduce_channel_balance, undo_reduce_channel_balance, ChannelInfo,
-    ReplyArgs, ALLOW_LIST, CHANNEL_INFO, REPLY_ARGS,
+    reduce_channel_balance, undo_reduce_channel_balance, ChannelInfo, ReplyArgs, ALLOW_LIST,
+    CHANNEL_INFO, REPLY_ARGS,
 };
 use cw20::Cw20ExecuteMsg;
 
@@ -32,11 +32,7 @@ pub struct Ics20Packet {
     pub receiver: String,
     /// the sender address
     pub sender: String,
-    /// used only by us to control ack handling
-    pub v: Option<u32>,
 }
-
-const V2: u32 = 2;
 
 impl Ics20Packet {
     pub fn new<T: Into<String>>(amount: Uint128, denom: T, sender: &str, receiver: &str) -> Self {
@@ -45,7 +41,6 @@ impl Ics20Packet {
             amount,
             sender: sender.to_string(),
             receiver: receiver.to_string(),
-            v: Some(V2),
         }
     }
 
@@ -317,14 +312,8 @@ pub fn ibc_packet_timeout(
 }
 
 // update the balance stored on this (channel, denom) index
-fn on_packet_success(deps: DepsMut, packet: IbcPacket) -> Result<IbcBasicResponse, ContractError> {
+fn on_packet_success(_deps: DepsMut, packet: IbcPacket) -> Result<IbcBasicResponse, ContractError> {
     let msg: Ics20Packet = from_binary(&packet.data)?;
-
-    // if this was for an older (pre-v2) packet we send continue with old behavior
-    // (this is needed for transitioning on a system with pending packet)
-    if msg.v.is_none() {
-        increase_channel_balance(deps.storage, &packet.src.channel_id, &msg.denom, msg.amount)?;
-    }
 
     // similar event messages like ibctransfer module
     let attributes = vec![
@@ -347,10 +336,8 @@ fn on_packet_failure(
 ) -> Result<IbcBasicResponse, ContractError> {
     let msg: Ics20Packet = from_binary(&packet.data)?;
 
-    // undo the balance update (but not for pre-v2/None packets which didn't add before sending)
-    if msg.v.is_some() {
-        reduce_channel_balance(deps.storage, &packet.src.channel_id, &msg.denom, msg.amount)?;
-    }
+    // undo the balance update on failure (as we pre-emptively added it on send)
+    reduce_channel_balance(deps.storage, &packet.src.channel_id, &msg.denom, msg.amount)?;
 
     let to_send = Amount::from_parts(msg.denom.clone(), msg.amount);
     let gas_limit = check_gas_limit(deps.as_ref(), &to_send)?;
@@ -426,7 +413,7 @@ mod test {
             "wasm1fucynrfkrt684pm8jrt8la5h2csvs5cnldcgqc",
         );
         // Example message generated from the SDK
-        let expected = r#"{"amount":"12345","denom":"ucosm","receiver":"wasm1fucynrfkrt684pm8jrt8la5h2csvs5cnldcgqc","sender":"cosmos1zedxv25ah8fksmg2lzrndrpkvsjqgk4zt5ff7n","v":2}"#;
+        let expected = r#"{"amount":"12345","denom":"ucosm","receiver":"wasm1fucynrfkrt684pm8jrt8la5h2csvs5cnldcgqc","sender":"cosmos1zedxv25ah8fksmg2lzrndrpkvsjqgk4zt5ff7n"}"#;
 
         let encdoded = String::from_utf8(to_vec(&packet).unwrap()).unwrap();
         assert_eq!(expected, encdoded.as_str());
@@ -474,7 +461,6 @@ mod test {
             amount: amount.into(),
             sender: "remote-sender".to_string(),
             receiver: receiver.to_string(),
-            v: Some(V2),
         };
         print!("Packet denom: {}", &data.denom);
         IbcPacket::new(
@@ -535,7 +521,6 @@ mod test {
             amount: Uint128::new(987654321),
             sender: "local-sender".to_string(),
             receiver: "remote-rcpt".to_string(),
-            v: Some(V2),
         };
         let timeout = mock_env().block.time.plus_seconds(DEFAULT_TIMEOUT);
         assert_eq!(

--- a/contracts/cw20-ics20/src/migrations.rs
+++ b/contracts/cw20-ics20/src/migrations.rs
@@ -17,11 +17,13 @@ pub mod v1 {
 
 // v2 format is anything older than 0.13.1 when we only updated the internal balances on success ack
 pub mod v2 {
-    use crate::state::{CHANNEL_INFO, CHANNEL_STATE};
+    use crate::amount::Amount;
+    use crate::state::{ChannelState, CHANNEL_INFO, CHANNEL_STATE};
     use crate::ContractError;
-    use cosmwasm_std::{Coin, DepsMut, Env, Order, StdResult};
+    use cosmwasm_std::{to_binary, Addr, DepsMut, Env, Order, StdResult, WasmQuery};
+    use cw20::{BalanceResponse, Cw20QueryMsg};
 
-    pub fn update_balances(deps: DepsMut, env: &Env) -> Result<(), ContractError> {
+    pub fn update_balances(mut deps: DepsMut, env: &Env) -> Result<(), ContractError> {
         let channels = CHANNEL_INFO
             .keys(deps.storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()?;
@@ -34,17 +36,8 @@ pub mod v2 {
                     .prefix(channel)
                     .range(deps.storage, None, None, Order::Ascending)
                     .collect::<StdResult<Vec<_>>>()?;
-                for (denom, mut state) in states.into_iter() {
-                    // this checks if we have received some coins that are "in flight" and not yet accounted in the state
-                    let Coin { amount, .. } = deps.querier.query_balance(addr, &denom)?;
-                    let diff = amount - state.outstanding;
-                    // if they are in flight, we add them to the internal state now, as if we added them when sent (not when acked)
-                    // to match the current logic
-                    if !diff.is_zero() {
-                        state.outstanding += diff;
-                        state.total_sent += diff;
-                        CHANNEL_STATE.save(deps.storage, (channel, &denom), &state)?;
-                    }
+                for (denom, state) in states.into_iter() {
+                    update_denom(deps.branch(), addr, channel, denom, state)?;
                 }
                 Ok(())
             }
@@ -52,5 +45,45 @@ pub mod v2 {
                 previous_contract: "multiple channels open".into(),
             }),
         }
+    }
+
+    fn update_denom(
+        deps: DepsMut,
+        contract: &Addr,
+        channel: &str,
+        denom: String,
+        mut state: ChannelState,
+    ) -> StdResult<()> {
+        // handle this for both native and cw20
+        let balance = match Amount::from_parts(denom.clone(), state.outstanding) {
+            Amount::Native(coin) => deps.querier.query_balance(contract, coin.denom)?.amount,
+            Amount::Cw20(coin) => {
+                // FIXME: we should be able to do this with the following line, but QuerierWrapper doesn't play
+                // with the Querier generics
+                // Cw20Contract(contract.clone()).balance(&deps.querier, contract)?
+                let msg = Cw20QueryMsg::Balance {
+                    address: contract.into(),
+                };
+                let query = WasmQuery::Smart {
+                    contract_addr: coin.address,
+                    msg: to_binary(&msg)?,
+                }
+                .into();
+                let res: BalanceResponse = deps.querier.query(&query)?;
+                res.balance
+            }
+        };
+
+        // this checks if we have received some coins that are "in flight" and not yet accounted in the state
+        let diff = balance - state.outstanding;
+        // if they are in flight, we add them to the internal state now, as if we added them when sent (not when acked)
+        // to match the current logic
+        if !diff.is_zero() {
+            state.outstanding += diff;
+            state.total_sent += diff;
+            CHANNEL_STATE.save(deps.storage, (channel, &denom), &state)?;
+        }
+
+        Ok(())
     }
 }

--- a/contracts/cw20-ics20/src/migrations.rs
+++ b/contracts/cw20-ics20/src/migrations.rs
@@ -60,16 +60,14 @@ pub mod v2 {
             Amount::Cw20(coin) => {
                 // FIXME: we should be able to do this with the following line, but QuerierWrapper doesn't play
                 // with the Querier generics
-                // Cw20Contract(contract.clone()).balance(&deps.querier, contract)?
-                let msg = Cw20QueryMsg::Balance {
-                    address: contract.into(),
-                };
+                // `Cw20Contract(contract.clone()).balance(&deps.querier, contract)?`
                 let query = WasmQuery::Smart {
                     contract_addr: coin.address,
-                    msg: to_binary(&msg)?,
-                }
-                .into();
-                let res: BalanceResponse = deps.querier.query(&query)?;
+                    msg: to_binary(&Cw20QueryMsg::Balance {
+                        address: contract.into(),
+                    })?,
+                };
+                let res: BalanceResponse = deps.querier.query(&query.into())?;
                 res.balance
             }
         };

--- a/contracts/cw20-ics20/src/migrations.rs
+++ b/contracts/cw20-ics20/src/migrations.rs
@@ -37,7 +37,7 @@ pub mod v2 {
                 for (denom, mut state) in states.into_iter() {
                     // this checks if we have received some coins that are "in flight" and not yet accounted in the state
                     let Coin { amount, .. } = deps.querier.query_balance(addr, &denom)?;
-                    let diff = state.outstanding - amount;
+                    let diff = amount - state.outstanding;
                     // if they are in flight, we add them to the internal state now, as if we added them when sent (not when acked)
                     // to match the current logic
                     if !diff.is_zero() {

--- a/contracts/cw20-ics20/src/migrations.rs
+++ b/contracts/cw20-ics20/src/migrations.rs
@@ -14,3 +14,43 @@ pub mod v1 {
 
     pub const CONFIG: Item<Config> = Item::new("ics20_config");
 }
+
+// v2 format is anything older than 0.13.1 when we only updated the internal balances on success ack
+pub mod v2 {
+    use crate::state::{CHANNEL_INFO, CHANNEL_STATE};
+    use crate::ContractError;
+    use cosmwasm_std::{Coin, DepsMut, Env, Order, StdResult};
+
+    pub fn update_balances(deps: DepsMut, env: &Env) -> Result<(), ContractError> {
+        let channels = CHANNEL_INFO
+            .keys(deps.storage, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()?;
+        match channels.len() {
+            0 => Ok(()),
+            1 => {
+                let channel = &channels[0];
+                let addr = &env.contract.address;
+                let states = CHANNEL_STATE
+                    .prefix(channel)
+                    .range(deps.storage, None, None, Order::Ascending)
+                    .collect::<StdResult<Vec<_>>>()?;
+                for (denom, mut state) in states.into_iter() {
+                    // this checks if we have received some coins that are "in flight" and not yet accounted in the state
+                    let Coin { amount, .. } = deps.querier.query_balance(addr, &denom)?;
+                    let diff = state.outstanding - amount;
+                    // if they are in flight, we add them to the internal state now, as if we added them when sent (not when acked)
+                    // to match the current logic
+                    if !diff.is_zero() {
+                        state.outstanding += diff;
+                        state.total_sent += diff;
+                        CHANNEL_STATE.save(deps.storage, (channel, &denom), &state)?;
+                    }
+                }
+                Ok(())
+            }
+            _ => Err(ContractError::CannotMigrate {
+                previous_contract: "multiple channels open".into(),
+            }),
+        }
+    }
+}


### PR DESCRIPTION
Closes #662 

We change the logic to always be the "v2" style, and no longer add a flag in the packet (which is rejected by the transfer module), but rather migrate current state to new format if possible (for 1 open channel, we can assign all current balance to inflight for this channel). 

If there are production versions that have multiple open channels and need migration, please comment here, and we could possibly support that migration in the future (but it is much trickier).

cc: @giansalex

TODO: add a test for the migration code