### PR TITLE
Fix `cargo wasm`

### DIFF
--- a/contracts/cw1-subkeys/.cargo/config
+++ b/contracts/cw1-subkeys/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 integration-test = "test --test integration"
 schema = "run --bin schema"

--- a/contracts/cw1-whitelist-ng/.cargo/config
+++ b/contracts/cw1-whitelist-ng/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 integration-test = "test --test integration"
 schema = "run --bin schema"

--- a/contracts/cw1-whitelist/.cargo/config
+++ b/contracts/cw1-whitelist/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 integration-test = "test --test integration"
 schema = "run --bin schema"

--- a/contracts/cw1155-base/.cargo/config
+++ b/contracts/cw1155-base/.cargo/config
@@ -1,5 +1,5 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 schema = "run --bin schema"

--- a/contracts/cw20-base/.cargo/config
+++ b/contracts/cw20-base/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 integration-test = "test --test integration"
 schema = "run --bin schema"

--- a/contracts/cw20-ics20/.cargo/config
+++ b/contracts/cw20-ics20/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 integration-test = "test --test integration"
 schema = "run --bin schema"

--- a/contracts/cw3-fixed-multisig/.cargo/config
+++ b/contracts/cw3-fixed-multisig/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 integration-test = "test --test integration"
 schema = "run --bin schema"

--- a/contracts/cw3-flex-multisig/.cargo/config
+++ b/contracts/cw3-flex-multisig/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 integration-test = "test --test integration"
 schema = "run --bin schema"

--- a/contracts/cw4-group/.cargo/config
+++ b/contracts/cw4-group/.cargo/config
@@ -1,5 +1,5 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 schema = "run --bin schema"

--- a/contracts/cw4-stake/.cargo/config
+++ b/contracts/cw4-stake/.cargo/config
@@ -1,5 +1,5 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
-wasm-debug = "build --target wasm32-unknown-unknown"
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+wasm-debug = "build --lib --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 schema = "run --bin schema"


### PR DESCRIPTION
Since we moved `schema.rs` from `examples` to `src/bin`, `cargo build` tries to build the schema binary by default. We need to specify we want the `--lib`.