### PR TITLE
Add clear and is_empty methods to Map

### DIFF
--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -109,6 +109,36 @@ where
             from_slice(&result).map(Some)
         }
     }
+
+    /// Clears the map, removing all elements.
+    #[cfg(feature = "iterator")]
+    pub fn clear(&self, store: &mut dyn Storage) {
+        const TAKE: usize = 10;
+        let mut cleared = false;
+
+        while !cleared {
+            let paths = self
+                .no_prefix_raw()
+                .keys_raw(store, None, None, cosmwasm_std::Order::Ascending)
+                .map(|raw_key| Path::<T>::new(self.namespace, &[raw_key.as_slice()]))
+                // Take just TAKE elements to prevent possible heap overflow if the Map is big.
+                .take(TAKE)
+                .collect::<Vec<_>>();
+
+            paths.iter().for_each(|path| store.remove(path));
+
+            cleared = paths.len() < TAKE;
+        }
+    }
+
+    /// Returns `true` if the map is empty.
+    #[cfg(feature = "iterator")]
+    pub fn is_empty(&self, store: &dyn Storage) -> bool {
+        self.no_prefix_raw()
+            .keys_raw(store, None, None, cosmwasm_std::Order::Ascending)
+            .next()
+            .is_none()
+    }
 }
 
 #[cfg(feature = "iterator")]
@@ -257,41 +287,6 @@ where
         K::Output: 'static,
     {
         self.no_prefix().keys(store, min, max, order)
-    }
-}
-
-#[cfg(feature = "iterator")]
-impl<'a, K, T> Map<'a, K, T>
-where
-    T: Serialize + DeserializeOwned,
-    K: PrimaryKey<'a>,
-{
-    /// Clears the map, removing all elements.
-    pub fn clear(&self, store: &mut dyn Storage) {
-        const TAKE: usize = 10;
-        let prefix = self.no_prefix_raw();
-        let mut cleared = false;
-
-        while !cleared {
-            let paths = prefix
-                .keys_raw(store, None, None, cosmwasm_std::Order::Ascending)
-                .map(|raw_key| Path::<T>::new(self.namespace, &[raw_key.as_slice()]))
-                // Take just TAKE elements to prevent possible heap overflow if the Map is big.
-                .take(TAKE)
-                .collect::<Vec<_>>();
-
-            paths.iter().for_each(|path| store.remove(path));
-
-            cleared = paths.len() < TAKE;
-        }
-    }
-
-    /// Returns `true` if the map is empty.
-    pub fn is_empty(&self, store: &dyn Storage) -> bool {
-        self.no_prefix_raw()
-            .keys_raw(store, None, None, cosmwasm_std::Order::Ascending)
-            .next()
-            .is_none()
     }
 }
 

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -1561,11 +1561,11 @@ mod test {
 
         TEST_MAP.clear(&mut storage);
 
-        assert!(!TEST_MAP.has(&mut storage, "key0"));
-        assert!(!TEST_MAP.has(&mut storage, "key1"));
-        assert!(!TEST_MAP.has(&mut storage, "key2"));
-        assert!(!TEST_MAP.has(&mut storage, "key3"));
-        assert!(!TEST_MAP.has(&mut storage, "key4"));
+        assert!(!TEST_MAP.has(&storage, "key0"));
+        assert!(!TEST_MAP.has(&storage, "key1"));
+        assert!(!TEST_MAP.has(&storage, "key2"));
+        assert!(!TEST_MAP.has(&storage, "key3"));
+        assert!(!TEST_MAP.has(&storage, "key4"));
     }
 
     #[test]

--- a/packages/storage-plus/src/map.rs
+++ b/packages/storage-plus/src/map.rs
@@ -285,6 +285,14 @@ where
             cleared = paths.len() < TAKE;
         }
     }
+
+    /// Returns `true` if the map is empty.
+    pub fn is_empty(&self, store: &dyn Storage) -> bool {
+        self.no_prefix_raw()
+            .keys_raw(store, None, None, cosmwasm_std::Order::Ascending)
+            .next()
+            .is_none()
+    }
 }
 
 #[cfg(test)]
@@ -1541,7 +1549,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "iterator")]
-    fn clear() {
+    fn clear_works() {
         const TEST_MAP: Map<&str, u32> = Map::new("test_map");
 
         let mut storage = MockStorage::new();
@@ -1558,5 +1566,20 @@ mod test {
         assert!(!TEST_MAP.has(&mut storage, "key2"));
         assert!(!TEST_MAP.has(&mut storage, "key3"));
         assert!(!TEST_MAP.has(&mut storage, "key4"));
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn is_empty_works() {
+        const TEST_MAP: Map<&str, u32> = Map::new("test_map");
+
+        let mut storage = MockStorage::new();
+
+        assert!(TEST_MAP.is_empty(&storage));
+
+        TEST_MAP.save(&mut storage, "key1", &1u32).unwrap();
+        TEST_MAP.save(&mut storage, "key2", &2u32).unwrap();
+
+        assert!(!TEST_MAP.is_empty(&storage));
     }
 }


### PR DESCRIPTION
This add two new utility methods to `Map` to make it more similar with the Rust `BTreeMap`
1. clear: Removes all the elements inside `Map`
2. is_empty: Returns `true` if the `Map` don't contains any element

To implement the two methods I rely on the `iterator` feature to get the keys of the elements inside the Map since I haven't find a better way to know the elements currently present inside the `Map`.