### PR TITLE
cw4 contracts: clean up imports and reexports

### DIFF
--- a/contracts/cw4-group/src/bin/schema.rs
+++ b/contracts/cw4-group/src/bin/schema.rs
@@ -1,7 +1,6 @@
 use cosmwasm_schema::write_api;
 
-pub use cw4::{AdminResponse, MemberListResponse, MemberResponse, TotalWeightResponse};
-pub use cw4_group::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cw4_group::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 fn main() {
     write_api! {

--- a/contracts/cw4-stake/src/bin/schema.rs
+++ b/contracts/cw4-stake/src/bin/schema.rs
@@ -1,9 +1,6 @@
 use cosmwasm_schema::write_api;
 
-pub use cw4::{AdminResponse, MemberListResponse, MemberResponse, TotalWeightResponse};
-pub use cw4_stake::msg::{
-    ClaimsResponse, ExecuteMsg, InstantiateMsg, QueryMsg, ReceiveMsg, StakedResponse,
-};
+use cw4_stake::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 fn main() {
     write_api! {


### PR DESCRIPTION
The re-exports couldn't possibly be useful; these are binaries, they can't be imported into a Rust project.

Thanks @pyramation for noticing!