### PR TITLE
Make `KeyDeserialize` trait public

### DIFF
--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -18,6 +18,7 @@ mod snapshot;
 
 #[cfg(feature = "iterator")]
 pub use bound::{Bound, Bounder, PrefixBound, RawBound};
+pub use de::KeyDeserialize;
 pub use endian::Endian;
 #[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::marker::PhantomData;
 
 #[cfg(feature = "iterator")]
-use crate::bound::{Bound, Bounder, PrefixBound};
+use crate::bound::{Bound, PrefixBound};
 #[cfg(feature = "iterator")]
 use crate::de::KeyDeserialize;
 use crate::helpers::query_raw;
@@ -196,7 +196,7 @@ where
 impl<'a, K, T> Map<'a, K, T>
 where
     T: Serialize + DeserializeOwned,
-    K: PrimaryKey<'a> + Bounder<'a>,
+    K: PrimaryKey<'a>,
 {
     pub fn range_raw<'c>(
         &self,
@@ -229,7 +229,7 @@ where
 impl<'a, K, T> Map<'a, K, T>
 where
     T: Serialize + DeserializeOwned,
-    K: PrimaryKey<'a> + KeyDeserialize + Bounder<'a>,
+    K: PrimaryKey<'a> + KeyDeserialize,
 {
     pub fn range<'c>(
         &self,
@@ -269,6 +269,9 @@ mod test {
     use cosmwasm_std::testing::MockStorage;
     #[cfg(feature = "iterator")]
     use cosmwasm_std::{Order, StdResult};
+
+    #[cfg(feature = "iterator")]
+    use crate::bound::Bounder;
 
     use crate::int_key::CwIntKey;
     #[cfg(feature = "iterator")]

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -196,7 +196,7 @@ where
 impl<'a, K, T> Map<'a, K, T>
 where
     T: Serialize + DeserializeOwned,
-    K: PrimaryKey<'a> + KeyDeserialize + Bounder<'a>,
+    K: PrimaryKey<'a> + Bounder<'a>,
 {
     pub fn range_raw<'c>(
         &self,
@@ -223,7 +223,14 @@ where
     {
         self.no_prefix_raw().keys_raw(store, min, max, order)
     }
+}
 
+#[cfg(feature = "iterator")]
+impl<'a, K, T> Map<'a, K, T>
+where
+    T: Serialize + DeserializeOwned,
+    K: PrimaryKey<'a> + KeyDeserialize + Bounder<'a>,
+{
     pub fn range<'c>(
         &self,
         store: &'c dyn Storage,


### PR DESCRIPTION
Closes #691.

Also fixes trait bounds required for `Map`.

Fixing all the trait bounds requires a detailed analysis that is out of scope here. Will be done as part of #693.