### PR TITLE
Use into_iter() instead of iter().cloned().

### DIFF
--- a/packages/controllers/src/claim.rs
+++ b/packages/controllers/src/claim.rs
@@ -65,7 +65,7 @@ impl<'a> Claims<'a> {
         let mut to_send = Uint128::zero();
         self.0.update(storage, addr, |claim| -> StdResult<_> {
             let (_send, waiting): (Vec<_>, _) =
-                claim.unwrap_or_default().iter().cloned().partition(|c| {
+                claim.unwrap_or_default().into_iter().partition(|c| {
                     // if mature and we can pay fully, then include in _send
                     if c.release_at.is_expired(block) {
                         if let Some(limit) = cap {


### PR DESCRIPTION
This ought to be a little more efficient as we don't need to clone every element as we walk the list.

Just for fun, I wrote a [little benchmark](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=51a85eeefe13d255485a656de7a3e2ef) for this, then ran it with a couple different sizes using hyperfine. The `into_iter()` method was around 1.5x as fast.