### PR TITLE
Code to convert cw20 to bank denom and vice versa

### DIFF
--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -270,6 +270,7 @@ mod tests {
             }],
             mint: None,
             marketing: None,
+            bank_denom: None,
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -271,7 +271,7 @@ pub fn execute_cw20_to_bank(
 
     let bank_transfer = BankMsg::Send {
         to_address: info.sender.to_string(),
-        amount: coins(amount.u128(), config.bank_denom.unwrap().to_string()),
+        amount: coins(amount.u128(), config.bank_denom.unwrap()),
     };
 
     let res = Response::new().add_message(bank_transfer);
@@ -308,7 +308,7 @@ pub fn execute_bank_to_cw20(
     TOKEN_INFO.save(deps.storage, &config)?;
 
     // add cw20 token amount to sender balance
-    let rcpt_addr = deps.api.addr_validate(&info.sender.as_str())?;
+    let rcpt_addr = deps.api.addr_validate(info.sender.as_str())?;
     BALANCES.update(
         deps.storage,
         &rcpt_addr,

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -73,6 +73,7 @@ mod tests {
             }],
             mint: None,
             marketing: None,
+            bank_denom: None,
         };
         let info = mock_info("creator", &[]);
         let env = mock_env();

--- a/contracts/cw20-base/src/error.rs
+++ b/contracts/cw20-base/src/error.rs
@@ -15,6 +15,15 @@ pub enum ContractError {
     #[error("Invalid zero amount")]
     InvalidZeroAmount {},
 
+    #[error("Insufficient balance")]
+    InsufficientBalance {},
+
+    #[error("Bank denom not set for cw20")]
+    BankDenomNotSet {},
+
+    #[error("Invalid bank denom")]
+    InvalidBankDenom {},
+
     #[error("Allowance is expired")]
     Expired {},
 

--- a/contracts/cw20-base/src/msg.rs
+++ b/contracts/cw20-base/src/msg.rs
@@ -17,7 +17,7 @@ pub struct InstantiateMarketingInfo {
 pub struct InstantiateMsg {
     pub name: String,
     pub symbol: String,
-    pub decimals: u8,    
+    pub decimals: u8,
     pub initial_balances: Vec<Cw20Coin>,
     pub mint: Option<MinterResponse>,
     pub marketing: Option<InstantiateMarketingInfo>,

--- a/contracts/cw20-base/src/msg.rs
+++ b/contracts/cw20-base/src/msg.rs
@@ -17,10 +17,11 @@ pub struct InstantiateMarketingInfo {
 pub struct InstantiateMsg {
     pub name: String,
     pub symbol: String,
-    pub decimals: u8,
+    pub decimals: u8,    
     pub initial_balances: Vec<Cw20Coin>,
     pub mint: Option<MinterResponse>,
     pub marketing: Option<InstantiateMarketingInfo>,
+    pub bank_denom: Option<String>,
 }
 
 impl InstantiateMsg {

--- a/contracts/cw20-base/src/state.rs
+++ b/contracts/cw20-base/src/state.rs
@@ -14,6 +14,7 @@ pub struct TokenInfo {
     pub decimals: u8,
     pub total_supply: Uint128,
     pub mint: Option<MinterData>,
+    pub bank_denom: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/cw3-fixed-multisig/src/integration_tests.rs
+++ b/contracts/cw3-fixed-multisig/src/integration_tests.rs
@@ -82,6 +82,7 @@ fn cw3_controls_cw20() {
             cap: None,
         }),
         marketing: None,
+	bank_denom: None,
     };
     let cw20_addr = router
         .instantiate_contract(

--- a/contracts/cw3-fixed-multisig/src/integration_tests.rs
+++ b/contracts/cw3-fixed-multisig/src/integration_tests.rs
@@ -82,7 +82,7 @@ fn cw3_controls_cw20() {
             cap: None,
         }),
         marketing: None,
-	bank_denom: None,
+        bank_denom: None,
     };
     let cw20_addr = router
         .instantiate_contract(

--- a/packages/cw20/src/msg.rs
+++ b/packages/cw20/src/msg.rs
@@ -8,6 +8,12 @@ use cw_utils::Expiration;
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Cw20ExecuteMsg {
+    /// Cw20ToBank is a base message to convert Cw20 to bank tokens
+    Cw20ToBank { amount: Uint128 },
+
+    /// BankToCw20 is a base message to convert bank tokens to Cw20 tokens
+    BankToCw20 {},
+
     /// Transfer is a base message to move tokens to another account without triggering actions
     Transfer { recipient: String, amount: Uint128 },
     /// Burn is a base message to destroy tokens forever


### PR DESCRIPTION
## Cw20 ↔ Bank denom conversion

This PR extends Cw20 base contract with functionality to convert Cw20 tokens into Bank denom  and vice versa.
### Advantages
- Cw20 tokens can be used as native tokens on the cosmos chain.
- Cw20 tokens can be transferred through IBC to other cosmos chains.
- Cw20 tokens  can be transferred to Ethereum if the bridge from Cosmos to Ethereum exists. etc

### Implementation
To achieve this, the CW20-base contract should be extended with two new functions 
- [x]  **bank_to_cw20**
    - User can invoke this function to convert bank denom to cw20 tokens. Upon invocation,
        - the CW20 contract should verify the user bank balance.
        - transfer the bank denom to CW20 contract address from user balance.
        - Mint equal amount of CW20 tokens for user address.        
- [x]   **cw20_to_bank**
    - User can invoke this function to convert cw20 tokens to bank denom. Upon invocation,
        - the CW20 contract should verify the user cw20 balance.
        - Burn cw20 tokens of the user
        - transfer equal amount of bank denom to user from CW20 contract address.        