### PR TITLE
Remove unused schemars dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,6 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
- "schemars",
  "serde",
 ]
 
@@ -386,7 +385,6 @@ dependencies = [
  "cw20",
  "cw20-base",
  "cw3",
- "schemars",
  "serde",
  "thiserror",
 ]
@@ -407,7 +405,6 @@ dependencies = [
  "cw3-fixed-multisig",
  "cw4",
  "cw4-group",
- "schemars",
  "serde",
  "thiserror",
 ]
@@ -419,7 +416,6 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
- "schemars",
  "serde",
 ]
 
@@ -434,7 +430,6 @@ dependencies = [
  "cw-utils",
  "cw2 1.0.0",
  "cw4",
- "schemars",
  "serde",
  "thiserror",
 ]
@@ -451,7 +446,6 @@ dependencies = [
  "cw2 1.0.0",
  "cw20",
  "cw4",
- "schemars",
  "serde",
  "thiserror",
 ]

--- a/contracts/cw3-fixed-multisig/Cargo.toml
+++ b/contracts/cw3-fixed-multisig/Cargo.toml
@@ -24,7 +24,6 @@ cw2 = { path = "../../packages/cw2", version = "1.0.0" }
 cw3 = { path = "../../packages/cw3", version = "1.0.0" }
 cw-storage-plus = "0.16.0"
 cosmwasm-std = { version = "1.1.0" }
-schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 

--- a/contracts/cw3-flex-multisig/Cargo.toml
+++ b/contracts/cw3-flex-multisig/Cargo.toml
@@ -27,7 +27,6 @@ cw4 = { path = "../../packages/cw4", version = "1.0.0" }
 cw20 = { path = "../../packages/cw20", version = "1.0.0" }
 cw-storage-plus = "0.16.0"
 cosmwasm-std = { version = "1.1.0" }
-schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 

--- a/contracts/cw4-group/Cargo.toml
+++ b/contracts/cw4-group/Cargo.toml
@@ -33,6 +33,5 @@ cw4 = { path = "../../packages/cw4", version = "1.0.0" }
 cw-controllers = { path = "../../packages/controllers", version = "1.0.0" }
 cw-storage-plus = "0.16.0"
 cosmwasm-std = { version = "1.1.0" }
-schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/contracts/cw4-stake/Cargo.toml
+++ b/contracts/cw4-stake/Cargo.toml
@@ -34,6 +34,5 @@ cw20 = { path = "../../packages/cw20", version = "1.0.0" }
 cw-controllers = { path = "../../packages/controllers", version = "1.0.0" }
 cw-storage-plus = "0.16.0"
 cosmwasm-std = { version = "1.1.0" }
-schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }

--- a/packages/cw2/Cargo.toml
+++ b/packages/cw2/Cargo.toml
@@ -12,5 +12,4 @@ homepage = "https://cosmwasm.com"
 cosmwasm-schema = "1.0.0"
 cosmwasm-std = { version = "1.0.0", default-features = false }
 cw-storage-plus = "0.16.0"
-schemars = "0.8.1"
 serde = { version = "1.0.0", default-features = false, features = ["derive"] }

--- a/packages/cw4/Cargo.toml
+++ b/packages/cw4/Cargo.toml
@@ -12,5 +12,4 @@ homepage = "https://cosmwasm.com"
 cw-storage-plus = "0.16.0"
 cosmwasm-schema = "1.1.0"
 cosmwasm-std = "1.1.0"
-schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }


### PR DESCRIPTION
This is wrapped in cosmwasm-schema now such that we don't need it anymore in those packages.