### PR TITLE
Remove storage-plus dependency from storage-macro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,11 +660,11 @@ jobs:
           name: Run unit tests (no iterator)
           command: cargo test --locked --no-default-features
       - run:
-          name: Build library for native target (with iterator)
-          command: cargo build --locked
+          name: Build library for native target (with iterator and macro)
+          command: cargo build --locked --all-features
       - run:
-          name: Run unit tests (with iterator)
-          command: cargo test --locked
+          name: Run unit tests (with iterator and macro)
+          command: cargo test --locked --all-features
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,6 @@ name = "cw-storage-macro"
 version = "0.15.1"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus",
  "serde",
  "syn",
 ]

--- a/packages/storage-macro/Cargo.toml
+++ b/packages/storage-macro/Cargo.toml
@@ -16,6 +16,5 @@ proc-macro = true
 syn = { version = "1.0.96", features = ["full"] }
 
 [dev-dependencies]
-cw-storage-plus = { version = "<=0.15.1, >=0.14.0", path = "../storage-plus" }
 cosmwasm-std = { version = "1.1.0", default-features = false }
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/storage-macro/src/lib.rs
+++ b/packages/storage-macro/src/lib.rs
@@ -5,6 +5,25 @@ use syn::{
     parse_macro_input, ItemStruct,
 };
 
+/// Auto generate an `IndexList` impl for your indexes struct.
+///
+/// # Example
+///
+/// ```rust
+/// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+/// struct TestStruct {
+///     id: u64,
+///     id2: u32,
+///     addr: Addr,
+/// }
+///
+/// #[index_list(TestStruct)] // <- Add this line right here.
+/// struct TestIndexes<'a> {
+///     id: MultiIndex<'a, u32, TestStruct, u64>,
+///     addr: UniqueIndex<'a, Addr, TestStruct>,
+/// }
+/// ```
+///
 #[proc_macro_attribute]
 pub fn index_list(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemStruct);

--- a/packages/storage-macro/src/lib.rs
+++ b/packages/storage-macro/src/lib.rs
@@ -5,25 +5,6 @@ use syn::{
     parse_macro_input, ItemStruct,
 };
 
-/// Auto generate an `IndexList` impl for your indexes struct.
-///
-/// # Example
-///
-/// ```rust
-/// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-/// struct TestStruct {
-///     id: u64,
-///     id2: u32,
-///     addr: Addr,
-/// }
-///
-/// #[index_list(TestStruct)] // <- Add this line right here.
-/// struct TestIndexes<'a> {
-///     id: MultiIndex<'a, u32, TestStruct, u64>,
-///     addr: UniqueIndex<'a, Addr, TestStruct>,
-/// }
-/// ```
-///
 #[proc_macro_attribute]
 pub fn index_list(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemStruct);

--- a/packages/storage-plus/Cargo.toml
+++ b/packages/storage-plus/Cargo.toml
@@ -8,6 +8,9 @@ license = "Apache-2.0"
 repository = "https://github.com/CosmWasm/cw-plus"
 homepage = "https://cosmwasm.com"
 
+[package.metadata.docs.rs]
+all-features = true # include macro feature when building docs
+
 [features]
 default = ["iterator"]
 iterator = ["cosmwasm-std/iterator"]
@@ -24,7 +27,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 cw-storage-macro = { version = "0.15.1", optional = true, path = "../storage-macro" }
 
 [dev-dependencies]
-criterion = { version = "0.3", features = [ "html_reports" ] }
+criterion = { version = "0.3", features = ["html_reports"] }
 rand = "0.8"
 
 [[bench]]

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -71,5 +71,3 @@ extern crate cw_storage_macro;
 /// ```
 ///
 pub use cw_storage_macro::index_list;
-#[cfg(all(feature = "iterator", feature = "macro"))]
-pub use cw_storage_macro::*;

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -46,5 +46,4 @@ pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};
 #[macro_use]
 extern crate cw_storage_macro;
 #[cfg(all(feature = "iterator", feature = "macro"))]
-#[doc(hidden)]
 pub use cw_storage_macro::*;

--- a/packages/storage-plus/src/lib.rs
+++ b/packages/storage-plus/src/lib.rs
@@ -42,8 +42,34 @@ pub use prefix::{range_with_prefix, Prefix};
 #[cfg(feature = "iterator")]
 pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};
 
+// cw_storage_macro reexports
 #[cfg(all(feature = "iterator", feature = "macro"))]
 #[macro_use]
 extern crate cw_storage_macro;
+#[cfg(all(feature = "iterator", feature = "macro"))]
+/// Auto generate an `IndexList` impl for your indexes struct.
+///
+/// # Example
+///
+/// ```rust
+/// use cosmwasm_std::Addr;
+/// use cw_storage_plus::{MultiIndex, UniqueIndex, index_list};
+/// use serde::{Serialize, Deserialize};
+///
+/// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+/// struct TestStruct {
+///     id: u64,
+///     id2: u32,
+///     addr: Addr,
+/// }
+///
+/// #[index_list(TestStruct)] // <- Add this line right here.
+/// struct TestIndexes<'a> {
+///     id: MultiIndex<'a, u32, TestStruct, u64>,
+///     addr: UniqueIndex<'a, Addr, TestStruct>,
+/// }
+/// ```
+///
+pub use cw_storage_macro::index_list;
 #[cfg(all(feature = "iterator", feature = "macro"))]
 pub use cw_storage_macro::*;

--- a/packages/storage-plus/tests/index_list.rs
+++ b/packages/storage-plus/tests/index_list.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "iterator", feature = "macro"))]
 mod test {
     use cosmwasm_std::{testing::MockStorage, Addr};
     use cw_storage_macro::index_list;


### PR DESCRIPTION
The tests that were depending on `storage-plus` are now in `storage-plus`. I also changed the CI to actually run them.

I added the docs from readme to the actual macro. I'm not sure how docs.rs works in this regard though, since the reexport is only available with the `macro` feature.

closes #808 