### PR TITLE
Prepare 0.13.1 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,7 +597,7 @@ jobs:
       - run:
           name: Install check_contract
           # Uses --debug for compilation speed
-          command: cargo install --debug --version 1.0.0-beta4 --features iterator --example check_contract -- cosmwasm-vm
+          command: cargo install --debug --version 1.0.0-beta6 --features iterator --example check_contract -- cosmwasm-vm
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 ## [Unreleased](https://github.com/CosmWasm/cw-plus/tree/HEAD)
 
-[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.13.0...HEAD)
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.13.1...HEAD)
+
+## [v0.13.1](https://github.com/CosmWasm/cw-plus/tree/v0.13.1) (2022-03-25)
+
+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/v0.13.0...v0.13.1)
+
+**Closed issues:**
+
+- cw20-base: duplicate accounts get overwritten in Init [\#683](https://github.com/CosmWasm/cw-plus/issues/683)
+- Implementation of hooks.rs \(not\) as `HashMap` [\#682](https://github.com/CosmWasm/cw-plus/issues/682)
+- Release `cw-plus` v0.13.0 [\#673](https://github.com/CosmWasm/cw-plus/issues/673)
+- ICS20, invalid packet data [\#662](https://github.com/CosmWasm/cw-plus/issues/662)
+- Duplicate accounts in cw20 initial balances causes unrecoverable inconsistent state [\#626](https://github.com/CosmWasm/cw-plus/issues/626)
+
+**Merged pull requests:**
+
+- Add default gas limit to cw20-ics20 [\#685](https://github.com/CosmWasm/cw-plus/pull/685) ([ethanfrey](https://github.com/ethanfrey))
+- Fix cw20 ics20 packets [\#684](https://github.com/CosmWasm/cw-plus/pull/684) ([ethanfrey](https://github.com/ethanfrey))
+- Clarify the stability of cw-storage-plus, no longer Experimental [\#676](https://github.com/CosmWasm/cw-plus/pull/676) ([ethanfrey](https://github.com/ethanfrey))
+- Update changelog add upcoming [\#675](https://github.com/CosmWasm/cw-plus/pull/675) ([maurolacy](https://github.com/maurolacy))
+- Reject proposals early [\#668](https://github.com/CosmWasm/cw-plus/pull/668) ([Callum-A](https://github.com/Callum-A))
+- cw20-base: validate addresses are unique in initial balances [\#659](https://github.com/CosmWasm/cw-plus/pull/659) ([harryscholes](https://github.com/harryscholes))
+- New SECURITY.md refering to wasmd [\#624](https://github.com/CosmWasm/cw-plus/pull/624) ([ethanfrey](https://github.com/ethanfrey))
 
 ## [v0.13.0](https://github.com/CosmWasm/cw-plus/tree/v0.13.0) (2022-03-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 
 - cw20-base: duplicate accounts get overwritten in Init [\#683](https://github.com/CosmWasm/cw-plus/issues/683)
 - Implementation of hooks.rs \(not\) as `HashMap` [\#682](https://github.com/CosmWasm/cw-plus/issues/682)
-- Release `cw-plus` v0.13.0 [\#673](https://github.com/CosmWasm/cw-plus/issues/673)
 - ICS20, invalid packet data [\#662](https://github.com/CosmWasm/cw-plus/issues/662)
 - Duplicate accounts in cw20 initial balances causes unrecoverable inconsistent state [\#626](https://github.com/CosmWasm/cw-plus/issues/626)
 
@@ -36,6 +35,7 @@
 
 **Closed issues:**
 
+- Release `cw-plus` v0.13.0 [\#673](https://github.com/CosmWasm/cw-plus/issues/673)
 - Querying over composite key [\#664](https://github.com/CosmWasm/cw-plus/issues/664)
 - the method `may_load` exists for struct `cw_storage_plus::Map<'static, (std::string::String, Uint256), Uint256>`, but its trait bounds were not satisfied the following trait bounds were not satisfied: `(std::string::String, Uint256): PrimaryKey` [\#663](https://github.com/CosmWasm/cw-plus/issues/663)
 - Make `Bound` helpers return `Option<Self>` [\#644](https://github.com/CosmWasm/cw-plus/issues/644)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-std",
  "criterion",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "cw1"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-subkeys"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist-ng"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "cw1155"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cw1155-base"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-ics20"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "cw3"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-fixed-multisig"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-flex-multisig"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "cw4"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-group"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-stake"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-subkeys"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement subkeys for authorizing native tokens as a cw1 proxy contract"
@@ -19,12 +19,12 @@ library = []
 test-utils = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw1 = { path = "../../packages/cw1", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.13.0", features = ["library"] }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw1 = { path = "../../packages/cw1", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.13.1", features = ["library"] }
 cosmwasm-std = { version = "1.0.0-beta6", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.23"
@@ -32,4 +32,4 @@ semver = "1"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.13.0", features = ["library", "test-utils"] }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.13.1", features = ["library", "test-utils"] }

--- a/contracts/cw1-whitelist-ng/Cargo.toml
+++ b/contracts/cw1-whitelist-ng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist-ng"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Bartłomiej Kuras <bartk@confio.gmbh>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -22,20 +22,20 @@ querier = ["library"]
 multitest = ["cw-multi-test", "anyhow"]
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw1 = { path = "../../packages/cw1", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw1 = { path = "../../packages/cw1", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.0", optional = true }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1", optional = true }
 anyhow = { version = "1", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1"
 cosmwasm-schema = { version = "1.0.0-beta6" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.0" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1" }
 derivative = "2"

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -19,11 +19,11 @@ library = []
 test-utils = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw1 = { path = "../../packages/cw1", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw1 = { path = "../../packages/cw1", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
@@ -32,5 +32,5 @@ thiserror = { version = "1.0.23" }
 anyhow = "1"
 assert_matches = "1"
 cosmwasm-schema = { version = "1.0.0-beta6" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.0" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1" }
 derivative = "2"

--- a/contracts/cw1155-base/Cargo.toml
+++ b/contracts/cw1155-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155-base"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-1155 compliant token"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
-cw1155 = { path = "../../packages/cw1155", version = "0.13.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
+cw1155 = { path = "../../packages/cw1155", version = "0.13.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-base"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-20 compliant token"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
-cw20 = { path = "../../packages/cw20", version = "0.13.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
+cw20 = { path = "../../packages/cw20", version = "0.13.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-ics20/Cargo.toml
+++ b/contracts/cw20-ics20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-ics20"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "IBC Enabled contracts that receives CW20 tokens and sends them over ICS20 to a remote chain"
@@ -18,12 +18,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
-cw20 = { path = "../../packages/cw20", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
+cw20 = { path = "../../packages/cw20", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6", features = ["stargate"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
-cw-controllers = { path = "../../packages/controllers", version = "0.13.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
+cw-controllers = { path = "../../packages/controllers", version = "0.13.1" }
 schemars = "0.8.1"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-fixed-multisig"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with an fixed group multisig"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
-cw3 = { path = "../../packages/cw3", version = "0.13.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
+cw3 = { path = "../../packages/cw3", version = "0.13.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -29,6 +29,6 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
-cw20 = { path = "../../packages/cw20", version = "0.13.0" }
-cw20-base = { path = "../cw20-base", version = "0.13.0", features = ["library"] }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.0" }
+cw20 = { path = "../../packages/cw20", version = "0.13.1" }
+cw20-base = { path = "../cw20-base", version = "0.13.1", features = ["library"] }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1" }

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-flex-multisig"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with multiple voting patterns and dynamic groups"
@@ -18,12 +18,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
-cw3 = { path = "../../packages/cw3", version = "0.13.0" }
-cw3-fixed-multisig = { path = "../cw3-fixed-multisig", version = "0.13.0", features = ["library"] }
-cw4 = { path = "../../packages/cw4", version = "0.13.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
+cw3 = { path = "../../packages/cw3", version = "0.13.1" }
+cw3-fixed-multisig = { path = "../cw3-fixed-multisig", version = "0.13.1", features = ["library"] }
+cw4 = { path = "../../packages/cw4", version = "0.13.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -31,5 +31,5 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
-cw4-group = { path = "../cw4-group", version = "0.13.0" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.0" }
+cw4-group = { path = "../cw4-group", version = "0.13.1" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1" }

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-group"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple cw4 implementation of group membership controlled by admin "
@@ -26,11 +26,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
-cw4 = { path = "../../packages/cw4", version = "0.13.0" }
-cw-controllers = { path = "../../packages/controllers", version = "0.13.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
+cw4 = { path = "../../packages/cw4", version = "0.13.1" }
+cw-controllers = { path = "../../packages/controllers", version = "0.13.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-stake"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CW4 implementation of group based on staked tokens"
@@ -26,12 +26,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw2 = { path = "../../packages/cw2", version = "0.13.0" }
-cw4 = { path = "../../packages/cw4", version = "0.13.0" }
-cw20 = { path = "../../packages/cw20", version = "0.13.0" }
-cw-controllers = { path = "../../packages/controllers", version = "0.13.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw2 = { path = "../../packages/cw2", version = "0.13.1" }
+cw4 = { path = "../../packages/cw4", version = "0.13.1" }
+cw20 = { path = "../../packages/cw20", version = "0.13.1" }
+cw-controllers = { path = "../../packages/controllers", version = "0.13.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/controllers/Cargo.toml
+++ b/packages/controllers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-controllers"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common controllers we can reuse in many contracts"
@@ -13,8 +13,8 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta6" }
-cw-utils = { path = "../utils", version = "0.13.0" }
-cw-storage-plus = { path = "../storage-plus", version = "0.13.0" }
+cw-utils = { path = "../utils", version = "0.13.1" }
+cw-storage-plus = { path = "../storage-plus", version = "0.13.1" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }

--- a/packages/cw1/Cargo.toml
+++ b/packages/cw1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1 interface"

--- a/packages/cw1155/Cargo.toml
+++ b/packages/cw1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1155 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw2"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-2 interface"
@@ -11,6 +11,6 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0-beta6", default-features = false }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw20/Cargo.toml
+++ b/packages/cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-20 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw3/Cargo.toml
+++ b/packages/cw3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw4/Cargo.toml
+++ b/packages/cw4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-4 Interface: Groups Members"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-storage-plus = { path = "../storage-plus", version = "0.13.0" }
+cw-storage-plus = { path = "../storage-plus", version = "0.13.1" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-multi-test"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Test helpers for multi-contract interactions"
@@ -18,8 +18,8 @@ staking = ["cosmwasm-std/staking"]
 backtrace = ["anyhow/backtrace"]
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0"}
+cw-utils = { path = "../../packages/utils", version = "0.13.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1"}
 cosmwasm-std = { version = "1.0.0-beta6", features = ["staking"] }
 cosmwasm-storage = { version = "1.0.0-beta6" }
 itertools = "0.10.1"

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-storage-plus"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Enhanced storage engines"

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-utils"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common helpers for other cw specs"
@@ -18,5 +18,5 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
 [dev-dependencies]
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
 prost = "0.9"


### PR DESCRIPTION
This updates the version, so we can publish a v0.13.1 release.

I merged a number of long outstanding PRs and gave feedback to correct https://github.com/CosmWasm/cw-plus/pull/668

I also added some fixes to the ics20 contract. I think I am the only one really using this currently, and I will test in ts-relayer when a release is cut.

