### PR TITLE
Add bytes variant of key using `Box<Vec<u8>>`

### DIFF
--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -12,6 +12,7 @@ pub enum Key<'a> {
     Val32([u8; 4]),
     Val64([u8; 8]),
     Val128([u8; 16]),
+    Bytes(Box<Vec<u8>>),
 }
 
 impl<'a> AsRef<[u8]> for Key<'a> {
@@ -23,6 +24,7 @@ impl<'a> AsRef<[u8]> for Key<'a> {
             Key::Val32(v) => v,
             Key::Val64(v) => v,
             Key::Val128(v) => v,
+            Key::Bytes(v) => v,
         }
     }
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -514,7 +514,7 @@ mod test {
 
     #[test]
     fn nested_bytes_key() {
-        #[derive(Debug, Clone)]
+        #[derive(Debug, Clone, PartialEq)]
         struct Test(String);
 
         impl PrimaryKey<'_> for Test {
@@ -564,5 +564,10 @@ mod test {
         assert_eq!(2, path.len());
         assert_eq!(b"TTT-Test", path[0].as_ref());
         assert_eq!(100u64.to_cw_bytes(), path[1].as_ref());
+
+        assert_eq!(
+            Test::from_vec(b"TTT-F".to_vec()).unwrap(),
+            Test("F".to_string())
+        );
     }
 }

--- a/packages/storage-plus/src/keys.rs
+++ b/packages/storage-plus/src/keys.rs
@@ -548,7 +548,7 @@ mod test {
                 Ok(Self(
                     std::str::from_utf8(&value)
                         .unwrap()
-                        .split("-")
+                        .split('-')
                         .last()
                         .unwrap()
                         .to_string(),

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -1520,11 +1520,11 @@ mod test {
                     .unwrap()
                     .split('-')
                     .collect::<Vec<_>>();
-                Ok(match s[0] {
-                    "n" => AssetInfo::Native(s[1].to_string()),
-                    "c" => AssetInfo::Cw20(s[1].to_string()),
-                    _ => panic!(),
-                })
+                match s[0] {
+                    "n" => Ok(AssetInfo::Native(s[1].to_string())),
+                    "c" => Ok(AssetInfo::Cw20(s[1].to_string())),
+                    _ => Err(StdError::generic_err("Not supported")),
+                }
             }
         }
 
@@ -1557,5 +1557,15 @@ mod test {
                 AssetInfo::Native("uosmo".to_string()),
             ]
         );
+
+        assert_eq!(
+            <&AssetInfo>::from_vec(b"n-uluna".to_vec()).unwrap(),
+            AssetInfo::Native("uluna".to_string())
+        );
+
+        assert!(matches!(
+            <&AssetInfo>::from_vec(b"g-uluna".to_vec()).unwrap_err(),
+            StdError::GenericErr { msg: _ }
+        ));
     }
 }


### PR DESCRIPTION
This makes us able to use dynamic size bytes as a key.

One use case is to index `AssetInfo` with utf-8 bytes and deserialize it back properly into the correct enum variant w/o usage of `addr_validate` as written in `Map` unit-test.

Another use case is to write a macro for auto implementing, `PrimaryKey`, `Prefixer`, and `KeyDeserialize` for "any" struct that impl serde `Serialize` and `Deserialize`.

This means that any struct/enum can be used as a `Map` key. Very useful for storing/indexing.

I'm not sure about the performance of this though, bench function might also be needed.