### PR TITLE
Update workspace-optimizer version in README to 0.12.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To compile all the contracts, run the following in the repo root:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.9
+  cosmwasm/workspace-optimizer:0.12.11
 ```
 
 This will compile all packages in the `contracts` directory and output the stripped and optimized wasm code under the


### PR DESCRIPTION
I came to build a cw1 contract and noticed we can update the `workspace-optimizer` version to the latest here:
https://hub.docker.com/r/cosmwasm/workspace-optimizer/tags

I've also run this locally myself and confirm it works as expected.
