### PR TITLE
fix: ignore expired allowances on execute_increase_allowance

### DIFF
--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -21,7 +21,11 @@ pub fn execute_increase_allowance(
     }
 
     let update_fn = |allow: Option<AllowanceResponse>| -> Result<_, _> {
-        let mut val = allow.unwrap_or_default();
+        // Filter out expired allowances, defaulting to zero
+        let mut val = allow
+            .filter(|a| !a.expires.is_expired(&env.block))
+            .unwrap_or_default();
+            
         if let Some(exp) = expires {
             if exp.is_expired(&env.block) {
                 return Err(ContractError::InvalidExpiration {});


### PR DESCRIPTION
Current `execute_increase_allowance` includes **expired** allowances when calculating the new increased allowance, which might cause the allowance to increase more than intended.

For example, after allowance of 10,000 is expired, increasing 5,000 will cause the allowance to become 15,000.
This should be fixed, so I added simple filtering logic in it.

This issue also mentions same problem
[Issue #909](https://github.com/CosmWasm/cw-plus/issues/909)