### PR TITLE
fix(multi-test): contract mock name for 0.9.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,11 +241,11 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "schemars",
  "serde",
  "thiserror",
@@ -271,13 +271,13 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "derivative",
  "itertools",
  "prost",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -320,10 +320,10 @@ dependencies = [
 
 [[package]]
 name = "cw0"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
+ "cw-storage-plus 0.9.2",
  "schemars",
  "serde",
  "thiserror",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "cw1"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -341,12 +341,12 @@ dependencies = [
 
 [[package]]
 name = "cw1-subkeys"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw1",
  "cw1-whitelist",
  "cw2",
@@ -357,15 +357,15 @@ dependencies = [
 
 [[package]]
 name = "cw1-whitelist"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "assert_matches",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test 0.8.1",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw1",
  "cw2",
  "derivative",
@@ -376,23 +376,23 @@ dependencies = [
 
 [[package]]
 name = "cw1155"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw0 0.9.0",
+ "cw0 0.9.2",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw1155-base"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw1155",
  "cw2",
  "schemars",
@@ -402,33 +402,33 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
+ "cw-storage-plus 0.9.2",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw20"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw0 0.9.0",
+ "cw0 0.9.2",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw20-atomic-swap"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "hex 0.3.2",
@@ -440,12 +440,12 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "schemars",
@@ -455,12 +455,12 @@ dependencies = [
 
 [[package]]
 name = "cw20-bonding"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "cw20-base",
@@ -474,13 +474,13 @@ dependencies = [
 
 [[package]]
 name = "cw20-escrow"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.9.0",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-multi-test 0.9.2",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "cw20-base",
@@ -491,12 +491,12 @@ dependencies = [
 
 [[package]]
 name = "cw20-ics20"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "schemars",
@@ -510,8 +510,8 @@ version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "hex 0.4.3",
@@ -524,13 +524,13 @@ dependencies = [
 
 [[package]]
 name = "cw20-staking"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "cw20-base",
@@ -541,24 +541,24 @@ dependencies = [
 
 [[package]]
 name = "cw3"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw0 0.9.0",
+ "cw0 0.9.2",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw3-fixed-multisig"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.9.0",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-multi-test 0.9.2",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "cw20-base",
@@ -570,13 +570,13 @@ dependencies = [
 
 [[package]]
 name = "cw3-flex-multisig"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test 0.9.0",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-multi-test 0.9.2",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw3",
  "cw4",
@@ -588,24 +588,24 @@ dependencies = [
 
 [[package]]
 name = "cw4"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
+ "cw-storage-plus 0.9.2",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw4-group"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw4",
  "schemars",
@@ -615,13 +615,13 @@ dependencies = [
 
 [[package]]
 name = "cw4-stake"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw20",
  "cw4",
@@ -632,23 +632,23 @@ dependencies = [
 
 [[package]]
 name = "cw721"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw0 0.9.0",
+ "cw0 0.9.2",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw721-base"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw721",
  "schemars",
@@ -658,12 +658,12 @@ dependencies = [
 
 [[package]]
 name = "cw721-metadata-uri"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.9.0",
- "cw0 0.9.0",
+ "cw-storage-plus 0.9.2",
+ "cw0 0.9.2",
  "cw2",
  "cw721",
  "cw721-base",

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-subkeys"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement subkeys for authorizing native tokens as a cw1 proxy contract"
@@ -19,16 +19,16 @@ library = []
 test-utils = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw1 = { path = "../../packages/cw1", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.9.0", features = ["library"] }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw1 = { path = "../../packages/cw1", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.9.2", features = ["library"] }
 cosmwasm-std = { version = "0.16.0", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }
-cw1-whitelist = { path = "../cw1-whitelist", version = "0.9.0", features = ["library", "test-utils"] }
+cw1-whitelist = { path = "../cw1-whitelist", version = "0.9.2", features = ["library", "test-utils"] }

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1-whitelist"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of an proxy contract using a whitelist"
@@ -19,11 +19,11 @@ library = []
 test-utils = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw1 = { path = "../../packages/cw1", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw1 = { path = "../../packages/cw1", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw1155-base/Cargo.toml
+++ b/contracts/cw1155-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155-base"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-1155 compliant token"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw1155 = { path = "../../packages/cw1155", version = "0.9.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw1155 = { path = "../../packages/cw1155", version = "0.9.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-atomic-swap/Cargo.toml
+++ b/contracts/cw20-atomic-swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-atomic-swap"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Mauro Lacy <maurolacy@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of Atomic Swaps"
@@ -15,11 +15,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-base"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Basic implementation of a CosmWasm-20 compliant token"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-bonding/Cargo.toml
+++ b/contracts/cw20-bonding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-bonding"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement basic bonding curve to issue cw20 tokens"
@@ -20,11 +20,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cw20-base = { path = "../../contracts/cw20-base", version = "0.9.0", features = ["library"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
+cw20-base = { path = "../../contracts/cw20-base", version = "0.9.2", features = ["library"] }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0", default-features = false, features = ["staking"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw20-escrow/Cargo.toml
+++ b/contracts/cw20-escrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-escrow"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementation of an escrow that accepts CosmWasm-20 tokens as well as native tokens"
@@ -18,16 +18,16 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.9.0" }
-cw20-base = { path = "../cw20-base", version = "0.9.0", features = ["library"] }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.9.2" }
+cw20-base = { path = "../cw20-base", version = "0.9.2", features = ["library"] }

--- a/contracts/cw20-ics20/Cargo.toml
+++ b/contracts/cw20-ics20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-ics20"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "IBC Enabled contracts that receives CW20 tokens and sends them over ICS20 to a remote chain"
@@ -18,11 +18,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0", features = ["stargate"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw20-merkle-airdrop/Cargo.toml
+++ b/contracts/cw20-merkle-airdrop/Cargo.toml
@@ -19,11 +19,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw20-staking/Cargo.toml
+++ b/contracts/cw20-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-staking"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implement simple staking derivatives as a cw20 token"
@@ -20,13 +20,13 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cw-controllers = { path = "../../packages/controllers", version = "0.9.0" }
-cw20-base = { path = "../../contracts/cw20-base", version = "0.9.0", features = ["library"] }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.9.2" }
+cw20-base = { path = "../../contracts/cw20-base", version = "0.9.2", features = ["library"] }
 cosmwasm-std = { version = "0.16.0", features = ["staking"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-fixed-multisig"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with an fixed group multisig"
@@ -18,10 +18,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw3 = { path = "../../packages/cw3", version = "0.9.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw3 = { path = "../../packages/cw3", version = "0.9.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -29,6 +29,6 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cw20-base = { path = "../cw20-base", version = "0.9.0", features = ["library"] }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.9.0" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
+cw20-base = { path = "../cw20-base", version = "0.9.2", features = ["library"] }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.9.2" }

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-flex-multisig"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing cw3 with multiple voting patterns and dynamic groups"
@@ -18,11 +18,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw3 = { path = "../../packages/cw3", version = "0.9.0" }
-cw4 = { path = "../../packages/cw4", version = "0.9.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw3 = { path = "../../packages/cw3", version = "0.9.2" }
+cw4 = { path = "../../packages/cw4", version = "0.9.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -30,5 +30,5 @@ thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }
-cw4-group = { path = "../cw4-group", version = "0.9.0" }
-cw-multi-test = { path = "../../packages/multi-test", version = "0.9.0" }
+cw4-group = { path = "../cw4-group", version = "0.9.2" }
+cw-multi-test = { path = "../../packages/multi-test", version = "0.9.2" }

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-group"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple cw4 implementation of group membership controlled by admin "
@@ -26,11 +26,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw4 = { path = "../../packages/cw4", version = "0.9.0" }
-cw-controllers = { path = "../../packages/controllers", version = "0.9.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw4 = { path = "../../packages/cw4", version = "0.9.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.9.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-stake"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CW4 implementation of group based on staked tokens"
@@ -26,12 +26,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw4 = { path = "../../packages/cw4", version = "0.9.0" }
-cw20 = { path = "../../packages/cw20", version = "0.9.0" }
-cw-controllers = { path = "../../packages/controllers", version = "0.9.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw4 = { path = "../../packages/cw4", version = "0.9.2" }
+cw20 = { path = "../../packages/cw20", version = "0.9.2" }
+cw-controllers = { path = "../../packages/controllers", version = "0.9.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-base"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Basic implementation cw721 NFTs"
@@ -25,10 +25,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw721 = { path = "../../packages/cw721", version = "0.9.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw721 = { path = "../../packages/cw721", version = "0.9.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw721-metadata-uri/Cargo.toml
+++ b/contracts/cw721-metadata-uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-metadata-uri"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Example extending CW721 NFT with ERC20 like metadata_uri"
@@ -25,11 +25,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw2 = { path = "../../packages/cw2", version = "0.9.0" }
-cw721 = { path = "../../packages/cw721", version = "0.9.0" }
-cw721-base = { path = "../cw721-base", version = "0.9.0", features = ["library"] }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw2 = { path = "../../packages/cw2", version = "0.9.2" }
+cw721 = { path = "../../packages/cw721", version = "0.9.2" }
+cw721-base = { path = "../cw721-base", version = "0.9.2", features = ["library"] }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/controllers/Cargo.toml
+++ b/packages/controllers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-controllers"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common controllers we can reuse in many contracts"
@@ -13,8 +13,8 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "0.16.0" }
-cw0 = { path = "../cw0", version = "0.9.0" }
-cw-storage-plus = { path = "../storage-plus", version = "0.9.0" }
+cw0 = { path = "../cw0", version = "0.9.2" }
+cw-storage-plus = { path = "../storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }

--- a/packages/cw0/Cargo.toml
+++ b/packages/cw0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw0"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Common helpers for other cw specs"
@@ -18,4 +18,4 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 
 [dev-dependencies]
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }

--- a/packages/cw1/Cargo.toml
+++ b/packages/cw1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1 interface"

--- a/packages/cw1155/Cargo.toml
+++ b/packages/cw1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw1155"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Huang Yi <huang@crypto.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-1155 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw2"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-2 interface"
@@ -11,6 +11,6 @@ documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "0.16.0", default-features = false }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw20/Cargo.toml
+++ b/packages/cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-20 interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw3/Cargo.toml
+++ b/packages/cw3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw4/Cargo.toml
+++ b/packages/cw4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm-4 Interface: Groups Members"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-storage-plus = { path = "../storage-plus", version = "0.9.0" }
+cw-storage-plus = { path = "../storage-plus", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-721 NFT interface"
@@ -10,7 +10,7 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/multi-test/Cargo.toml
+++ b/packages/multi-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-multi-test"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Test helpers for multi-contract interactions"
@@ -17,8 +17,8 @@ stargate = ["cosmwasm-std/stargate"]
 backtrace = ["anyhow/backtrace"]
 
 [dependencies]
-cw0 = { path = "../../packages/cw0", version = "0.9.0" }
-cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.0"}
+cw0 = { path = "../../packages/cw0", version = "0.9.2" }
+cw-storage-plus = { path = "../../packages/storage-plus", version = "0.9.2"}
 cosmwasm-std = { version = "0.16.0", features = ["staking"] }
 cosmwasm-storage = { version = "0.16.0" }
 itertools = "0.10.1"

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -741,7 +741,8 @@ where
             .range(storage, None, None, Order::Ascending)
             .count();
         // we make this longer so it is not rejected by tests
-        Addr::unchecked(format!("Contract #{}", count.to_string()))
+        // it is lowercase to be compatible with the MockApi implementation of cosmwasm-std >= 0.16.7
+        Addr::unchecked(format!("contract #{}", count.to_string()))
     }
 
     fn contract_namespace(&self, contract: &Addr) -> Vec<u8> {

--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -742,7 +742,7 @@ where
             .count();
         // we make this longer so it is not rejected by tests
         // it is lowercase to be compatible with the MockApi implementation of cosmwasm-std >= 0.16.7
-        Addr::unchecked(format!("contract #{}", count.to_string()))
+        Addr::unchecked(format!("contract{}", count))
     }
 
     fn contract_namespace(&self, contract: &Addr) -> Vec<u8> {

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-storage-plus"
-version = "0.9.0"
+version = "0.9.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Enhanced/experimental storage engines"


### PR DESCRIPTION
This PR makes the mock name lowercase so the mocked address could pass the normalized validation check in `cosmwasm-std@0.16.7`

Related to: https://github.com/CosmWasm/cw-plus/pull/699

FYI: @webmaster128 @ethanfrey 