### PR TITLE
Address minor typos in cw1 comments and README

### DIFF
--- a/contracts/cw1-whitelist/README.md
+++ b/contracts/cw1-whitelist/README.md
@@ -5,7 +5,7 @@ It contains a set of admins that are defined upon creation.
 Any of those admins may `Execute` any message via the contract,
 per the CW1 spec.
 
-To make this slighly less minimalistic, you can allow the admin set
+To make this slightly less minimalistic, you can allow the admin set
 to be mutable or immutable. If it is mutable, then any admin may
 (a) change the admin set and (b) freeze it (making it immutable).
 
@@ -40,5 +40,5 @@ ls -l cw1_whitelist.wasm
 sha256sum cw1_whitelist.wasm
 ```
 
-Or for a production-ready (optimized) build, run a build command in the
+Or for a production-ready (optimized) build, run a build command in 
 the repository root: https://github.com/CosmWasm/cw-plus#compiling.

--- a/contracts/cw1-whitelist/src/msg.rs
+++ b/contracts/cw1-whitelist/src/msg.rs
@@ -51,8 +51,8 @@ pub struct AdminListResponse {
 
 #[cfg(any(test, feature = "test-utils"))]
 impl AdminListResponse {
-    /// Utility function forconverting message to its canonical form, so two messages with
-    /// different representation but same semantical meaning can be easly compared.
+    /// Utility function for converting message to its canonical form, so two messages with
+    /// different representation but same semantic meaning can be easily compared.
     ///
     /// It could be encapsulated in custom `PartialEq` implementation, but `PartialEq` is expected
     /// to be quickly, so it seems to be reasonable to keep it as representation-equality, and


### PR DESCRIPTION
Pretty small and self-explanatory. Just happened to notice some minor typos.