### PR TITLE
Allowances per spender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "cw2",
  "cw20",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,8 +434,10 @@ version = "0.13.4"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw2",
  "prost",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -24,6 +24,7 @@ cw20 = { path = "../../packages/cw20", version = "0.13.4" }
 cw-storage-plus = { path = "../../packages/storage-plus", version = "0.13.4" }
 cosmwasm-std = { version = "1.0.0" }
 schemars = "0.8.1"
+semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 

--- a/contracts/cw20-base/examples/schema.rs
+++ b/contracts/cw20-base/examples/schema.rs
@@ -4,8 +4,8 @@ use std::fs::create_dir_all;
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
 use cw20::{
-    AllAccountsResponse, AllAllowancesResponse, AllowanceResponse, BalanceResponse,
-    TokenInfoResponse,
+    AllAccountsResponse, AllAllowancesResponse, AllSpenderAllowancesResponse, AllowanceResponse,
+    BalanceResponse, TokenInfoResponse,
 };
 use cw20_base::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
@@ -22,5 +22,6 @@ fn main() {
     export_schema(&schema_for!(BalanceResponse), &out_dir);
     export_schema(&schema_for!(TokenInfoResponse), &out_dir);
     export_schema(&schema_for!(AllAllowancesResponse), &out_dir);
+    export_schema(&schema_for!(AllSpenderAllowancesResponse), &out_dir);
     export_schema(&schema_for!(AllAccountsResponse), &out_dir);
 }

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -14,7 +14,7 @@ use crate::allowances::{
     execute_burn_from, execute_decrease_allowance, execute_increase_allowance, execute_send_from,
     execute_transfer_from, query_allowance,
 };
-use crate::enumerable::{query_all_accounts, query_all_allowances};
+use crate::enumerable::{query_all_accounts, query_owner_allowances, query_spender_allowances};
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::state::{MinterData, TokenInfo, BALANCES, LOGO, MARKETING_INFO, TOKEN_INFO};
@@ -528,7 +528,17 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             owner,
             start_after,
             limit,
