### PR TITLE
fix: Decoding data before executing reply

### DIFF
--- a/packages/multi-test/src/wasm.rs
+++ b/packages/multi-test/src/wasm.rs
@@ -512,7 +512,11 @@ where
                     id,
                     result: SubMsgResult::Ok(SubMsgResponse {
                         events: r.events.clone(),
-                        data: r.data,
+                        data: if let Some(binary) = r.data {
+                            Some(ExecuteResponse::decode(binary.as_slice())?.data.into())
+                        } else {
+                            None
+                        },
                     }),
                 };
                 // do reply and combine it with the original response


### PR DESCRIPTION
Response data was not decoded before being sent to the smart contract causing it to also hold a header. Response is encoded on line 900 /line 896 from old file/.