### PR TITLE
Validate allowance expiration

### DIFF
--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -864,10 +864,10 @@ mod tests {
             expires: Some(expires),
         };
 
-        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        execute(deps.as_mut(), env, info, msg).unwrap();
 
         // ensure it looks good
-        let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
+        let allowance = query_allowance(deps.as_ref(), owner, spender).unwrap();
         assert_eq!(
             allowance,
             AllowanceResponse {

--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -24,7 +24,7 @@ pub fn execute_increase_allowance(
         let mut val = allow.unwrap_or_default();
         if let Some(exp) = expires {
             if exp.is_expired(&env.block) {
-                return Err(ContractError::Expired {});
+                return Err(ContractError::InvalidExpiration {});
             }
             val.expires = exp;
         }
@@ -72,7 +72,7 @@ pub fn execute_decrease_allowance(
             .map_err(StdError::overflow)?;
         if let Some(exp) = expires {
             if exp.is_expired(&env.block) {
-                return Err(ContractError::Expired {});
+                return Err(ContractError::InvalidExpiration {});
             }
             allowance.expires = exp;
         }
@@ -780,7 +780,7 @@ mod tests {
 
         // ensure it is rejected
         assert_eq!(
-            Err(ContractError::Expired {}),
+            Err(ContractError::InvalidExpiration {}),
             execute(deps.as_mut(), env.clone(), info.clone(), msg)
         );
 
@@ -794,7 +794,7 @@ mod tests {
 
         // ensure it is rejected
         assert_eq!(
-            Err(ContractError::Expired {}),
+            Err(ContractError::InvalidExpiration {}),
             execute(deps.as_mut(), env.clone(), info.clone(), msg)
         );
 
@@ -851,7 +851,7 @@ mod tests {
 
         // ensure it is rejected
         assert_eq!(
-            Err(ContractError::Expired {}),
+            Err(ContractError::InvalidExpiration {}),
             execute(deps.as_mut(), env.clone(), info.clone(), msg)
         );
 

--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -20,9 +20,12 @@ pub fn execute_increase_allowance(
         return Err(ContractError::CannotSetOwnAccount {});
     }
 
-    let update_fn = |allow: Option<AllowanceResponse>| -> StdResult<_> {
+    let update_fn = |allow: Option<AllowanceResponse>| -> Result<_, _> {
         let mut val = allow.unwrap_or_default();
         if let Some(exp) = expires {
+            if exp.is_expired(&env.block) {
+                return Err(ContractError::Expired { });
+            }
             val.expires = exp;
         }
         val.allowance += amount;

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -1403,7 +1403,7 @@ mod tests {
 
             // Set allowance
             let allow1 = Uint128::new(7777);
-            let expires = Expiration::AtHeight(5432);
+            let expires = Expiration::AtHeight(123_456);
             let msg = CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: cw20_addr.to_string(),
                 msg: to_binary(&ExecuteMsg::IncreaseAllowance {

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -127,7 +127,7 @@ mod tests {
 
         // set allowance with height expiration
         let allow1 = Uint128::new(7777);
-        let expires = Expiration::AtHeight(5432);
+        let expires = Expiration::AtHeight(123_456);
         let msg = ExecuteMsg::IncreaseAllowance {
             spender: spender1.clone(),
             amount: allow1,
@@ -192,7 +192,7 @@ mod tests {
 
         // set allowance with height expiration
         let allow1 = Uint128::new(7777);
-        let expires = Expiration::AtHeight(5432);
+        let expires = Expiration::AtHeight(123_456);
         let msg = ExecuteMsg::IncreaseAllowance {
             spender: spender.clone(),
             amount: allow1,

--- a/contracts/cw20-base/src/error.rs
+++ b/contracts/cw20-base/src/error.rs
@@ -33,6 +33,9 @@ pub enum ContractError {
     #[error("Invalid png header")]
     InvalidPngHeader {},
 
+    #[error("Invalid expiration value")]
+    InvalidExpiration {},
+
     #[error("Duplicate initial balance addresses")]
     DuplicateInitialBalanceAddresses {},
 }


### PR DESCRIPTION
Closes https://github.com/CosmWasm/cw-plus/issues/628

Adds a check for valid expiration when increasing or decreasing allowance.
Also had to change some of the tests because they were creating expired allowances to test the expiration checks of the other message handlers.