### PR TITLE
Upgrade all contracts and packages to cosmwasm-std beta8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,7 +597,7 @@ jobs:
       - run:
           name: Install check_contract
           # Uses --debug for compilation speed
-          command: cargo install --debug --version 1.0.0-beta6 --features iterator --example check_contract -- cosmwasm-vm
+          command: cargo install --debug --version 1.0.0-beta8 --features iterator --example check_contract -- cosmwasm-vm
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,22 +155,22 @@ checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0-beta6"
+version = "1.0.0-beta8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc1443004c6340e55ca66d98e9d2f1a44aadf4ce2bed2c4f29baa8a15e7b7"
+checksum = "37e70111e9701c3ec43bfbff0e523cd4cb115876b4d3433813436dd0934ee962"
 dependencies = [
  "digest",
  "ed25519-zebra",
  "k256",
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0-beta6"
+version = "1.0.0-beta8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4f0f10f165b8bcc558a13cddb498140960544519aa0581532c766dd80b5598"
+checksum = "58bc2ad5d86be5f6068833f63e20786768db6890019c095dd7775232184fb7b3"
 dependencies = [
  "syn",
 ]
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0-beta6"
+version = "1.0.0-beta8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0f3145097b692b2d95fa5d2c7c6fdd60f193ccc709857e7e1987a608725300"
+checksum = "915ca82bd944f116f3a9717481f3fa657e4a73f28c4887288761ebb24e6fbe10"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-beta6"
+version = "1.0.0-beta8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2945b2c28f64a09e1831f8f830641dc86b39b374c211215e88f2252f474dcb6e"
+checksum = "1c4be9fd8c9d3ae7d0c32a925ecbc20707007ce0cba1f7538c0d78b7a2d3729b"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -701,16 +701,17 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
+checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
  "serde",
  "sha2",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -1358,9 +1359,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uint"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0-beta6"
+version = "1.0.0-beta8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497432aa9a8e154e3789845f64049d088eb797ba5a7f78da312153f46c822388"
+checksum = "0d75f6a05667d8613b24171ef2c77a8bf6fb9c14f9e3aaa39aa10e0c6416ed67"
 dependencies = [
  "schemars",
  "serde_json",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-std",
  "criterion",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "cw1"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-subkeys"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist-ng"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "cw1155"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cw1155-base"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-ics20"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "cw3"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-fixed-multisig"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-flex-multisig"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "cw4"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-group"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-stake"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-subkeys"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement subkeys for authorizing native tokens as a cw1 proxy contract"
@@ -19,17 +19,17 @@ library = []
 test-utils = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw1 = { path = "../../packages/cw1", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.13.1", features = ["library"] }
-cosmwasm-std = { version = "1.0.0-beta6", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw1 = { path = "../../packages/cw1", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.13.2", features = ["library"] }
+cosmwasm-std = { version = "1.0.0-beta8", features = ["staking"] }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.23"
 semver = "1"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.13.1", features = ["library", "test-utils"] }
+cosmwasm-schema = { version = "1.0.0-beta8" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.13.2", features = ["library", "test-utils"] }

--- a/contracts/cw1-whitelist-ng/Cargo.toml
+++ b/contracts/cw1-whitelist-ng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist-ng"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Bartłomiej Kuras <bartk@confio.gmbh>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -22,20 +22,20 @@ querier = ["library"]
 multitest = ["cw-multi-test", "anyhow"]
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw1 = { path = "../../packages/cw1", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw1 = { path = "../../packages/cw1", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8", features = ["staking"] }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1", optional = true }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.2", optional = true }
 anyhow = { version = "1", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1"
-cosmwasm-schema = { version = "1.0.0-beta6" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1" }
+cosmwasm-schema = { version = "1.0.0-beta8" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.2" }
 derivative = "2"

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -19,11 +19,11 @@ library = []
 test-utils = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw1 = { path = "../../packages/cw1", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw1 = { path = "../../packages/cw1", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8", features = ["staking"] }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
@@ -31,6 +31,6 @@ thiserror = { version = "1.0.23" }
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1"
-cosmwasm-schema = { version = "1.0.0-beta6" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1" }
+cosmwasm-schema = { version = "1.0.0-beta8" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.2" }
 derivative = "2"

--- a/contracts/cw1155-base/Cargo.toml
+++ b/contracts/cw1155-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155-base"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-1155 compliant token"
@@ -18,14 +18,14 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cw1155 = { path = "../../packages/cw1155", version = "0.13.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cw1155 = { path = "../../packages/cw1155", version = "0.13.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-base"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-20 compliant token"
@@ -18,14 +18,14 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cw20 = { path = "../../packages/cw20", version = "0.13.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cw20 = { path = "../../packages/cw20", version = "0.13.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/contracts/cw20-ics20/Cargo.toml
+++ b/contracts/cw20-ics20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-ics20"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "IBC Enabled contracts that receives CW20 tokens and sends them over ICS20 to a remote chain"
@@ -18,16 +18,16 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cw20 = { path = "../../packages/cw20", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6", features = ["stargate"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
-cw-controllers = { path = "../../packages/controllers", version = "0.13.1" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cw20 = { path = "../../packages/cw20", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8", features = ["stargate"] }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.13.2" }
 schemars = "0.8.1"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -204,7 +204,7 @@ pub fn execute_allow(
 
 const MIGRATE_MIN_VERSION: &str = "0.11.1";
 const MIGRATE_VERSION_2: &str = "0.12.0-alpha1";
-const MIGRATE_VERSION_3: &str = "0.13.1";
+const MIGRATE_VERSION_3: &str = "0.13.2";
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(mut deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-fixed-multisig"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with an fixed group multisig"
@@ -18,17 +18,17 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cw3 = { path = "../../packages/cw3", version = "0.13.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cw3 = { path = "../../packages/cw3", version = "0.13.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
-cw20 = { path = "../../packages/cw20", version = "0.13.1" }
-cw20-base = { path = "../cw20-base", version = "0.13.1", features = ["library"] }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1" }
+cosmwasm-schema = { version = "1.0.0-beta8" }
+cw20 = { path = "../../packages/cw20", version = "0.13.2" }
+cw20-base = { path = "../cw20-base", version = "0.13.2", features = ["library"] }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.2" }

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-flex-multisig"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with multiple voting patterns and dynamic groups"
@@ -18,18 +18,18 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cw3 = { path = "../../packages/cw3", version = "0.13.1" }
-cw3-fixed-multisig = { path = "../cw3-fixed-multisig", version = "0.13.1", features = ["library"] }
-cw4 = { path = "../../packages/cw4", version = "0.13.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cw3 = { path = "../../packages/cw3", version = "0.13.2" }
+cw3-fixed-multisig = { path = "../cw3-fixed-multisig", version = "0.13.2", features = ["library"] }
+cw4 = { path = "../../packages/cw4", version = "0.13.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
-cw4-group = { path = "../cw4-group", version = "0.13.1" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.13.1" }
+cosmwasm-schema = { version = "1.0.0-beta8" }
+cw4-group = { path = "../cw4-group", version = "0.13.2" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.13.2" }

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-group"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple cw4 implementation of group membership controlled by admin "
@@ -26,15 +26,15 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cw4 = { path = "../../packages/cw4", version = "0.13.1" }
-cw-controllers = { path = "../../packages/controllers", version = "0.13.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cw4 = { path = "../../packages/cw4", version = "0.13.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.13.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-stake"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CW4 implementation of group based on staked tokens"
@@ -26,16 +26,16 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw2 = { path = "../../packages/cw2", version = "0.13.1" }
-cw4 = { path = "../../packages/cw4", version = "0.13.1" }
-cw20 = { path = "../../packages/cw20", version = "0.13.1" }
-cw-controllers = { path = "../../packages/controllers", version = "0.13.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw2 = { path = "../../packages/cw2", version = "0.13.2" }
+cw4 = { path = "../../packages/cw4", version = "0.13.2" }
+cw20 = { path = "../../packages/cw20", version = "0.13.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.13.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/packages/controllers/Cargo.toml
+++ b/packages/controllers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-controllers"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common controllers we can reuse in many contracts"
@@ -12,9 +12,9 @@ documentation = "https://docs.cosmwasm.com"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta6" }
-cw-utils = { path = "../utils", version = "0.13.1" }
-cw-storage-plus = { path = "../storage-plus", version = "0.13.1" }
+cosmwasm-std = { version = "1.0.0-beta8" }
+cw-utils = { path = "../utils", version = "0.13.2" }
+cw-storage-plus = { path = "../storage-plus", version = "0.13.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }

--- a/packages/cw1/Cargo.toml
+++ b/packages/cw1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1 interface"
@@ -10,9 +10,9 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta6" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/packages/cw1155/Cargo.toml
+++ b/packages/cw1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1155 interface"
@@ -10,10 +10,10 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw2"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-2 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta6", default-features = false }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
+cosmwasm-std = { version = "1.0.0-beta8", default-features = false }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw20/Cargo.toml
+++ b/packages/cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-20 interface"
@@ -10,10 +10,10 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/packages/cw3/Cargo.toml
+++ b/packages/cw3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -10,10 +10,10 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/packages/cw4/Cargo.toml
+++ b/packages/cw4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-4 Interface: Groups Members"
@@ -10,10 +10,10 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-storage-plus = { path = "../storage-plus", version = "0.13.1" }
-cosmwasm-std = { version = "1.0.0-beta6" }
+cw-storage-plus = { path = "../storage-plus", version = "0.13.2" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta6" }
+cosmwasm-schema = { version = "1.0.0-beta8" }

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-multi-test"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Test helpers for multi-contract interactions"
@@ -18,8 +18,8 @@ staking = ["cosmwasm-std/staking"]
 backtrace = ["anyhow/backtrace"]
 
 [dependencies]
-cw-utils = { path = "../../packages/utils", version = "0.13.1" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1"}
+cw-utils = { path = "../../packages/utils", version = "0.13.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2"}
 cosmwasm-std = { version = "1.0.0-beta8", features = ["staking"] }
 cosmwasm-storage = { version = "1.0.0-beta8" }
 itertools = "0.10.1"

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -20,8 +20,8 @@ backtrace = ["anyhow/backtrace"]
 [dependencies]
 cw-utils = { path = "../../packages/utils", version = "0.13.1" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1"}
-cosmwasm-std = { version = "1.0.0-beta6", features = ["staking"] }
-cosmwasm-storage = { version = "1.0.0-beta6" }
+cosmwasm-std = { version = "1.0.0-beta8", features = ["staking"] }
+cosmwasm-storage = { version = "1.0.0-beta8" }
 itertools = "0.10.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -779,7 +779,7 @@ where
             .range_raw(storage, None, None, Order::Ascending)
             .count();
         // we make this longer so it is not rejected by tests
-        // it is lowercase to be compatible with beta8
+        // it is lowercase to be compatible with the MockApi implementation of cosmwasm-std >= 1.0.0-beta8
         Addr::unchecked(format!("contract{}", count))
     }
 

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -779,7 +779,8 @@ where
             .range_raw(storage, None, None, Order::Ascending)
             .count();
         // we make this longer so it is not rejected by tests
-        Addr::unchecked(format!("Contract #{}", count))
+        // it is lowercase to be compatible with beta8
+        Addr::unchecked(format!("contract{}", count))
     }
 
     fn contract_namespace(&self, contract: &Addr) -> Vec<u8> {

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-storage-plus"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Enhanced storage engines"
@@ -18,7 +18,7 @@ iterator = ["cosmwasm-std/iterator"]
 bench = false
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta6", default-features = false }
+cosmwasm-std = { version = "1.0.0-beta8", default-features = false }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-utils"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common helpers for other cw specs"
@@ -12,11 +12,11 @@ documentation = "https://docs.cosmwasm.com"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta6" }
+cosmwasm-std = { version = "1.0.0-beta8" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
 [dev-dependencies]
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.1" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.2" }
 prost = "0.9"


### PR DESCRIPTION
Contracts using multi-test currently fail on cw-std beta8 because all addresses are now required to be normalized/lower case. This should fix that issue.

Specifically this is done by lower-casing the return value of the `next_address` function in multi-test.