### PR TITLE
add execute msg to update minter

### DIFF
--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -307,8 +307,17 @@ pub fn execute_mint(
         return Err(ContractError::InvalidZeroAmount {});
     }
 
-    let mut config = TOKEN_INFO.load(deps.storage)?;
-    if config.mint.is_none() || config.mint.as_ref().unwrap().minter != info.sender {
+    let mut config = TOKEN_INFO
+        .may_load(deps.storage)?
+        .ok_or(ContractError::Unauthorized {})?;
+
+    if config
+        .mint
+        .as_ref()
+        .ok_or(ContractError::Unauthorized {})?
+        .minter
+        != info.sender
+    {
         return Err(ContractError::Unauthorized {});
     }
 
@@ -386,16 +395,19 @@ pub fn execute_update_minter(
     info: MessageInfo,
     new_minter: String,
 ) -> Result<Response, ContractError> {
-    let mut config = TOKEN_INFO.load(deps.storage)?;
-    // Check that sender is authorized to update minter
-    if config.mint.is_none() || config.mint.as_ref().unwrap().minter != info.sender {
+    let mut config = TOKEN_INFO
+        .may_load(deps.storage)?
+        .ok_or(ContractError::Unauthorized {})?;
+
+    let mint = config.mint.as_ref().ok_or(ContractError::Unauthorized {})?;
+    if mint.minter != info.sender {
         return Err(ContractError::Unauthorized {});
     }
 
     let minter = deps.api.addr_validate(&new_minter)?;
     let minter_data = MinterData {
         minter,
-        cap: config.mint.unwrap().cap,
+        cap: mint.cap,
     };
     config.mint = Some(minter_data);
 
@@ -403,7 +415,7 @@ pub fn execute_update_minter(
 
     Ok(Response::default()
         .add_attribute("action", "update_minter")
-        .add_attribute("minter", new_minter))
+        .add_attribute("new_minter", new_minter))
 }
 
 pub fn execute_update_marketing(
@@ -901,25 +913,34 @@ mod tests {
     }
 
     #[test]
-    fn minter_can_update_itself() {
+    fn minter_can_update_minter_but_not_cap() {
         let mut deps = mock_dependencies();
         let minter = String::from("minter");
+        let cap = Some(Uint128::from(3000000u128));
         do_instantiate_with_minter(
             deps.as_mut(),
             &String::from("genesis"),
             Uint128::new(1234),
             &minter,
-            None,
+            cap,
         );
 
+        let new_minter = "new_minter";
         let msg = ExecuteMsg::UpdateMinter {
-            new_minter: String::from("new_minter"),
+            new_minter: new_minter.to_string(),
         };
 
         let info = mock_info(&minter, &[]);
         let env = mock_env();
-        let res = execute(deps.as_mut(), env, info, msg);
+        let res = execute(deps.as_mut(), env.clone(), info, msg);
         assert!(res.is_ok());
+        let query_minter_msg = QueryMsg::Minter {};
+        let res = query(deps.as_ref(), env, query_minter_msg);
+        let mint: MinterResponse = from_binary(&res.unwrap()).unwrap();
+
+        // Minter cannot update cap.
+        assert!(mint.cap == cap);
+        assert!(mint.minter == new_minter)
     }
 
     #[test]

--- a/packages/cw20/src/msg.rs
+++ b/packages/cw20/src/msg.rs
@@ -55,6 +55,8 @@ pub enum Cw20ExecuteMsg {
     /// Only with the "mintable" extension. If authorized, creates amount new tokens
     /// and adds to the recipient balance.
     Mint { recipient: String, amount: Uint128 },
+    /// Only with the "mintable" extension. The current minter may set a new minter.
+    UpdateMinter { new_minter: String },
     /// Only with the "marketing" extension. If authorized, updates marketing metadata.
     /// Setting None/null for any of these will leave it unchanged.
     /// Setting Some("") will clear this field on the contract storage


### PR DESCRIPTION
Allows current minter to update minter. Cap cannot be updated.