### PR TITLE
Remove non-existent profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,6 @@ incremental = false
 codegen-units = 1
 incremental = false
 
-[profile.release.package.cw1155-base]
-codegen-units = 1
-incremental = false
-
 [profile.release]
 rpath = false
 lto = true


### PR DESCRIPTION
`cw1155-base` was removed in https://github.com/CosmWasm/cw-plus/issues/830, but the release profile still exists. I caught the bug while running e2e tests in https://github.com/mandrean/cw-optimizoor.

