### PR TITLE
Expose cw-multi-test `FailingModule`

### DIFF
--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -26,6 +26,6 @@ pub use crate::app::{
 pub use crate::bank::{Bank, BankKeeper, BankSudo};
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
-pub use crate::module::Module;
+pub use crate::module::{Module, FailingModule};
 pub use crate::staking::{FailingDistribution, FailingStaking, Staking, StakingSudo};
 pub use crate::wasm::{Wasm, WasmKeeper, WasmSudo};

--- a/packages/multi-test/src/lib.rs
+++ b/packages/multi-test/src/lib.rs
@@ -26,6 +26,6 @@ pub use crate::app::{
 pub use crate::bank::{Bank, BankKeeper, BankSudo};
 pub use crate::contracts::{Contract, ContractWrapper};
 pub use crate::executor::{AppResponse, Executor};
-pub use crate::module::{Module, FailingModule};
+pub use crate::module::{FailingModule, Module};
 pub use crate::staking::{FailingDistribution, FailingStaking, Staking, StakingSudo};
 pub use crate::wasm::{Wasm, WasmKeeper, WasmSudo};


### PR DESCRIPTION
Make `FailingModule` in cw-multi-test public would be useful to build a custom failing module for the custom chain, say:
```rust
pub trait DesmosModule: Module<ExecT = DesmosMsg, QueryT = DesmosQuery, SudoT = Empty> {}

impl DesmosModule for DesmosKeeper {}
impl DesmosModule for FailingModule<DesmosMsg, DesmosQuery, Empty> {}
```