### PR TITLE
Add Deque

### DIFF
--- a/packages/storage-plus/README.md
+++ b/packages/storage-plus/README.md
@@ -639,7 +639,7 @@ to be correctly defined, so that it matches the primary key type, or its (typica
 ## Deque
 
 The usage of a [`Deque`](./src/deque.rs) is pretty straight-forward.
-Conceptually it works like a storage-backed `VecDeque`and can be used as a queue or stack.
+Conceptually it works like a storage-backed version of Rust std's `VecDeque` and can be used as a queue or stack.
 It allows you to push and pop elements on both ends and also read the first or last element without mutating the deque.
 
 Example Usage:
@@ -656,7 +656,7 @@ const DATA: Deque<Data> = Deque::new("data");
 fn demo() -> StdResult<()> {
     let mut store = MockStorage::new();
 
-    // read methods return Option<T>, so None if the deque is empty
+    // read methods return a wrapped Option<T>, so None if the deque is empty
     let empty = DATA.front(&store)?;
     assert_eq!(None, empty);
 

--- a/packages/storage-plus/README.md
+++ b/packages/storage-plus/README.md
@@ -636,11 +636,12 @@ the index key (the part that corresponds to the primary key, that is).
 So, to correctly use type-safe bounds over multi-indexes ranges, it is fundamental for this `PK` type
 to be correctly defined, so that it matches the primary key type, or its (typically owned) deserialization variant.
 
-## Deque
+## VecDeque
 
-The usage of a [`Deque`](./src/deque.rs) is pretty straight-forward.
+The usage of a [`VecDeque`](./src/deque.rs) is pretty straight-forward.
 Conceptually it works like a storage-backed version of Rust std's `VecDeque` and can be used as a queue or stack.
 It allows you to push and pop elements on both ends and also read the first or last element without mutating the deque.
+You can also read a specific index directly.
 
 Example Usage:
 
@@ -694,6 +695,11 @@ fn demo() -> StdResult<()> {
 
     let all: StdResult<Vec<_>> = DATA.iter(&store)?.collect();
     assert_eq!(all?, [p2, p1]);
+
+    // or access an index directly
+    assert_eq!(DATA.get(&store, 0)?, Some(p2));
+    assert_eq!(DATA.get(&store, 1)?, Some(p1));
+    assert_eq!(DATA.get(&store, 3)?, None);
 
     Ok(())
 }

--- a/packages/storage-plus/README.md
+++ b/packages/storage-plus/README.md
@@ -635,3 +635,66 @@ In the particular case of `MultiIndex`, the primary key (`PK`) type parameter al
 the index key (the part that corresponds to the primary key, that is).
 So, to correctly use type-safe bounds over multi-indexes ranges, it is fundamental for this `PK` type
 to be correctly defined, so that it matches the primary key type, or its (typically owned) deserialization variant.
+
+## Deque
+
+The usage of a [`Deque`](./src/deque.rs) is pretty straight-forward.
+Conceptually it works like a storage-backed `VecDeque`and can be used as a queue or stack.
+It allows you to push and pop elements on both ends and also read the first or last element without mutating the deque.
+
+Example Usage:
+
+```rust
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+struct Data {
+    pub name: String,
+    pub age: i32,
+}
+
+const DATA: Deque<Data> = Deque::new("data");
+
+fn demo() -> StdResult<()> {
+    let mut store = MockStorage::new();
+
+    // read methods return Option<T>, so None if the deque is empty
+    let empty = DATA.front(&store)?;
+    assert_eq!(None, empty);
+
+    // some example entries
+    let p1 = Data {
+        name: "admin".to_string(),
+        age: 1234,
+    };
+    let p2 = Data {
+        name: "user".to_string(),
+        age: 123,
+    };
+
+    // use it like a queue by pushing and popping at opposite ends
+    DATA.push_back(&mut store, &p1)?;
+    DATA.push_back(&mut store, &p2)?;
+
+    let admin = DATA.pop_front(&mut store)?;
+    assert_eq!(admin.as_ref(), Some(&p1));
+    let user = DATA.pop_front(&mut store)?;
+    assert_eq!(user.as_ref(), Some(&p2));
+
+    // or push and pop at the same end to use it as a stack
+    DATA.push_back(&mut store, &p1)?;
+    DATA.push_back(&mut store, &p2)?;
+
+    let user = DATA.pop_back(&mut store)?;
+    assert_eq!(user.as_ref(), Some(&p2));
+    let admin = DATA.pop_back(&mut store)?;
+    assert_eq!(admin.as_ref(), Some(&p1));
+
+    // you can also iterate over it
+    DATA.push_front(&mut store, &p1)?;
+    DATA.push_front(&mut store, &p2)?;
+
+    let all: StdResult<Vec<_>> = DATA.iter(&store)?.collect();
+    assert_eq!(all?, [p2, p1]);
+
+    Ok(())
+}
+```

--- a/packages/storage-plus/src/deque.rs
+++ b/packages/storage-plus/src/deque.rs
@@ -10,6 +10,9 @@ const TAIL_KEY: &[u8] = b"t";
 const HEAD_KEY: &[u8] = b"h";
 
 /// A deque stores multiple items at the given key. It provides efficient FIFO and LIFO access.
+///
+/// It has a maximum capacity of `u32::MAX - 1`. Make sure to never exceed that number when using this type.
+/// If you do, the methods won't work as intended anymore.
 pub struct Deque<'a, T> {
     // prefix of the deque items
     namespace: &'a [u8],

--- a/packages/storage-plus/src/deque.rs
+++ b/packages/storage-plus/src/deque.rs
@@ -490,7 +490,7 @@ mod tests {
     fn readme_works() -> StdResult<()> {
         let mut store = MockStorage::new();
 
-        // read methods return Option<T>, so None if the deque is empty
+        // read methods return a wrapped Option<T>, so None if the deque is empty
         let empty = DATA.front(&store)?;
         assert_eq!(None, empty);
 

--- a/packages/storage-plus/src/deque.rs
+++ b/packages/storage-plus/src/deque.rs
@@ -348,6 +348,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "iterator")]
     fn iterator() {
         let deque: Deque<u32> = Deque::new("test");
         let mut store = MockStorage::new();
@@ -373,6 +374,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "iterator")]
     fn reverse_iterator() {
         let deque: Deque<u32> = Deque::new("test");
         let mut store = MockStorage::new();
@@ -431,6 +433,13 @@ mod tests {
             Some(1),
             "popping should work, even when wrapping"
         );
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn wrapping_iterator() {
+        let deque: Deque<u32> = Deque::new("test");
+        let mut store = MockStorage::new();
 
         deque.set_head(&mut store, u32::MAX);
         deque.set_tail(&mut store, u32::MAX);
@@ -476,6 +485,7 @@ mod tests {
     const DATA: Deque<Data> = Deque::new("data");
 
     #[test]
+    #[cfg(feature = "iterator")]
     fn readme_works() -> StdResult<()> {
         let mut store = MockStorage::new();
 

--- a/packages/storage-plus/src/deque.rs
+++ b/packages/storage-plus/src/deque.rs
@@ -9,7 +9,8 @@ use crate::helpers::{may_deserialize, namespaces_with_key};
 const TAIL_KEY: &[u8] = b"t";
 const HEAD_KEY: &[u8] = b"h";
 
-/// A deque stores multiple items at the given key. It provides efficient FIFO and LIFO access.
+/// A deque stores multiple items at the given key. It provides efficient FIFO and LIFO access,
+/// as well as direct index access.
 ///
 /// It has a maximum capacity of `u32::MAX - 1`. Make sure to never exceed that number when using this type.
 /// If you do, the methods won't work as intended anymore.
@@ -552,7 +553,12 @@ mod tests {
         DATA.push_front(&mut store, &p2)?;
 
         let all: StdResult<Vec<_>> = DATA.iter(&store)?.collect();
-        assert_eq!(all?, [p2, p1]);
+        assert_eq!(all?, [p2.clone(), p1.clone()]);
+
+        // or access an index directly
+        assert_eq!(DATA.get(&store, 0)?, Some(p2));
+        assert_eq!(DATA.get(&store, 1)?, Some(p1));
+        assert_eq!(DATA.get(&store, 3)?, None);
 
         Ok(())
     }

--- a/packages/storage-plus/src/deque.rs
+++ b/packages/storage-plus/src/deque.rs
@@ -31,7 +31,7 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     pub fn push_back(&self, storage: &mut dyn Storage, value: &T) -> StdResult<()> {
         // save value
         let pos = self.tail(storage)?;
-        self.set_at_unchecked(storage, pos, value)?;
+        self.set_unchecked(storage, pos, value)?;
         // update tail
         self.set_tail(storage, pos.wrapping_add(1));
 
@@ -42,7 +42,7 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     pub fn push_front(&self, storage: &mut dyn Storage, value: &T) -> StdResult<()> {
         // need to subtract first, because head potentially points to existing element
         let pos = self.head(storage)?.wrapping_sub(1);
-        self.set_at_unchecked(storage, pos, value)?;
+        self.set_unchecked(storage, pos, value)?;
         // update head
         self.set_head(storage, pos);
 
@@ -53,9 +53,9 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     pub fn pop_back(&self, storage: &mut dyn Storage) -> StdResult<Option<T>> {
         // get position
         let pos = self.tail(storage)?.wrapping_sub(1);
-        let value = self.get_at_unchecked(storage, pos)?;
+        let value = self.get_unchecked(storage, pos)?;
         if value.is_some() {
-            self.remove_at_unchecked(storage, pos);
+            self.remove_unchecked(storage, pos);
             // only update tail if a value was popped
             self.set_tail(storage, pos);
         }
@@ -66,9 +66,9 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     pub fn pop_front(&self, storage: &mut dyn Storage) -> StdResult<Option<T>> {
         // get position
         let pos = self.head(storage)?;
-        let value = self.get_at_unchecked(storage, pos)?;
+        let value = self.get_unchecked(storage, pos)?;
         if value.is_some() {
-            self.remove_at_unchecked(storage, pos);
+            self.remove_unchecked(storage, pos);
             // only update head if a value was popped
             self.set_head(storage, pos.wrapping_add(1));
         }
@@ -78,13 +78,13 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     /// Returns the first element of the deque without removing it
     pub fn front(&self, storage: &dyn Storage) -> StdResult<Option<T>> {
         let pos = self.head(storage)?;
-        self.get_at_unchecked(storage, pos)
+        self.get_unchecked(storage, pos)
     }
 
     /// Returns the first element of the deque without removing it
     pub fn back(&self, storage: &dyn Storage) -> StdResult<Option<T>> {
         let pos = self.tail(storage)?.wrapping_sub(1);
-        self.get_at_unchecked(storage, pos)
+        self.get_unchecked(storage, pos)
     }
 
     /// Gets the length of the deque.
@@ -148,21 +148,21 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
 
     /// Tries to get the value at the given position
     /// Used internally
-    fn get_at_unchecked(&self, storage: &dyn Storage, pos: u32) -> StdResult<Option<T>> {
+    fn get_unchecked(&self, storage: &dyn Storage, pos: u32) -> StdResult<Option<T>> {
         let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
         may_deserialize(&storage.get(&prefixed_key))
     }
 
     /// Removes the value at the given position
     /// Used internally
-    fn remove_at_unchecked(&self, storage: &mut dyn Storage, pos: u32) {
+    fn remove_unchecked(&self, storage: &mut dyn Storage, pos: u32) {
         let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
         storage.remove(&prefixed_key);
     }
 
     /// Tries to set the value at the given position
     /// Used internally when pushing
-    fn set_at_unchecked(&self, storage: &mut dyn Storage, pos: u32, value: &T) -> StdResult<()> {
+    fn set_unchecked(&self, storage: &mut dyn Storage, pos: u32, value: &T) -> StdResult<()> {
         let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
         storage.set(&prefixed_key, &to_vec(value)?);
 
@@ -207,7 +207,7 @@ where
 
         let item = self
             .deque
-            .get_at_unchecked(self.storage, self.start)
+            .get_unchecked(self.storage, self.start)
             .and_then(|item| item.ok_or_else(|| StdError::not_found(type_name::<T>())));
         self.start = self.start.wrapping_add(1);
 
@@ -247,7 +247,7 @@ where
 
         let item = self
             .deque
-            .get_at_unchecked(self.storage, self.end.wrapping_sub(1)) // end points to position after last element
+            .get_unchecked(self.storage, self.end.wrapping_sub(1)) // end points to position after last element
             .and_then(|item| item.ok_or_else(|| StdError::not_found(type_name::<T>())));
         self.end = self.end.wrapping_sub(1);
 

--- a/packages/storage-plus/src/deque.rs
+++ b/packages/storage-plus/src/deque.rs
@@ -88,6 +88,7 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     }
 
     /// Gets the length of the deque.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self, storage: &dyn Storage) -> StdResult<u32> {
         Ok(self.tail(storage)?.wrapping_sub(self.head(storage)?))
     }
@@ -315,7 +316,7 @@ mod tests {
         let mut store = MockStorage::new();
 
         assert_eq!(deque.len(&store).unwrap(), 0);
-        assert_eq!(deque.is_empty(&store).unwrap(), true);
+        assert!(deque.is_empty(&store).unwrap());
 
         // push some entries
         deque.push_front(&mut store, &1234).unwrap();
@@ -323,19 +324,19 @@ mod tests {
         deque.push_front(&mut store, &3456).unwrap();
         deque.push_back(&mut store, &4567).unwrap();
         assert_eq!(deque.len(&store).unwrap(), 4);
-        assert_eq!(deque.is_empty(&store).unwrap(), false);
+        assert!(!deque.is_empty(&store).unwrap());
 
         // pop some
         deque.pop_front(&mut store).unwrap();
         deque.pop_back(&mut store).unwrap();
         deque.pop_front(&mut store).unwrap();
         assert_eq!(deque.len(&store).unwrap(), 1);
-        assert_eq!(deque.is_empty(&store).unwrap(), false);
+        assert!(!deque.is_empty(&store).unwrap());
 
         // pop the last one
         deque.pop_front(&mut store).unwrap();
         assert_eq!(deque.len(&store).unwrap(), 0);
-        assert_eq!(deque.is_empty(&store).unwrap(), true);
+        assert!(deque.is_empty(&store).unwrap());
 
         // should stay 0 after that
         assert_eq!(deque.pop_back(&mut store).unwrap(), None);
@@ -344,7 +345,7 @@ mod tests {
             0,
             "popping from empty deque should keep length 0"
         );
-        assert_eq!(deque.is_empty(&store).unwrap(), true);
+        assert!(deque.is_empty(&store).unwrap());
     }
 
     #[test]
@@ -359,16 +360,16 @@ mod tests {
         deque.push_back(&mut store, &3).unwrap();
         deque.push_back(&mut store, &4).unwrap();
 
-        let items: StdResult<Vec<_>> = deque.iter(&mut store).unwrap().collect();
+        let items: StdResult<Vec<_>> = deque.iter(&store).unwrap().collect();
         assert_eq!(items.unwrap(), [1, 2, 3, 4]);
 
         // nth should work correctly
-        let mut iter = deque.iter(&mut store).unwrap();
+        let mut iter = deque.iter(&store).unwrap();
         assert_eq!(iter.nth(6), None);
         assert_eq!(iter.start, iter.end, "iter should detect skipping too far");
         assert_eq!(iter.next(), None);
 
-        let mut iter = deque.iter(&mut store).unwrap();
+        let mut iter = deque.iter(&store).unwrap();
         assert_eq!(iter.nth(1).unwrap().unwrap(), 2);
         assert_eq!(iter.next().unwrap().unwrap(), 3);
     }
@@ -385,21 +386,21 @@ mod tests {
         deque.push_back(&mut store, &3).unwrap();
         deque.push_back(&mut store, &4).unwrap();
 
-        let items: StdResult<Vec<_>> = deque.iter(&mut store).unwrap().rev().collect();
+        let items: StdResult<Vec<_>> = deque.iter(&store).unwrap().rev().collect();
         assert_eq!(items.unwrap(), [4, 3, 2, 1]);
 
         // nth should work correctly
-        let mut iter = deque.iter(&mut store).unwrap();
+        let mut iter = deque.iter(&store).unwrap();
         assert_eq!(iter.nth_back(6), None);
         assert_eq!(iter.start, iter.end, "iter should detect skipping too far");
         assert_eq!(iter.next_back(), None);
 
-        let mut iter = deque.iter(&mut store).unwrap().rev();
+        let mut iter = deque.iter(&store).unwrap().rev();
         assert_eq!(iter.nth(1).unwrap().unwrap(), 3);
         assert_eq!(iter.next().unwrap().unwrap(), 2);
 
         // mixed
-        let mut iter = deque.iter(&mut store).unwrap();
+        let mut iter = deque.iter(&store).unwrap();
         assert_eq!(iter.next().unwrap().unwrap(), 1);
         assert_eq!(iter.next_back().unwrap().unwrap(), 4);
         assert_eq!(iter.next_back().unwrap().unwrap(), 3);

--- a/packages/storage-plus/src/deque.rs
+++ b/packages/storage-plus/src/deque.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, marker::PhantomData};
+use std::{any::type_name, convert::TryInto, marker::PhantomData};
 
 use cosmwasm_std::{to_vec, StdError, StdResult, Storage};
 use serde::{de::DeserializeOwned, Serialize};
@@ -208,7 +208,7 @@ where
         let item = self
             .deque
             .get_at_unchecked(self.storage, self.start)
-            .transpose()?;
+            .and_then(|item| item.ok_or_else(|| StdError::not_found(type_name::<T>())));
         self.start = self.start.wrapping_add(1);
 
         Some(item)
@@ -248,7 +248,7 @@ where
         let item = self
             .deque
             .get_at_unchecked(self.storage, self.end.wrapping_sub(1)) // end points to position after last element
-            .transpose()?;
+            .and_then(|item| item.ok_or_else(|| StdError::not_found(type_name::<T>())));
         self.end = self.end.wrapping_sub(1);
 
         Some(item)

--- a/packages/storage-plus/src/deque.rs
+++ b/packages/storage-plus/src/deque.rs
@@ -180,6 +180,7 @@ where
     end: u32,
 }
 
+#[cfg(feature = "iterator")]
 impl<'a, T> Iterator for DequeIter<'a, T>
 where
     T: Serialize + DeserializeOwned,
@@ -218,6 +219,7 @@ where
     }
 }
 
+#[cfg(feature = "iterator")]
 impl<'a, T> DoubleEndedIterator for DequeIter<'a, T>
 where
     T: Serialize + DeserializeOwned,

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -12,6 +12,7 @@ mod keys;
 mod map;
 mod path;
 mod prefix;
+mod queue;
 mod snapshot;
 
 #[cfg(feature = "iterator")]
@@ -35,6 +36,9 @@ pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
 pub use prefix::{range_with_prefix, Prefix};
+pub use queue::Queue;
+#[cfg(feature = "iterator")]
+pub use queue::QueueIter;
 #[cfg(feature = "iterator")]
 pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};
 

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -18,9 +18,9 @@ mod snapshot;
 #[cfg(feature = "iterator")]
 pub use bound::{Bound, Bounder, PrefixBound, RawBound};
 pub use de::KeyDeserialize;
-pub use deque::Deque;
+pub use deque::VecDeque;
 #[cfg(feature = "iterator")]
-pub use deque::DequeIter;
+pub use deque::VecDequeIter;
 pub use endian::Endian;
 #[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -1,5 +1,6 @@
 mod bound;
 mod de;
+mod deque;
 mod endian;
 mod helpers;
 mod indexed_map;
@@ -12,12 +13,14 @@ mod keys;
 mod map;
 mod path;
 mod prefix;
-mod queue;
 mod snapshot;
 
 #[cfg(feature = "iterator")]
 pub use bound::{Bound, Bounder, PrefixBound, RawBound};
 pub use de::KeyDeserialize;
+pub use deque::Deque;
+#[cfg(feature = "iterator")]
+pub use deque::DequeIter;
 pub use endian::Endian;
 #[cfg(feature = "iterator")]
 pub use indexed_map::{IndexList, IndexedMap};
@@ -36,9 +39,6 @@ pub use map::Map;
 pub use path::Path;
 #[cfg(feature = "iterator")]
 pub use prefix::{range_with_prefix, Prefix};
-pub use queue::Queue;
-#[cfg(feature = "iterator")]
-pub use queue::QueueIter;
 #[cfg(feature = "iterator")]
 pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};
 

--- a/packages/storage-plus/src/queue.rs
+++ b/packages/storage-plus/src/queue.rs
@@ -1,0 +1,306 @@
+use std::{convert::TryInto, marker::PhantomData};
+
+use cosmwasm_std::{to_vec, StdError, StdResult, Storage};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::helpers::{may_deserialize, namespaces_with_key};
+
+// metadata keys need to have different length than the position type (4 bytes) to prevent collisions
+const TAIL_KEY: &[u8] = b"t";
+const HEAD_KEY: &[u8] = b"h";
+
+/// A queue stores multiple items at the given key. It provides efficient FIFO access.
+pub struct Queue<'a, T> {
+    // prefix of the queue items
+    namespace: &'a [u8],
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    item_type: PhantomData<T>,
+}
+
+impl<'a, T> Queue<'a, T> {
+    pub const fn new(prefix: &'a str) -> Self {
+        Self {
+            namespace: prefix.as_bytes(),
+            item_type: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: Serialize + DeserializeOwned> Queue<'a, T> {
+    /// Adds the given value to the end of the queue
+    pub fn push(&self, storage: &mut dyn Storage, value: &T) -> StdResult<()> {
+        // save value
+        let pos = self.tail(storage)?;
+        self.set_at(storage, pos, value)?;
+        // update tail
+        self.set_tail(storage, pos.wrapping_add(1));
+
+        Ok(())
+    }
+
+    /// Removes the first item of the queue and returns it
+    pub fn pop(&self, storage: &mut dyn Storage) -> StdResult<Option<T>> {
+        // get position
+        let pos = self.head(storage)?;
+        let value = self.get_at(storage, pos)?;
+        if value.is_some() {
+            self.remove_at(storage, pos);
+            // only update head if a value was popped
+            self.set_head(storage, pos.wrapping_add(1));
+        }
+        Ok(value)
+    }
+
+    /// Gets the length of the queue.
+    pub fn len(&self, storage: &dyn Storage) -> StdResult<u32> {
+        Ok(self.tail(storage)?.wrapping_sub(self.head(storage)?))
+    }
+
+    /// Returns `true` if the queue contains no elements.
+    pub fn is_empty(&self, storage: &dyn Storage) -> StdResult<bool> {
+        Ok(self.len(storage)? == 0)
+    }
+
+    /// Gets the head position from storage.
+    ///
+    /// Points to the front of the queue (where elements are popped).
+    fn head(&self, storage: &dyn Storage) -> StdResult<u32> {
+        self.read_meta_key(storage, HEAD_KEY)
+    }
+
+    /// Gets the tail position from storage.
+    ///
+    /// Points to the end of the queue (where elements are pushed).
+    fn tail(&self, storage: &dyn Storage) -> StdResult<u32> {
+        self.read_meta_key(storage, TAIL_KEY)
+    }
+
+    fn set_head(&self, storage: &mut dyn Storage, value: u32) {
+        self.set_meta_key(storage, HEAD_KEY, value);
+    }
+
+    fn set_tail(&self, storage: &mut dyn Storage, value: u32) {
+        self.set_meta_key(storage, TAIL_KEY, value);
+    }
+
+    /// Helper method for `tail` and `head` methods to handle reading the value from storage
+    fn read_meta_key(&self, storage: &dyn Storage, key: &[u8]) -> StdResult<u32> {
+        let full_key = namespaces_with_key(&[self.namespace], key);
+        storage
+            .get(&full_key)
+            .map(|vec| {
+                Ok(u32::from_be_bytes(
+                    vec.as_slice()
+                        .try_into()
+                        .map_err(|e| StdError::parse_err("u32", e))?,
+                ))
+            })
+            .unwrap_or(Ok(0))
+    }
+
+    /// Helper method for `set_tail` and `set_head` methods to write to storage
+    #[inline]
+    fn set_meta_key(&self, storage: &mut dyn Storage, key: &[u8], value: u32) {
+        let full_key = namespaces_with_key(&[self.namespace], key);
+        storage.set(&full_key, &value.to_be_bytes());
+    }
+
+    /// Tries to get the value at the given position (without bounds checking)
+    /// Used internally when popping
+    fn get_at(&self, storage: &dyn Storage, pos: u32) -> StdResult<Option<T>> {
+        let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
+        may_deserialize(&storage.get(&prefixed_key))
+    }
+
+    /// Removes the value at the given position
+    /// Used internally when popping
+    fn remove_at(&self, storage: &mut dyn Storage, pos: u32) {
+        let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
+        storage.remove(&prefixed_key);
+    }
+
+    /// Tries to set the value at the given position (without bounds checking)
+    /// Used internally when pushing
+    fn set_at(&self, storage: &mut dyn Storage, pos: u32, value: &T) -> StdResult<()> {
+        let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
+        storage.set(&prefixed_key, &to_vec(value)?);
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "iterator")]
+impl<'a, T: Serialize + DeserializeOwned> Queue<'a, T> {
+    pub fn iter(&self, storage: &'a dyn Storage) -> StdResult<QueueIter<T>> {
+        Ok(QueueIter {
+            queue: self,
+            storage,
+            start: self.head(storage)?,
+            end: self.tail(storage)?,
+        })
+    }
+}
+
+#[cfg(feature = "iterator")]
+pub struct QueueIter<'a, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    queue: &'a Queue<'a, T>,
+    storage: &'a dyn Storage,
+    start: u32,
+    end: u32,
+}
+
+impl<'a, T> Iterator for QueueIter<'a, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    type Item = StdResult<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start == self.end {
+            return None;
+        }
+
+        let item = self.queue.get_at(self.storage, self.start).transpose()?;
+        self.start = self.start.wrapping_add(1);
+
+        Some(item)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.end.wrapping_sub(self.start) as usize;
+        (len, Some(len))
+    }
+
+    /// The default implementation calls `next` repeatedly, which is very costly in our case.
+    /// It is used when skipping over items, so this allows cheap skipping.
+    ///
+    /// Once `advance_by` is stabilized, we can implement that instead (`nth` calls it internally).
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let start_lt_end = self.start < self.end;
+        self.start = self.start.wrapping_add(n as u32);
+        // make sure that we didn't skip past the end
+        if self.start > self.end && start_lt_end || self.start < self.end && !start_lt_end {
+            // start and end switched places, which means the iterator is empty now
+            self.start = self.end;
+        }
+        self.next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::queue::Queue;
+
+    use cosmwasm_std::testing::MockStorage;
+    use cosmwasm_std::StdResult;
+
+    #[test]
+    fn push_and_pop() {
+        const PEOPLE: Queue<String> = Queue::new("people");
+        let mut store = MockStorage::new();
+
+        // push some entries
+        PEOPLE.push(&mut store, &"jack".to_owned()).unwrap();
+        PEOPLE.push(&mut store, &"john".to_owned()).unwrap();
+        PEOPLE.push(&mut store, &"joanne".to_owned()).unwrap();
+
+        // pop them, should be in correct order
+        assert_eq!("jack", PEOPLE.pop(&mut store).unwrap().unwrap());
+        assert_eq!("john", PEOPLE.pop(&mut store).unwrap().unwrap());
+
+        // push again in-between
+        PEOPLE.push(&mut store, &"jason".to_owned()).unwrap();
+
+        // pop last person from first batch
+        assert_eq!("joanne", PEOPLE.pop(&mut store).unwrap().unwrap());
+
+        // pop the entry pushed in-between
+        assert_eq!("jason", PEOPLE.pop(&mut store).unwrap().unwrap());
+
+        // nothing after that
+        assert_eq!(None, PEOPLE.pop(&mut store).unwrap());
+    }
+
+    #[test]
+    fn length() {
+        let queue: Queue<u32> = Queue::new("test");
+        let mut store = MockStorage::new();
+
+        assert_eq!(queue.len(&store).unwrap(), 0);
+
+        // push some entries
+        queue.push(&mut store, &1234).unwrap();
+        queue.push(&mut store, &2345).unwrap();
+        queue.push(&mut store, &3456).unwrap();
+        queue.push(&mut store, &4567).unwrap();
+        assert_eq!(queue.len(&store).unwrap(), 4);
+
+        // pop some
+        queue.pop(&mut store).unwrap();
+        queue.pop(&mut store).unwrap();
+        queue.pop(&mut store).unwrap();
+        assert_eq!(queue.len(&store).unwrap(), 1);
+
+        // pop the last one
+        queue.pop(&mut store).unwrap();
+        assert_eq!(queue.len(&store).unwrap(), 0);
+
+        // should stay 0 after that
+        queue.pop(&mut store).unwrap();
+        assert_eq!(
+            queue.len(&store).unwrap(),
+            0,
+            "popping from empty queue should keep length 0"
+        );
+    }
+
+    #[test]
+    fn iterator() {
+        let queue: Queue<u32> = Queue::new("test");
+        let mut store = MockStorage::new();
+
+        // push some items
+        queue.push(&mut store, &1).unwrap();
+        queue.push(&mut store, &2).unwrap();
+        queue.push(&mut store, &3).unwrap();
+        queue.push(&mut store, &4).unwrap();
+
+        let items: StdResult<Vec<_>> = queue.iter(&mut store).unwrap().collect();
+        assert_eq!(items.unwrap(), [1, 2, 3, 4]);
+
+        let mut iter = queue.iter(&mut store).unwrap();
+        assert_eq!(iter.nth(6), None);
+        assert_eq!(iter.start, iter.end, "iter should detect skipping too far");
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn wrapping() {
+        let queue: Queue<u32> = Queue::new("test");
+        let mut store = MockStorage::new();
+
+        // simulate queue that was pushed and popped `u32::MAX` times
+        queue.set_head(&mut store, u32::MAX);
+        queue.set_tail(&mut store, u32::MAX);
+
+        // should be empty
+        assert_eq!(queue.pop(&mut store).unwrap(), None);
+        assert_eq!(queue.len(&store).unwrap(), 0);
+
+        // pushing should still work
+        queue.push(&mut store, &1).unwrap();
+        assert_eq!(
+            queue.len(&store).unwrap(),
+            1,
+            "length should calculate correctly, even when wrapping"
+        );
+        assert_eq!(
+            queue.pop(&mut store).unwrap(),
+            Some(1),
+            "popping should work, even when wrapping"
+        );
+    }
+}


### PR DESCRIPTION
closes #776

Implements a deque, similar to the std lib `VecDeque`.
This allows having both queue and stack semantics with a single data structure.
I used wrapping math, such that, in case the indexes ever reach `u32::MAX` or you always push to the front, it will still work (as long as it's not filled completely).
No random access at the moment, but can add that, if desired.

The implementation is inspired by #786 
