### PR TITLE
Replace serde/jsonschema derives with `cosmwasm_schema::cw_serde`

### DIFF
--- a/contracts/cw1-subkeys/src/state.rs
+++ b/contracts/cw1-subkeys/src/state.rs
@@ -1,7 +1,6 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::fmt;
 
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Addr;
 use cw_storage_plus::Map;
 use cw_utils::{Expiration, NativeBalance};
@@ -10,7 +9,8 @@ use cw_utils::{Expiration, NativeBalance};
 // Could have implemented permissions for each cosmos module(StakingPermissions, GovPermissions etc...)
 // But that meant a lot of code for each module. Keeping the permissions inside one struct is more
 // optimal. Define other modules permissions here.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default, Copy)]
+#[cw_serde]
+#[derive(Eq, Default, Copy)]
 pub struct Permissions {
     pub delegate: bool,
     pub redelegate: bool,
@@ -28,7 +28,8 @@ impl fmt::Display for Permissions {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
+#[cw_serde]
+#[derive(Default)]
 pub struct Allowance {
     pub balance: NativeBalance,
     pub expires: Expiration,

--- a/contracts/cw1-whitelist/src/state.rs
+++ b/contracts/cw1-whitelist/src/state.rs
@@ -1,10 +1,9 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Eq, Default)]
 pub struct AdminList {
     pub admins: Vec<Addr>,
     pub mutable: bool,

--- a/contracts/cw20-base/src/msg.rs
+++ b/contracts/cw20-base/src/msg.rs
@@ -1,8 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{StdError, StdResult, Uint128};
 use cw20::{Cw20Coin, Logo, MinterResponse};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 pub use cw20::Cw20ExecuteMsg as ExecuteMsg;
 
@@ -122,7 +120,7 @@ pub enum QueryMsg {
     DownloadLogo {},
 }
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[cw_serde]
 pub struct MigrateMsg {}
 
 #[cfg(test)]

--- a/contracts/cw20-ics20/src/ibc.rs
+++ b/contracts/cw20-ics20/src/ibc.rs
@@ -1,6 +1,3 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_schema::cw_serde;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -26,7 +23,8 @@ pub const ICS20_ORDERING: IbcOrder = IbcOrder::Unordered;
 /// The format for sending an ics20 packet.
 /// Proto defined here: https://github.com/cosmos/cosmos-sdk/blob/v0.42.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20
 /// This is compatible with the JSON serialization
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Eq, Default)]
 pub struct Ics20Packet {
     /// amount of tokens to transfer is encoded as a string, but limited to u64 max
     pub amount: Uint128,

--- a/packages/cw20/src/query.rs
+++ b/packages/cw20/src/query.rs
@@ -1,6 +1,3 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Binary, Uint128};
 
@@ -64,7 +61,8 @@ pub struct TokenInfoResponse {
     pub total_supply: Uint128,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Default)]
 pub struct AllowanceResponse {
     pub allowance: Uint128,
     pub expires: Expiration,
@@ -79,7 +77,8 @@ pub struct MinterResponse {
     pub cap: Option<Uint128>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Default)]
 pub struct MarketingInfoResponse {
     /// A URL pointing to the project behind this token.
     pub project: Option<String>,
@@ -106,7 +105,8 @@ pub struct AllowanceInfo {
     pub expires: Expiration,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Default)]
 pub struct AllAllowancesResponse {
     pub allowances: Vec<AllowanceInfo>,
 }
@@ -118,12 +118,14 @@ pub struct SpenderAllowanceInfo {
     pub expires: Expiration,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Default)]
 pub struct AllSpenderAllowancesResponse {
     pub allowances: Vec<SpenderAllowanceInfo>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Eq, Default)]
 pub struct AllAccountsResponse {
     pub accounts: Vec<String>,
 }

--- a/packages/cw3/src/msg.rs
+++ b/packages/cw3/src/msg.rs
@@ -1,5 +1,4 @@
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use cosmwasm_schema::cw_serde;
@@ -31,8 +30,8 @@ where
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, JsonSchema, Debug)]
-#[serde(rename_all = "lowercase")]
+#[cw_serde]
+#[derive(Copy, Eq)]
 pub enum Vote {
     /// Marks support for the proposal.
     Yes,


### PR DESCRIPTION
This PR aims to reduce derive boilerplate with `cw_serde` macro. Originally I was missing `Debug` derive for cw20 base MigrateMsg and noticed that in this repo sometimes `cw_serde` macro used, sometimes `derive(Serialize, Deserialze...)`