### PR TITLE
Update to the `2.0.0` framework/tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +78,12 @@ name = "bnum"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128a44527fc0d6abf05f9eda748b9027536e12dff93f5acc8449f51583309350"
+
+[[package]]
+name = "bnum"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "byteorder"
@@ -103,9 +115,22 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca101fbf2f76723711a30ea3771ef312ec3ec254ad021b237871ed802f9f175"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "ed25519-zebra",
- "k256 0.13.1",
+ "k256 0.13.3",
+ "rand_core 0.6.4",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5188089c28996a446b882b61abb74dc5b90f1a4cfe26e4584a722c5f75ed4f43"
+dependencies = [
+ "digest 0.10.7",
+ "ed25519-zebra",
+ "k256 0.13.3",
  "rand_core 0.6.4",
  "thiserror",
 ]
@@ -120,12 +145,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-derive"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7436a7247ddcb6125dd55566687e566e7e67b8cbf27f2f9916f4bfb731f9bf4b"
+dependencies = [
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "cosmwasm-schema"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce34a08020433989af5cc470104f6bd22134320fe0221bd8aeb919fd5ec92d5"
 dependencies = [
- "cosmwasm-schema-derive",
+ "cosmwasm-schema-derive 1.4.0",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7877c1debbe8dc6e8026de081c39d357579d5baa5c79d76e4428c1b26013bd38"
+dependencies = [
+ "cosmwasm-schema-derive 2.0.0-rc.1",
  "schemars",
  "serde",
  "serde_json",
@@ -144,22 +191,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-schema-derive"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa51536f0c56ac14971576cff2ef4bde35d21eafcb619e16d6e89417d41e85ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "cosmwasm-std"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a44d3f9c25b2f864737c6605a98f2e4675d53fd8bbc7cf4d7c02475661a793d"
 dependencies = [
  "base64",
- "bnum",
- "cosmwasm-crypto",
- "cosmwasm-derive",
+ "bnum 0.8.0",
+ "cosmwasm-crypto 1.4.0",
+ "cosmwasm-derive 1.4.0",
  "derivative",
  "forward_ref",
  "hex",
  "schemars",
  "serde",
- "serde-json-wasm",
+ "serde-json-wasm 0.5.0",
  "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-std"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb9f0cb520832e993af5cbe97bc3c163bd0c3870989e99d5f1d5499e6f28a53"
+dependencies = [
+ "base64",
+ "bech32",
+ "bnum 0.10.0",
+ "cosmwasm-crypto 2.0.0-rc.1",
+ "cosmwasm-derive 2.0.0-rc.1",
+ "derivative",
+ "forward_ref",
+ "hex",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+ "sha2 0.10.6",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -225,10 +305,10 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57de8d3761e46be863e3ac1eba8c8a976362a48c6abf240df1e26c3e421ee9e8"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.3",
  "schemars",
  "serde",
  "thiserror",
@@ -241,9 +321,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127c7bb95853b8e828bdab97065c81cb5ddc20f7339180b61b2300565aaa99d1"
 dependencies = [
  "anyhow",
- "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils",
+ "cosmwasm-std 1.4.0",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.3",
  "derivative",
  "itertools",
  "k256 0.11.6",
@@ -259,7 +339,18 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f0e92a069d62067f3472c62e30adedb4cab1754725c0f2a682b3128d2bf3c79"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.4.0",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw-storage-plus"
+version = "2.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8950902b662b249447c86ddf35b70f83603aedfb5e388434f53fb4aba6a1378"
+dependencies = [
+ "cosmwasm-std 2.0.0-rc.1",
  "schemars",
  "serde",
 ]
@@ -270,11 +361,24 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4a657e5caacc3a0d00ee96ca8618745d050b8f757c709babafb81208d4239c"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw2",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
+ "cw2 1.1.2",
  "schemars",
  "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-utils"
+version = "2.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e9dfd846ca70673781742aa739bae515bc833e8cf1c033611288df5067d734"
+dependencies = [
+ "cosmwasm-schema 2.0.0-rc.1",
+ "cosmwasm-std 2.0.0-rc.1",
+ "schemars",
  "serde",
  "thiserror",
 ]
@@ -283,8 +387,8 @@ dependencies = [
 name = "cw1"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 2.0.0-rc.1",
+ "cosmwasm-std 2.0.0-rc.1",
  "schemars",
  "serde",
 ]
@@ -293,13 +397,14 @@ dependencies = [
 name = "cw1-subkeys"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils",
+ "cosmwasm-schema 2.0.0-rc.1",
+ "cosmwasm-std 2.0.0-rc.1",
+ "cw-storage-plus 2.0.0-rc.0",
+ "cw-utils 2.0.0-rc.0",
  "cw1",
  "cw1-whitelist",
- "cw2",
+ "cw2 2.0.0-rc.0",
+ "easy-addr",
  "schemars",
  "semver",
  "serde",
@@ -312,13 +417,13 @@ version = "1.1.2"
 dependencies = [
  "anyhow",
  "assert_matches",
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 2.0.0-rc.1",
+ "cosmwasm-std 2.0.0-rc.1",
  "cw-multi-test",
- "cw-storage-plus",
- "cw-utils",
+ "cw-storage-plus 2.0.0-rc.0",
+ "cw-utils 1.0.3",
  "cw1",
- "cw2",
+ "cw2 2.0.0-rc.0",
  "derivative",
  "schemars",
  "serde",
@@ -331,9 +436,24 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c120b24fbbf5c3bedebb97f2cc85fbfa1c3287e09223428e7e597b5293c1fa"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
+ "cw-storage-plus 1.1.0",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw2"
+version = "2.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43047e25dc908fe27ff5d4cf015007ef7693d4ab89c77be415f532e5cccde6eb"
+dependencies = [
+ "cosmwasm-schema 2.0.0-rc.1",
+ "cosmwasm-std 2.0.0-rc.1",
+ "cw-storage-plus 2.0.0-rc.0",
  "schemars",
  "semver",
  "serde",
@@ -344,9 +464,9 @@ dependencies = [
 name = "cw20"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-utils",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
+ "cw-utils 1.0.3",
  "schemars",
  "serde",
 ]
@@ -355,12 +475,12 @@ dependencies = [
 name = "cw20-base"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
  "cw-multi-test",
- "cw-storage-plus",
- "cw-utils",
- "cw2",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw20",
  "schemars",
  "semver",
@@ -372,12 +492,12 @@ dependencies = [
 name = "cw20-ics20"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
  "cw-controllers",
- "cw-storage-plus",
- "cw-utils",
- "cw2",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw20",
  "schemars",
  "semver",
@@ -389,9 +509,9 @@ dependencies = [
 name = "cw3"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-utils",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
+ "cw-utils 1.0.3",
  "cw20",
  "schemars",
  "serde",
@@ -402,12 +522,12 @@ dependencies = [
 name = "cw3-fixed-multisig"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
  "cw-multi-test",
- "cw-storage-plus",
- "cw-utils",
- "cw2",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw20",
  "cw20-base",
  "cw3",
@@ -420,12 +540,12 @@ dependencies = [
 name = "cw3-flex-multisig"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
  "cw-multi-test",
- "cw-storage-plus",
- "cw-utils",
- "cw2",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw20",
  "cw20-base",
  "cw3",
@@ -441,9 +561,9 @@ dependencies = [
 name = "cw4"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
+ "cw-storage-plus 1.1.0",
  "schemars",
  "serde",
 ]
@@ -452,12 +572,12 @@ dependencies = [
 name = "cw4-group"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
  "cw-controllers",
- "cw-storage-plus",
- "cw-utils",
- "cw2",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw4",
  "schemars",
  "serde",
@@ -468,12 +588,12 @@ dependencies = [
 name = "cw4-stake"
 version = "1.1.2"
 dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
+ "cosmwasm-schema 1.4.0",
+ "cosmwasm-std 1.4.0",
  "cw-controllers",
- "cw-storage-plus",
- "cw-utils",
- "cw2",
+ "cw-storage-plus 1.1.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
  "cw20",
  "cw4",
  "schemars",
@@ -523,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.3",
  "const-oid",
@@ -538,6 +658,16 @@ name = "dyn-clone"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+
+[[package]]
+name = "easy-addr"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-std 2.0.0-rc.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ecdsa"
@@ -553,13 +683,13 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.8",
- "digest 0.10.6",
- "elliptic-curve 0.13.5",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
  "signature 2.1.0",
  "spki 0.7.2",
@@ -595,7 +725,7 @@ dependencies = [
  "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest 0.10.6",
+ "digest 0.10.7",
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
@@ -608,13 +738,13 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.3",
- "digest 0.10.6",
+ "digest 0.10.7",
  "ff 0.13.0",
  "generic-array",
  "group 0.13.0",
@@ -716,7 +846,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -748,13 +878,13 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.7",
- "elliptic-curve 0.13.5",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2 0.10.6",
  "signature 2.1.0",
@@ -768,9 +898,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -958,6 +1088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-json-wasm"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05da0d153dd4595bdffd5099dc0e9ce425b205ee648eb93437ff7302af8c9a5"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,7 +1150,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1020,7 +1159,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -1030,7 +1169,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -1053,6 +1192,12 @@ dependencies = [
  "base64ct",
  "der 0.7.8",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -1128,6 +1273,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/contracts/cw1-subkeys/Cargo.toml
+++ b/contracts/cw1-subkeys/Cargo.toml
@@ -13,24 +13,23 @@ documentation = "https://docs.cosmwasm.com"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 test-utils = []
 
 [dependencies]
-cosmwasm-schema = { version = "1.4.0" }
-cw-utils = "1.0.1"
+cosmwasm-schema = { version = "2.0.0-rc.1" }
+cw-utils = "2.0.0-rc.0"
 cw1 = { path = "../../packages/cw1", version = "1.1.2" }
-cw2 = "1.1.2"
+cw2 = "2.0.0-rc.0"
 cw1-whitelist = { path = "../cw1-whitelist", version = "1.1.2", features = [
   "library",
 ] }
-cosmwasm-std = { version = "1.4.0", features = ["staking"] }
-cw-storage-plus = "1.1.0"
+cosmwasm-std = { version = "2.0.0-rc.1", features = ["staking"] }
+cw-storage-plus = "2.0.0-rc.0"
 schemars = "0.8.15"
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }
-thiserror = "1.0.49"
+thiserror = "1.0.4"
 semver = "1"
 
 [dev-dependencies]
@@ -38,3 +37,4 @@ cw1-whitelist = { path = "../cw1-whitelist", version = "1.1.2", features = [
   "library",
   "test-utils",
 ] }
+easy-addr = { path = "../../packages/easy-addr" }

--- a/contracts/cw1-subkeys/src/contract.rs
+++ b/contracts/cw1-subkeys/src/contract.rs
@@ -5,8 +5,8 @@ use std::ops::{AddAssign, Sub};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, ensure_ne, to_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, DistributionMsg,
-    Empty, Env, MessageInfo, Order, Response, StakingMsg, StdResult,
+    ensure, ensure_ne, to_json_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut,
+    DistributionMsg, Empty, Env, MessageInfo, Order, Response, StakingMsg, StdResult,
 };
 use cw1::CanExecuteResponse;
 use cw1_whitelist::{
@@ -304,17 +304,17 @@ where
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::AdminList {} => to_binary(&query_admin_list(deps)?),
-        QueryMsg::Allowance { spender } => to_binary(&query_allowance(deps, env, spender)?),
-        QueryMsg::Permissions { spender } => to_binary(&query_permissions(deps, spender)?),
+        QueryMsg::AdminList {} => to_json_binary(&query_admin_list(deps)?),
+        QueryMsg::Allowance { spender } => to_json_binary(&query_allowance(deps, env, spender)?),
+        QueryMsg::Permissions { spender } => to_json_binary(&query_permissions(deps, spender)?),
         QueryMsg::CanExecute { sender, msg } => {
-            to_binary(&query_can_execute(deps, env, sender, msg)?)
+            to_json_binary(&query_can_execute(deps, env, sender, msg)?)
         }
         QueryMsg::AllAllowances { start_after, limit } => {
-            to_binary(&query_all_allowances(deps, env, start_after, limit)?)
+            to_json_binary(&query_all_allowances(deps, env, start_after, limit)?)
         }
         QueryMsg::AllPermissions { start_after, limit } => {
-            to_binary(&query_all_permissions(deps, start_after, limit)?)
+            to_json_binary(&query_all_permissions(deps, start_after, limit)?)
         }
     }
 }
@@ -479,21 +479,23 @@ mod tests {
     use cw2::{get_contract_version, ContractVersion};
     use cw_utils::NativeBalance;
 
+    use easy_addr::addr;
+
     use crate::state::Permissions;
 
     use std::collections::HashMap;
 
     use super::*;
 
-    const OWNER: &str = "owner";
+    const OWNER: &str = addr!("owner");
 
-    const ADMIN1: &str = "admin1";
-    const ADMIN2: &str = "admin2";
+    const ADMIN1: &str = addr!("admin1");
+    const ADMIN2: &str = addr!("admin2");
 
-    const SPENDER1: &str = "spender1";
-    const SPENDER2: &str = "spender2";
-    const SPENDER3: &str = "spender3";
-    const SPENDER4: &str = "spender4";
+    const SPENDER1: &str = addr!("spender1");
+    const SPENDER2: &str = addr!("spender2");
+    const SPENDER3: &str = addr!("spender3");
+    const SPENDER4: &str = addr!("spender4");
 
     const TOKEN: &str = "token";
     const TOKEN1: &str = "token1";
@@ -2225,12 +2227,12 @@ mod tests {
     fn permissions_allowances_independent() {
         let mut deps = mock_dependencies();
 
-        let owner = "admin0001";
+        let owner = addr!("admin0001");
         let admins = vec![owner.to_string()];
 
         // spender1 has every permission to stake
-        let spender1 = "spender0001";
-        let spender2 = "spender0002";
+        let spender1 = addr!("spender0001");
+        let spender2 = addr!("spender0002");
         let denom = "token1";
         let amount = 10000;
         let coin = coin(amount, denom);

--- a/contracts/cw1-whitelist/Cargo.toml
+++ b/contracts/cw1-whitelist/Cargo.toml
@@ -13,18 +13,17 @@ documentation = "https://docs.cosmwasm.com"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 test-utils = []
 
 [dependencies]
-cosmwasm-schema = { version = "1.4.0" }
+cosmwasm-schema = { version = "2.0.0-rc.1" }
 cw-utils = "1.0.1"
 cw1 = { path = "../../packages/cw1", version = "1.1.2" }
-cw2 = "1.1.2"
-cosmwasm-std = { version = "1.4.0", features = ["staking"] }
-cw-storage-plus = "1.1.0"
+cw2 = "2.0.0-rc.0"
+cosmwasm-std = { version = "2.0.0-rc.1", features = ["staking"] }
+cw-storage-plus = "2.0.0-rc.0"
 schemars = "0.8.15"
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.49" }

--- a/contracts/cw1-whitelist/src/contract.rs
+++ b/contracts/cw1-whitelist/src/contract.rs
@@ -4,7 +4,7 @@ use std::fmt;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Response,
+    to_json_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Response,
     StdResult,
 };
 
@@ -118,8 +118,10 @@ fn can_execute(deps: Deps, sender: &str) -> StdResult<bool> {
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::AdminList {} => to_binary(&query_admin_list(deps)?),
-        QueryMsg::CanExecute { sender, msg } => to_binary(&query_can_execute(deps, sender, msg)?),
+        QueryMsg::AdminList {} => to_json_binary(&query_admin_list(deps)?),
+        QueryMsg::CanExecute { sender, msg } => {
+            to_json_binary(&query_can_execute(deps, sender, msg)?)
+        }
     }
 }
 
@@ -242,7 +244,7 @@ mod tests {
             .into(),
             WasmMsg::Execute {
                 contract_addr: "some contract".into(),
-                msg: to_binary(&freeze).unwrap(),
+                msg: to_json_binary(&freeze).unwrap(),
                 funds: vec![],
             }
             .into(),

--- a/contracts/cw1-whitelist/src/integration_tests.rs
+++ b/contracts/cw1-whitelist/src/integration_tests.rs
@@ -1,7 +1,9 @@
 use crate::msg::{AdminListResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use anyhow::{anyhow, Result};
 use assert_matches::assert_matches;
-use cosmwasm_std::{to_binary, Addr, CosmosMsg, Empty, QueryRequest, StdError, WasmMsg, WasmQuery};
+use cosmwasm_std::{
+    to_json_binary, Addr, CosmosMsg, Empty, QueryRequest, StdError, WasmMsg, WasmQuery,
+};
 use cw1::Cw1Contract;
 use cw_multi_test::{App, AppResponse, Contract, ContractWrapper, Executor};
 use derivative::Derivative;
@@ -68,7 +70,7 @@ impl Suite {
         let execute: ExecuteMsg = ExecuteMsg::Execute {
             msgs: vec![CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: target_contract.to_string(),
-                msg: to_binary(&msg)?,
+                msg: to_json_binary(&msg)?,
                 funds: vec![],
             })],
         };
@@ -88,7 +90,7 @@ impl Suite {
     {
         self.app.wrap().query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: target_contract.to_string(),
-            msg: to_binary(&msg).unwrap(),
+            msg: to_json_binary(&msg).unwrap(),
         }))
     }
 }

--- a/packages/cw1/Cargo.toml
+++ b/packages/cw1/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/CosmWasm/cw-plus"
 homepage = "https://cosmwasm.com"
 
 [dependencies]
-cosmwasm-schema = "1.4.0"
-cosmwasm-std = "1.4.0"
+cosmwasm-schema = "2.0.0-rc.1"
+cosmwasm-std = "2.0.0-rc.1"
 schemars = "0.8.15"
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }

--- a/packages/cw1/src/helpers.rs
+++ b/packages/cw1/src/helpers.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_binary, Addr, CosmosMsg, StdResult, WasmMsg};
+use cosmwasm_std::{to_json_binary, Addr, CosmosMsg, StdResult, WasmMsg};
 
 use crate::msg::Cw1ExecuteMsg;
 
@@ -19,7 +19,7 @@ impl Cw1Contract {
         let msg = Cw1ExecuteMsg::Execute { msgs: msgs.into() };
         Ok(WasmMsg::Execute {
             contract_addr: self.addr().into(),
-            msg: to_binary(&msg)?,
+            msg: to_json_binary(&msg)?,
             funds: vec![],
         }
         .into())

--- a/packages/easy-addr/Cargo.toml
+++ b/packages/easy-addr/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "easy-addr"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cosmwasm-std = "2.0.0-rc.1"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1.0.6", features = ["full", "printing", "extra-traits"] }

--- a/packages/easy-addr/src/lib.rs
+++ b/packages/easy-addr/src/lib.rs
@@ -1,0 +1,15 @@
+use cosmwasm_std::testing::mock_dependencies;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse_macro_input;
+
+#[proc_macro]
+pub fn addr(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::LitStr).value();
+    let addr = mock_dependencies()
+        .api
+        .addr_make(input.as_str())
+        .to_string();
+    TokenStream::from(quote! {#addr})
+}


### PR DESCRIPTION
- [ ] `cw1`
  - [ ] package
  - [ ] `subkeys`
  - [ ] `whitelist`
- [ ] `cw20`
  - [ ] package
  - [ ] `base`
  - [ ] `ics20`
- [ ] `cw3`
  - [ ] package
  - [ ] `fixed`
  - [ ] `flex`
- [ ] `cw4`
  - [ ] package
  - [ ] `group`
  - [ ] `stake`