### PR TITLE
Install latest cosmwasm-check on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,7 +455,7 @@ jobs:
       - run:
           name: Install cosmwasm-check
           # Uses --debug for compilation speed
-          command: cargo install --locked --debug --version 2.0.0-rc.1 cosmwasm-check
+          command: cargo install --locked --debug cosmwasm-check
       - save_cache:
           paths:
             - /usr/local/cargo/registry


### PR DESCRIPTION
I found out locally that `cosmwasm-check` fails on `cw1-whitelist` binary with:

```
target/wasm32-unknown-unknown/release/cw1_whitelist.wasm: failure
Error during static Wasm validation: Wasm bytecode could not be deserialized. Deserialization error: "reference-types not enabled: zero byte expected (at offset 0x139a)"
```

This PR is for consideration to detect such cases by using the latest version of `cosmwasm-check` and to showcase the issue.