-        } => to_binary(&query_all_allowances(deps, owner, start_after, limit)?),
+        } => to_binary(&query_owner_allowances(deps, owner, start_after, limit)?),
+        QueryMsg::AllSpenderAllowances {
+            spender,
+            start_after,
+            limit,
+        } => to_binary(&query_spender_allowances(
+            deps,
+            spender,
+            start_after,
+            limit,
+        )?),
         QueryMsg::AllAccounts { start_after, limit } => {
             to_binary(&query_all_accounts(deps, start_after, limit)?)
         }

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -607,7 +607,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     let original_version =
         ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    if original_version.to_string() < "0.14.0".to_string() {
+    if original_version < "0.14.0".parse::<semver::Version>().unwrap() {
         // Build reverse map of allowances per spender
         let data = ALLOWANCES
             .range(deps.storage, None, None, Ascending)

--- a/contracts/cw20-base/src/msg.rs
+++ b/contracts/cw20-base/src/msg.rs
@@ -93,6 +93,14 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    /// Only with "enumerable" extension (and "allowances")
+    /// Returns all allowances this spender has been granted. Supports pagination.
+    /// Return type: AllSpenderAllowancesResponse.
+    AllSpenderAllowances {
+        spender: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
     /// Only with "enumerable" extension
     /// Returns all accounts that have balances. Supports pagination.
     /// Return type: AllAccountsResponse.

--- a/contracts/cw20-base/src/state.rs
+++ b/contracts/cw20-base/src/state.rs
@@ -34,3 +34,6 @@ pub const MARKETING_INFO: Item<MarketingInfoResponse> = Item::new("marketing_inf
 pub const LOGO: Item<Logo> = Item::new("logo");
 pub const BALANCES: Map<&Addr, Uint128> = Map::new("balance");
 pub const ALLOWANCES: Map<(&Addr, &Addr), AllowanceResponse> = Map::new("allowance");
+// TODO: After https://github.com/CosmWasm/cw-plus/issues/670 is implemented, replace this with a `MultiIndex` over `ALLOWANCES`
+pub const ALLOWANCES_SPENDER: Map<(&Addr, &Addr), AllowanceResponse> =
+    Map::new("allowance_spender");

--- a/packages/cw20/src/lib.rs
+++ b/packages/cw20/src/lib.rs
@@ -7,8 +7,9 @@ pub use crate::helpers::Cw20Contract;
 pub use crate::logo::{EmbeddedLogo, Logo, LogoInfo};
 pub use crate::msg::Cw20ExecuteMsg;
 pub use crate::query::{
-    AllAccountsResponse, AllAllowancesResponse, AllowanceInfo, SpenderAllowanceInfo, AllowanceResponse, AllSpenderAllowancesResponse, BalanceResponse,
-    Cw20QueryMsg, DownloadLogoResponse, MarketingInfoResponse, MinterResponse, TokenInfoResponse,
+    AllAccountsResponse, AllAllowancesResponse, AllSpenderAllowancesResponse, AllowanceInfo,
+    AllowanceResponse, BalanceResponse, Cw20QueryMsg, DownloadLogoResponse, MarketingInfoResponse,
+    MinterResponse, SpenderAllowanceInfo, TokenInfoResponse,
 };
 pub use crate::receiver::Cw20ReceiveMsg;
 

--- a/packages/cw20/src/lib.rs
+++ b/packages/cw20/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::helpers::Cw20Contract;
 pub use crate::logo::{EmbeddedLogo, Logo, LogoInfo};
 pub use crate::msg::Cw20ExecuteMsg;
 pub use crate::query::{
-    AllAccountsResponse, AllAllowancesResponse, AllowanceInfo, AllowanceResponse, BalanceResponse,
+    AllAccountsResponse, AllAllowancesResponse, AllowanceInfo, SpenderAllowanceInfo, AllowanceResponse, AllSpenderAllowancesResponse, BalanceResponse,
     Cw20QueryMsg, DownloadLogoResponse, MarketingInfoResponse, MinterResponse, TokenInfoResponse,
 };
 pub use crate::receiver::Cw20ReceiveMsg;

--- a/packages/cw20/src/query.rs
+++ b/packages/cw20/src/query.rs
@@ -110,6 +110,18 @@ pub struct AllAllowancesResponse {
     pub allowances: Vec<AllowanceInfo>,
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct SpenderAllowanceInfo {
+    pub owner: String,
+    pub allowance: Uint128,
+    pub expires: Expiration,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+pub struct AllSpenderAllowancesResponse {
+    pub allowances: Vec<SpenderAllowanceInfo>,
+}
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
 pub struct AllAccountsResponse {
     pub accounts: Vec<String>,

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -12,9 +12,7 @@ homepage = "https://cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
-
 cw2 = { path = "../../packages/cw2", version = "0.13.4" }
-
 schemars = "0.8.1"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -12,7 +12,11 @@ homepage = "https://cosmwasm.com"
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
+
+cw2 = { path = "../../packages/cw2", version = "0.13.4" }
+
 schemars = "0.8.1"
+semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
 

--- a/packages/utils/src/lib.rs
+++ b/packages/utils/src/lib.rs
@@ -1,12 +1,14 @@
 mod balance;
 mod event;
 mod expiration;
+mod migrate;
 mod pagination;
 mod parse_reply;
 mod payment;
 mod scheduled;
 mod threshold;
 
+pub use migrate::ensure_from_older_version;
 pub use pagination::{
     calc_range_end, calc_range_start, calc_range_start_string, maybe_addr, maybe_canonical,
 };

--- a/packages/utils/src/migrate.rs
+++ b/packages/utils/src/migrate.rs
@@ -2,6 +2,9 @@ use cosmwasm_std::{StdError, StdResult, Storage};
 use cw2::{get_contract_version, set_contract_version};
 use semver::Version;
 
+/// This function not only validates that the right contract and version can be migrated, but also
+/// updates the contract version from the original (stored) version to the new version.
+/// It returns the original version for the convenience of doing external checks.
 pub fn ensure_from_older_version(
     storage: &mut dyn Storage,
     name: &str,

--- a/packages/utils/src/migrate.rs
+++ b/packages/utils/src/migrate.rs
@@ -1,0 +1,86 @@
+use cosmwasm_std::{StdError, StdResult, Storage};
+use cw2::{get_contract_version, set_contract_version};
+use semver::Version;
+
+pub fn ensure_from_older_version(
+    storage: &mut dyn Storage,
+    name: &str,
+    new_version: &str,
+) -> StdResult<Version> {
+    let version: Version = new_version.parse().map_err(from_semver)?;
+    let stored = get_contract_version(storage)?;
+    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
+
+    if name != stored.contract {
+        let msg = format!("Cannot migrate from {} to {}", stored.contract, name);
+        return Err(StdError::generic_err(msg));
+    }
+
+    if storage_version > version {
+        let msg = format!(
+            "Cannot migrate from newer version ({}) to older ({})",
+            stored.version, new_version
+        );
+        return Err(StdError::generic_err(msg));
+    }
+    if storage_version < version {
+        // we don't need to save anything if migrating from the same version
+        set_contract_version(storage, name, new_version)?;
+    }
+
+    Ok(storage_version)
+}
+
+fn from_semver(err: semver::Error) -> StdError {
+    StdError::generic_err(format!("Semver: {}", err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::MockStorage;
+
+    #[test]
+    fn accepts_identical_version() {
+        let mut storage = MockStorage::new();
+        set_contract_version(&mut storage, "demo", "0.1.2").unwrap();
+        // ensure this matches
+        ensure_from_older_version(&mut storage, "demo", "0.1.2").unwrap();
+    }
+
+    #[test]
+    fn accepts_and_updates_on_newer_version() {
+        let mut storage = MockStorage::new();
+        set_contract_version(&mut storage, "demo", "0.4.0").unwrap();
+        // ensure this matches
+        let original_version = ensure_from_older_version(&mut storage, "demo", "0.4.2").unwrap();
+
+        // check the original version is returned
+        assert_eq!(original_version.to_string(), "0.4.0".to_string());
+
+        // check the version is updated
+        let stored = get_contract_version(&storage).unwrap();
+        assert_eq!(stored.contract, "demo".to_string());
+        assert_eq!(stored.version, "0.4.2".to_string());
+    }
+
+    #[test]
+    fn errors_on_name_mismatch() {
+        let mut storage = MockStorage::new();
+        set_contract_version(&mut storage, "demo", "0.1.2").unwrap();
+        // ensure this matches
+        let err = ensure_from_older_version(&mut storage, "cw20-base", "0.1.2").unwrap_err();
+        assert!(err.to_string().contains("cw20-base"), "{}", err);
+        assert!(err.to_string().contains("demo"), "{}", err);
+    }
+
+    #[test]
+    fn errors_on_older_version() {
+        let mut storage = MockStorage::new();
+        set_contract_version(&mut storage, "demo", "0.10.2").unwrap();
+        // ensure this matches
+        let err = ensure_from_older_version(&mut storage, "demo", "0.9.7").unwrap_err();
+        assert!(err.to_string().contains("0.10.2"), "{}", err);
+        assert!(err.to_string().contains("0.9.7"), "{}", err);
+    }
+}

--- a/packages/utils/src/migrate.rs
+++ b/packages/utils/src/migrate.rs
@@ -86,4 +86,15 @@ mod tests {
         assert!(err.to_string().contains("0.10.2"), "{}", err);
         assert!(err.to_string().contains("0.9.7"), "{}", err);
     }
+
+    #[test]
+    fn errors_on_broken_version() {
+        let mut storage = MockStorage::new();
+        let err = ensure_from_older_version(&mut storage, "demo", "0.a.7").unwrap_err();
+        assert!(
+            err.to_string().contains("unexpected character 'a'"),
+            "{}",
+            err
+        );
+    }
 }


### PR DESCRIPTION
Closes #756.

Opted for a non-api-breaking (i.e. backwards compatible) implementation. This just add a new `AllSpenderAllowances` query, and keeps all the rest the same.

TODO:

- ~~Add migration step to populate the `ALLOWANCE_SPENDER` map~~. (done)
- ~~Add migration test~~. (already done)