### PR TITLE
Add primary key to `MultiIndex` index fn params

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,6 +2,30 @@
 
 This guide lists API changes between *cw-plus* major releases.
 
+## v0.13.x -> v0.14.0
+
+### Breaking Issues / PRs
+
+- `MultiIndex` index fn params now include the pk [\#670](https://github.com/CosmWasm/cw-plus/issues/670)
+
+The `idx_fn` param of the `MultiIndex` constructor now has signature `fn(&[u8], &T) -> IK`, where the first param is the
+primary key of the index (in raw format), and the second param is the associated value.
+That allows us to use the pk or parts of it for building the index key.
+
+Migration of existing code is straight-forward. Just add an (unused) `_pk` param to the index function definition:
+
+```diff
+fn build_map<'a>() -> IndexedMap<'a, &'a str, Data, DataIndexes<'a>> {
+   let indexes = DataIndexes {
+-     name: MultiIndex::new(|d| d.name.clone(), "data", "data__name"),
++     name: MultiIndex::new(|_pk, d| d.name.clone(), "data", "data__name"),
+      age: UniqueIndex::new(|d| d.age, "data__age"),
+      name_lastname: UniqueIndex::new(
+```
+
+If you want to leverage this new functionality, take a look at the `pk_based_index()` test / example
+in `src/indexed_map.rs`.
+
 ## v0.11.0 -> v0.12.0
 
 ### Breaking Issues / PRs

--- a/packages/storage-macro/tests/index_list.rs
+++ b/packages/storage-macro/tests/index_list.rs
@@ -23,7 +23,7 @@ mod test {
         let _: IndexedMap<u64, TestStruct, TestIndexes> = IndexedMap::new(
             "t",
             TestIndexes {
-                id: MultiIndex::new(|t| t.id2, "t", "t_id2"),
+                id: MultiIndex::new(|_pk, t| t.id2, "t", "t_id2"),
                 addr: UniqueIndex::new(|t| t.addr.clone(), "t_addr"),
             },
         );
@@ -48,7 +48,7 @@ mod test {
         let idm: IndexedMap<u64, TestStruct, TestIndexes> = IndexedMap::new(
             "t",
             TestIndexes {
-                id: MultiIndex::new(|t| t.id2, "t", "t_2"),
+                id: MultiIndex::new(|_pk, t| t.id2, "t", "t_2"),
                 addr: UniqueIndex::new(|t| t.addr.clone(), "t_addr"),
             },
         );

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -1660,6 +1660,23 @@ mod test {
             let items: Vec<_> = items.into_iter().map(|(_, v)| v.u128()).collect();
 
             assert_eq!(items, vec![11, 21]);
+
+            // Prefix over the indexed values, and deserialize primary key as well
+            let items: Vec<_> = map
+                .idx
+                .spender
+                .prefix(Addr::unchecked("spender2"))
+                .range(&store, None, None, Order::Ascending)
+                .collect::<Result<_, _>>()
+                .unwrap();
+
+            assert_eq!(
+                items,
+                vec![(
+                    (Addr::unchecked("owner1"), Addr::unchecked("spender2")),
+                    Uint128::new(12)
+                )]
+            );
         }
     }
 }

--- a/packages/storage-plus/src/indexed_map.rs
+++ b/packages/storage-plus/src/indexed_map.rs
@@ -322,7 +322,7 @@ mod test {
     // Can we make it easier to define this? (less wordy generic)
     fn build_map<'a>() -> IndexedMap<'a, &'a str, Data, DataIndexes<'a>> {
         let indexes = DataIndexes {
-            name: MultiIndex::new(|d| d.name.clone(), "data", "data__name"),
+            name: MultiIndex::new(|_pk, d| d.name.clone(), "data", "data__name"),
             age: UniqueIndex::new(|d| d.age, "data__age"),
             name_lastname: UniqueIndex::new(
                 |d| index_string_tuple(&d.name, &d.last_name),
@@ -651,7 +651,11 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map = IndexedMap::new("data", indexes);
 
@@ -712,7 +716,11 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map = IndexedMap::new("data", indexes);
 
@@ -1070,7 +1078,11 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map = IndexedMap::new("data", indexes);
 
@@ -1125,7 +1137,11 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map = IndexedMap::new("data", indexes);
 
@@ -1177,7 +1193,11 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map = IndexedMap::new("data", indexes);
 
@@ -1235,7 +1255,11 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map = IndexedMap::new("data", indexes);
 
@@ -1316,7 +1340,11 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map = IndexedMap::new("data", indexes);
 
@@ -1478,7 +1506,7 @@ mod test {
         fn composite_key_query() {
             let indexes = Indexes {
                 secondary: MultiIndex::new(
-                    |secondary| *secondary,
+                    |_pk, secondary| *secondary,
                     "test_map",
                     "test_map__secondary",
                 ),

--- a/packages/storage-plus/src/indexed_snapshot.rs
+++ b/packages/storage-plus/src/indexed_snapshot.rs
@@ -347,7 +347,7 @@ mod test {
     // Can we make it easier to define this? (less wordy generic)
     fn build_snapshot_map<'a>() -> IndexedSnapshotMap<'a, &'a str, Data, DataIndexes<'a>> {
         let indexes = DataIndexes {
-            name: MultiIndex::new(|d| d.name.as_bytes().to_vec(), "data", "data__name"),
+            name: MultiIndex::new(|_pk, d| d.name.as_bytes().to_vec(), "data", "data__name"),
             age: UniqueIndex::new(|d| d.age, "data__age"),
             name_lastname: UniqueIndex::new(
                 |d| index_string_tuple(&d.name, &d.last_name),
@@ -677,7 +677,11 @@ mod test {
         let mut height = 2;
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map =
             IndexedSnapshotMap::new("data", "checks", "changes", Strategy::EveryBlock, indexes);
@@ -743,7 +747,11 @@ mod test {
         let mut height = 2;
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map =
             IndexedSnapshotMap::new("data", "checks", "changes", Strategy::EveryBlock, indexes);
@@ -1134,7 +1142,11 @@ mod test {
         let mut store = MockStorage::new();
 
         let indexes = DataCompositeMultiIndex {
-            name_age: MultiIndex::new(|d| index_tuple(&d.name, d.age), "data", "data__name_age"),
+            name_age: MultiIndex::new(
+                |_pk, d| index_tuple(&d.name, d.age),
+                "data",
+                "data__name_age",
+            ),
         };
         let map =
             IndexedSnapshotMap::new("data", "checks", "changes", Strategy::EveryBlock, indexes);


### PR DESCRIPTION
Closes #670. Adds the (raw) primary key to the `MultiIndex` index fn params.

It is then the index function's responsibility to deserialise the pk, if it wants to use all or parts of it for building the index key.

TODO:

- ~~Add example / tests for this indexing mechanism~~. (done)
- ~~Add MIGRATING entry / notice~~. (done, for upcoming v0.14.0)