### PR TITLE
Typo fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1078,7 +1078,7 @@
 - Proper event/data handling on reply in multitest [\#326](https://github.com/CosmWasm/cw-plus/issues/326)
 - Messages differ for cw20 & cw20_base [\#320](https://github.com/CosmWasm/cw-plus/issues/320)
 - Upgrade cw20-staking to cw 15 [\#312](https://github.com/CosmWasm/cw-plus/issues/312)
-- Uprade cw20-ics20 to cw 0.15 [\#311](https://github.com/CosmWasm/cw-plus/issues/311)
+- Upgrade cw20-ics20 to cw 0.15 [\#311](https://github.com/CosmWasm/cw-plus/issues/311)
 - Upgrade cw20-escrow to 0.15 [\#309](https://github.com/CosmWasm/cw-plus/issues/309)
 - Upgrade cw20-bonding to 0.15 [\#307](https://github.com/CosmWasm/cw-plus/issues/307)
 - cw1-subkeys [\#305](https://github.com/CosmWasm/cw-plus/issues/305)


### PR DESCRIPTION
## Description

This pull request fixes a typo in the documentation:  
- Corrected "Uprade" to "Upgrade" to improve clarity and maintain professionalism.

## Changes Made
- **File Modified**: Specify the file(s) where the typo was found (e.g., `README.md`, `CHANGELOG.md`, etc.).
  - Replaced "Uprade" with "Upgrade."

## Rationale
Accurate spelling in documentation is essential for clear communication and maintaining the quality of the project.

## Checklist
- [x] Reviewed the contributing guidelines to ensure compliance.
- [x] Verified that the change is minor and does not affect functionality.
- [x] Checked for other instances of the typo across the repository.

