### PR TITLE
No Minter Params Error added in cw20 Mint function (to differentiate between unauthorized via wrong sender)

### DIFF
--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -305,7 +305,9 @@ pub fn execute_mint(
     }
 
     let mut config = TOKEN_INFO.load(deps.storage)?;
-    if config.mint.is_none() || config.mint.as_ref().unwrap().minter != info.sender {
+    if config.mint.is_none() {
+        return Err(ContractError::NoMinterParams {});
+    } else if config.mint.as_ref().unwrap().minter != info.sender {
         return Err(ContractError::Unauthorized {});
     }
 

--- a/contracts/cw20-base/src/error.rs
+++ b/contracts/cw20-base/src/error.rs
@@ -9,6 +9,9 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
+    #[error("Minter parameters not configured")]
+    NoMinterParams {},
+
     #[error("Cannot set to own account")]
     CannotSetOwnAccount {},
 


### PR DESCRIPTION
The unauthorized error when mint was not configured in instantiate was a bit misleading