### PR TITLE
Added optional memo to ics20 packets

### DIFF
--- a/contracts/cw20-ics20/src/contract.rs
+++ b/contracts/cw20-ics20/src/contract.rs
@@ -135,7 +135,7 @@ pub fn execute_transfer(
         amount.denom(),
         sender.as_ref(),
         &msg.remote_address,
-    );
+    ).with_memo(msg.memo);
     packet.validate()?;
 
     // Update the balance now (optimistically) like ibctransfer modules.

--- a/contracts/cw20-ics20/src/ibc.rs
+++ b/contracts/cw20-ics20/src/ibc.rs
@@ -33,6 +33,9 @@ pub struct Ics20Packet {
     pub receiver: String,
     /// the sender address
     pub sender: String,
+    /// optional memo for the IBC transfer
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memo: Option<String>,
 }
 
 impl Ics20Packet {
@@ -42,7 +45,12 @@ impl Ics20Packet {
             amount,
             sender: sender.to_string(),
             receiver: receiver.to_string(),
+            memo: None
         }
+    }
+
+    pub fn with_memo(self, memo: Option<String>) -> Self {
+        Ics20Packet { memo, ..self }
     }
 
     pub fn validate(&self) -> Result<(), ContractError> {

--- a/contracts/cw20-ics20/src/msg.rs
+++ b/contracts/cw20-ics20/src/msg.rs
@@ -51,6 +51,8 @@ pub struct TransferMsg {
     pub remote_address: String,
     /// How long the packet lives in seconds. If not specified, use default_timeout
     pub timeout: Option<u64>,
+    /// An optional memo to add to the IBC transfer
+    pub memo: Option<String>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
IBC has introduced an optional [memo field](https://github.com/cosmos/ibc/tree/main/spec/app/ics-020-fungible-token-transfer#using-the-memo-field) on the ICS20 transfer packet. The memo enables features such as Osmosis cross chain swaps, and forwarding tokens using the [packet forward middleware](https://github.com/strangelove-ventures/packet-forward-middleware). 

The change in this PR allows users to specify the memo to use when transferring CW20s. Note that since the memo is optional (both in the messages passed to the contract and the serialization of the Ics20Packet) this change will only affect the case when the memo is included in TransferMsg by the user. In short, this change should be backwards compatible. 