### PR TITLE
Fix broken links, minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ many custom contracts.
 If you don't know what CosmWasm is, please check out
 [our homepage](https://cosmwasm.com) and
 [our documentation](https://docs.cosmwasm.com) to get more background.
-We are running a [public testnet](https://github.com/CosmWasm/testnets/blob/master/sandynet-1/README.md)
+We are running [public testnets](https://github.com/CosmWasm/testnets#running)
 you can use to test out any contracts.
 
 **Warning** None of these contracts have been audited and no liability is
@@ -62,7 +62,7 @@ cleaner (before: `expires: {at_height: {height: 12345}}` after
 The most reusable components are the various cwXYZ specifications under
 `packages`. Each one defines a standard interface for different domains,
 e.g. [cw20](./packages/cw20/README.md) for fungible tokens,
-[cw721](./packages/cw721/README.md) for non-fungible tokens,
+[cw721](https://github.com/CosmWasm/cw-nfts/blob/main/packages/cw721/README.md) for non-fungible tokens,
 [cw1](./packages/cw1/README.md) for  "proxy contracts", etc.
 The interface comes with a human description in the READMEs, as well
 as Rust types that can be imported.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ and depth of discussion can give an idea how much review was present.
 
 After that, fuzzing it (ideally with an intelligent fuzzer that understands the domain)
 can be valuable. And beyond that formal verification can provide even more assurance
-(but is very time consuming and expensive).
+(but is very time-consuming and expensive).
 
 ### Code Coverage
 
@@ -213,7 +213,7 @@ relevant `Cargo.toml` file for clarity.
 
 All *specifications* will always be Apache-2.0. All contracts that are
 meant to be *building blocks* will also be Apache-2.0. This is along
-the lines of Open Zepellin or other public references.
+the lines of Open Zeppelin or other public references.
 
 Contracts that are "ready to deploy" may be licensed under AGPL 3.0 to
 encourage anyone using them to contribute back any improvements they


### PR DESCRIPTION
I've been running through a few repos that I want to share with my team and correcting small items.
Pretty self-explanatory. I think when the NFTs moved we forgot a couple links so I'm trying to lean in a little.