### PR TITLE
add new variant Arr to Key enum

### DIFF
--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -12,6 +12,7 @@ pub enum Key<'a> {
     Val32([u8; 4]),
     Val64([u8; 8]),
     Val128([u8; 16]),
+    Arr([u8]), // support key to store indefinite number of bytes
 }
 
 impl<'a> AsRef<[u8]> for Key<'a> {


### PR DESCRIPTION
We might want to have the ability to store whole data within Key instead of only store a reference, e.g. if we want to implement PrimaryKey trait for an enum, currently there seem no obvious solution (Or just me haven't figured it out). the code below throws `returns a value referencing data owned by the current function`. If we allow bytes directly stored in Key, the problem can be solved and allow easier implementation of PrimaryKey trait for more complex types. 
The question is actually what's a recommended/robust way to encode and decode "complicated" key for cw_storage_plus::Map
```
// allow denom as part of key of cw_storage_plus::Map
impl<'a> PrimaryKey<'a> for Denom {
    type Prefix = ();

    type SubPrefix = ();

    type Suffix = Self;

    type SuperSuffix = Self;

    fn key(&self) -> Vec<cw_storage_plus::Key> {
        vec![Key::Ref(&format!("{}", self).as_bytes())] // this throws err since only reference allowed to be stored in Ref
    }
}
```